### PR TITLE
Rename PokéVault to Trove

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,11 +2,11 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "pokevault-dev",
+      "name": "trove-dev",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
-      "port": 5173,
-      "cwd": "/Users/tommymarcheschi/dev/rsmc"
+      "runtimeArgs": ["run", "dev", "--", "--port", "5176"],
+      "port": 5176,
+      "cwd": ""
     }
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# PokéVault Environment Variables
+# Trove Environment Variables
 # Copy this file to .env.local and fill in your values
 
 # Supabase (Required)

--- a/TROVE_PLAN.md
+++ b/TROVE_PLAN.md
@@ -1,4 +1,4 @@
-# PokéVault — Master Build Plan
+# Trove — Master Build Plan
 
 Personal Pokémon TCG Collector Intelligence App
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "pokevault",
+	"name": "trove",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "pokevault",
+			"name": "trove",
 			"version": "0.1.0",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.39.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "pokevault",
+	"name": "trove",
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {

--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 
-/* PokéVault Custom Theme — Warm, fun, Pokemon-inspired */
+/* Trove Custom Theme — Warm, fun, Pokemon-inspired */
 @theme {
 	/* Core palette — warm darks with purple undertones */
 	--color-vault-bg: #12111a;

--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta name="description" content="PokéVault — Personal Pokémon TCG Collector Intelligence" />
+		<meta name="description" content="Trove — Pokémon TCG Collector Intelligence" />
 		<meta name="theme-color" content="#12111a" />
 		%sveltekit.head%
 	</head>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,7 +51,7 @@
 					<circle cx="12" cy="12" r="3" fill="currentColor"/>
 				</svg>
 			</div>
-			<span class="text-xl font-bold text-gradient">PokéVault</span>
+			<span class="text-xl font-bold text-gradient">Trove</span>
 		</div>
 
 		<!-- Nav items -->
@@ -154,7 +154,7 @@
 						<circle cx="12" cy="12" r="3" fill="currentColor"/>
 					</svg>
 				</div>
-				<span class="text-xl font-bold text-gradient">PokéVault</span>
+				<span class="text-xl font-bold text-gradient">Trove</span>
 			</div>
 			<nav class="space-y-1 p-3">
 				{#each navItems as item}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <svelte:head>
-	<title>PokéVault — Dashboard</title>
+	<title>Trove — Dashboard</title>
 </svelte:head>
 
 <div class="space-y-6 sm:space-y-8">

--- a/src/routes/analytics/+page.svelte
+++ b/src/routes/analytics/+page.svelte
@@ -117,7 +117,7 @@
 </script>
 
 <svelte:head>
-	<title>Analytics — PokéVault</title>
+	<title>Analytics — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/src/routes/browse/+page.svelte
+++ b/src/routes/browse/+page.svelte
@@ -139,7 +139,7 @@
 </script>
 
 <svelte:head>
-	<title>Browse Cards — PokéVault</title>
+	<title>Browse Cards — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -94,7 +94,7 @@
 </script>
 
 <svelte:head>
-	<title>{card.name} — PokéVault</title>
+	<title>{card.name} — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/src/routes/collection/+page.svelte
+++ b/src/routes/collection/+page.svelte
@@ -157,7 +157,7 @@
 </script>
 
 <svelte:head>
-	<title>My Collection — PokéVault</title>
+	<title>My Collection — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/src/routes/grading/+page.svelte
+++ b/src/routes/grading/+page.svelte
@@ -161,7 +161,7 @@
 </script>
 
 <svelte:head>
-	<title>Grading — PokéVault</title>
+	<title>Grading — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/src/routes/insights/+page.svelte
+++ b/src/routes/insights/+page.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <svelte:head>
-	<title>Insights — PokéVault</title>
+	<title>Insights — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/src/routes/sets/+page.svelte
+++ b/src/routes/sets/+page.svelte
@@ -37,7 +37,7 @@
 </script>
 
 <svelte:head>
-	<title>Set Tracker — PokéVault</title>
+	<title>Set Tracker — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -3,13 +3,13 @@
 </script>
 
 <svelte:head>
-	<title>Settings — PokéVault</title>
+	<title>Settings — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">
 	<div>
 		<h1 class="text-2xl font-bold text-gradient sm:text-3xl">Settings</h1>
-		<p class="mt-1 text-vault-text-muted">Configure your PokéVault experience</p>
+		<p class="mt-1 text-vault-text-muted">Configure your Trove experience</p>
 	</div>
 
 	<div class="max-w-2xl space-y-6">

--- a/src/routes/style-guide/+page.svelte
+++ b/src/routes/style-guide/+page.svelte
@@ -3,13 +3,13 @@
 </script>
 
 <svelte:head>
-	<title>Style Guide — PokéVault</title>
+	<title>Style Guide — Trove</title>
 </svelte:head>
 
 <div class="space-y-8">
 	<div>
 		<h1 class="text-2xl font-bold text-gradient sm:text-3xl">Style Guide</h1>
-		<p class="mt-1 text-vault-text-muted">PokéVault design system reference</p>
+		<p class="mt-1 text-vault-text-muted">Trove design system reference</p>
 	</div>
 
 	<!-- Tabs -->

--- a/src/routes/watchlist/+page.svelte
+++ b/src/routes/watchlist/+page.svelte
@@ -54,7 +54,7 @@
 </script>
 
 <svelte:head>
-	<title>Watchlist — PokéVault</title>
+	<title>Watchlist — Trove</title>
 </svelte:head>
 
 <div class="space-y-6">

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,4 +1,4 @@
--- PokéVault Initial Schema
+-- Trove Initial Schema
 -- Run this in your Supabase SQL editor to set up all tables
 
 -- ============================================


### PR DESCRIPTION
## Summary
- Rename all PokéVault references to Trove across the entire app
- Updates page titles, sidebar branding, meta description, package name, config files, and docs

## Test plan
- [x] Dev server starts and all pages render with "Trove" branding
- [x] No remaining PokéVault references in source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)