### PR TITLE
Smart price caching via Supabase

### DIFF
--- a/src/lib/components/PriceChart.svelte
+++ b/src/lib/components/PriceChart.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import type { PriceHistory } from '$services/price-tracker';
+	// PriceHistory type — compatible with both price-tracker API and our cache
+	interface PriceHistory {
+		card_id: string;
+		data_points: { date: string; price: number }[];
+		period: string;
+	}
 
 	interface Props {
 		priceHistory: PriceHistory | null;
@@ -95,9 +100,14 @@
 	});
 </script>
 
-{#if priceHistory?.data_points?.length}
+{#if priceHistory?.data_points?.length && priceHistory.data_points.length >= 2}
 	<div style="height: {height}px;">
 		<canvas bind:this={canvas}></canvas>
+	</div>
+{:else if priceHistory?.data_points?.length === 1}
+	<div class="flex flex-col items-center justify-center gap-2 py-8 text-sm text-vault-text-muted" style="height: {height}px;">
+		<div class="text-2xl font-bold text-vault-green">${priceHistory.data_points[0].price.toFixed(2)}</div>
+		<p>Price tracking started — chart builds as you browse over time</p>
 	</div>
 {:else}
 	<div class="flex items-center justify-center py-8 text-sm text-vault-text-muted" style="height: {height}px;">

--- a/src/lib/services/price-cache.ts
+++ b/src/lib/services/price-cache.ts
@@ -1,0 +1,230 @@
+/**
+ * Price Cache Service — Caches TCGPlayer prices from the Pokemon TCG API into Supabase
+ *
+ * The Pokemon TCG API returns free TCGPlayer price data on every card.
+ * This service caches that data in Supabase for:
+ * 1. Price history over time (daily snapshots)
+ * 2. Fast portfolio valuation (no API calls needed)
+ * 3. Offline price access when the TCG API is slow/down
+ */
+
+import { supabase } from './supabase';
+import type { TCGPlayerData, PriceData } from '$types';
+import type { PriceHistory } from './price-tracker';
+
+/** Preferred variant order for picking a "primary" price */
+const VARIANT_PRIORITY = [
+	'holofoil',
+	'reverseHolofoil',
+	'normal',
+	'1stEditionHolofoil',
+	'1stEditionNormal',
+	'unlimited',
+	'unlimitedHolofoil'
+];
+
+/**
+ * Pick the best market price from a card's TCGPlayer variants.
+ * Prefers holofoil > reverseHolofoil > normal > any other.
+ */
+function pickMarketPrice(prices: Record<string, PriceData>): number | null {
+	for (const variant of VARIANT_PRIORITY) {
+		const p = prices[variant];
+		if (p?.market != null) return p.market;
+		if (p?.mid != null) return p.mid;
+	}
+	// Fallback: first variant with a market or mid price
+	for (const p of Object.values(prices)) {
+		if (p?.market != null) return p.market;
+		if (p?.mid != null) return p.mid;
+	}
+	return null;
+}
+
+/**
+ * Check if we already cached this card's price today.
+ * Returns true if cache is stale (needs update).
+ */
+export async function shouldCachePrice(cardId: string): Promise<boolean> {
+	try {
+		const today = new Date().toISOString().split('T')[0];
+		const { data } = await supabase
+			.from('price_cache')
+			.select('cached_at')
+			.eq('card_id', cardId)
+			.eq('source', 'tcgplayer')
+			.single();
+
+		if (!data) return true;
+		const cachedDate = data.cached_at?.split('T')[0];
+		return cachedDate !== today;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Cache TCGPlayer prices into both price_cache (latest) and price_history (daily snapshot).
+ * Fire-and-forget — errors are caught and never block page loads.
+ */
+export async function cacheTcgPlayerPrices(
+	cardId: string,
+	tcgplayer: TCGPlayerData
+): Promise<void> {
+	const prices = tcgplayer.prices;
+	if (!prices || Object.keys(prices).length === 0) return;
+
+	const stale = await shouldCachePrice(cardId);
+	if (!stale) return;
+
+	const marketPrice = pickMarketPrice(prices);
+
+	// 1. Upsert price_cache (latest snapshot)
+	try {
+		await supabase
+			.from('price_cache')
+			.upsert(
+				{
+					card_id: cardId,
+					source: 'tcgplayer',
+					raw_price: marketPrice,
+					graded_prices: prices,
+					cached_at: new Date().toISOString()
+				},
+				{ onConflict: 'card_id,source' }
+			);
+	} catch {
+		// Ignore — fire-and-forget
+	}
+
+	// 2. Upsert price_history rows (one per variant)
+	const today = new Date().toISOString().split('T')[0];
+	const rows = Object.entries(prices).map(([variant, p]) => ({
+		card_id: cardId,
+		variant,
+		low: p.low ?? null,
+		mid: p.mid ?? null,
+		high: p.high ?? null,
+		market: p.market ?? null,
+		direct_low: p.directLow ?? null,
+		recorded_at: today
+	}));
+
+	if (rows.length > 0) {
+		try {
+			await supabase
+				.from('price_history')
+				.upsert(rows, { onConflict: 'card_id,variant,recorded_at' });
+		} catch {
+			// Ignore — fire-and-forget
+		}
+	}
+}
+
+/**
+ * Get price history for a card from cached daily snapshots.
+ * Returns data in the format PriceChart.svelte expects.
+ */
+export async function getPriceHistoryFromCache(
+	cardId: string,
+	days: number = 365
+): Promise<PriceHistory | null> {
+	try {
+		const since = new Date();
+		since.setDate(since.getDate() - days);
+		const sinceStr = since.toISOString().split('T')[0];
+
+		const { data, error } = await supabase
+			.from('price_history')
+			.select('variant, market, mid, recorded_at')
+			.eq('card_id', cardId)
+			.gte('recorded_at', sinceStr)
+			.order('recorded_at', { ascending: true });
+
+		if (error || !data || data.length === 0) return null;
+
+		// Group by date, pick best variant price per day
+		const byDate = new Map<string, number>();
+		for (const row of data) {
+			const price = row.market ?? row.mid;
+			if (price == null) continue;
+
+			const existing = byDate.get(row.recorded_at);
+			// Keep the first non-null price per date (data comes sorted)
+			if (existing == null) {
+				byDate.set(row.recorded_at, price);
+			}
+		}
+
+		if (byDate.size === 0) return null;
+
+		const dataPoints = Array.from(byDate.entries()).map(([date, price]) => ({
+			date,
+			price
+		}));
+
+		return {
+			card_id: cardId,
+			data_points: dataPoints,
+			period: `${days}d`
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Get the latest cached price for a single card.
+ */
+export async function getCachedPrice(
+	cardId: string
+): Promise<{ market: number; prices: Record<string, PriceData> } | null> {
+	try {
+		const { data } = await supabase
+			.from('price_cache')
+			.select('raw_price, graded_prices')
+			.eq('card_id', cardId)
+			.eq('source', 'tcgplayer')
+			.single();
+
+		if (!data || data.raw_price == null) return null;
+
+		return {
+			market: Number(data.raw_price),
+			prices: (data.graded_prices as Record<string, PriceData>) ?? {}
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Batch-fetch cached market prices for multiple cards.
+ * Used by dashboard for portfolio valuation.
+ */
+export async function getCachedPricesForCards(
+	cardIds: string[]
+): Promise<Map<string, number>> {
+	const result = new Map<string, number>();
+	if (cardIds.length === 0) return result;
+
+	try {
+		const { data } = await supabase
+			.from('price_cache')
+			.select('card_id, raw_price')
+			.eq('source', 'tcgplayer')
+			.in('card_id', cardIds);
+
+		if (data) {
+			for (const row of data) {
+				if (row.raw_price != null) {
+					result.set(row.card_id, Number(row.raw_price));
+				}
+			}
+		}
+	} catch {
+		// Return whatever we got
+	}
+
+	return result;
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,6 @@
 import { supabase } from '$services/supabase';
 import { getCard } from '$services/tcg-api';
+import { getCachedPricesForCards } from '$services/price-cache';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -20,22 +21,33 @@ export const load: PageServerLoad = async () => {
 		0
 	);
 
-	// Portfolio valuation — fetch current market prices for collection cards
 	let portfolioValue = 0;
 	let topHoldings: { card_id: string; name: string; quantity: number; marketPrice: number; totalValue: number; imageUrl: string; gainLoss: number }[] = [];
 
 	if (collection.length > 0) {
-		// Fetch prices for up to 20 unique cards (avoid hammering API)
 		const uniqueCardIds = [...new Set(collection.map((e: { card_id: string }) => e.card_id))].slice(0, 20);
+
+		// Try cached prices first, then fall back to TCG API for uncached cards
+		const cachedPrices = await getCachedPricesForCards(uniqueCardIds);
+		const uncachedIds = uniqueCardIds.filter((id) => !cachedPrices.has(id));
+
 		const cardResults = await Promise.all(
-			uniqueCardIds.map((id) => getCard(id).catch(() => null))
+			uncachedIds.map((id) => getCard(id).catch(() => null))
 		);
 
 		const cardMap = new Map<string, { name: string; marketPrice: number; imageUrl: string }>();
-		for (const card of cardResults) {
+
+		// Add cached prices (need card name/image from API still)
+		// Fetch all cards for metadata but use cached price when available
+		const allCardResults = await Promise.all(
+			uniqueCardIds.map((id) => getCard(id).catch(() => null))
+		);
+
+		for (const card of allCardResults) {
 			if (!card) continue;
-			let marketPrice = 0;
-			if (card.tcgplayer?.prices) {
+			// Prefer cached price, fall back to live TCGPlayer price from card data
+			let marketPrice = cachedPrices.get(card.id) ?? 0;
+			if (marketPrice === 0 && card.tcgplayer?.prices) {
 				for (const variant of Object.values(card.tcgplayer.prices)) {
 					if (variant.market) { marketPrice = variant.market; break; }
 					if (variant.mid) { marketPrice = variant.mid; break; }

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -1,10 +1,10 @@
 import { getCard } from '$services/tcg-api';
 import { getPokemon, getEvolutionChain } from '$services/pokeapi';
 import { getCardPrices } from '$services/poketrace';
-import { getGradedPrices, getPriceHistory } from '$services/price-tracker';
+import { getGradedPrices } from '$services/price-tracker';
 import { searchEbaySold } from '$services/ebay-scraper';
 import { searchPSAPop } from '$services/psa-scraper';
-import { supabase } from '$services/supabase';
+import { cacheTcgPlayerPrices, getPriceHistoryFromCache } from '$services/price-cache';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -12,37 +12,28 @@ export const load: PageServerLoad = async ({ params }) => {
 	const card = await getCard(params.id).catch(() => null);
 	if (!card) throw error(404, 'Card not found');
 
-	// Fetch all enrichment data in parallel
+	// Cache TCGPlayer prices to Supabase (fire-and-forget, once per day)
+	if (card.tcgplayer?.prices) {
+		cacheTcgPlayerPrices(card.id, card.tcgplayer).catch(() => {});
+	}
+
 	const dexNumber = card.nationalPokedexNumbers?.[0];
 
-	const [pokedexData, evolutionChain, poketracePrice, gradedPrices, priceHistory, ebaySold, psaPop] =
+	// Core data: Pokedex enrichment + price history from our cache
+	// External APIs: only attempt if env vars are configured
+	const hasPokeTrace = !!process.env.POKETRACE_API_KEY;
+	const hasPriceTracker = !!process.env.PRICE_TRACKER_API_KEY;
+
+	const [pokedexData, evolutionChain, priceHistory, poketracePrice, gradedPrices, ebaySold, psaPop] =
 		await Promise.all([
 			dexNumber ? getPokemon(dexNumber) : Promise.resolve(null),
 			dexNumber ? getEvolutionChain(dexNumber) : Promise.resolve(null),
-			getCardPrices(params.id),
-			getGradedPrices(params.id),
-			getPriceHistory(params.id, '1y'),
+			getPriceHistoryFromCache(params.id),
+			hasPokeTrace ? getCardPrices(params.id) : Promise.resolve(null),
+			hasPriceTracker ? getGradedPrices(params.id) : Promise.resolve([]),
 			searchEbaySold(card.name, card.set?.name, 10),
 			searchPSAPop(card.name, card.set?.name)
 		]);
-
-	// Cache the price data in Supabase if we got PokeTrace data
-	if (poketracePrice) {
-		const marketPrice = poketracePrice.tcgplayer?.raw?.market;
-		await supabase
-			.from('price_cache')
-			.upsert(
-				{
-					card_id: params.id,
-					source: 'poketrace',
-					raw_price: marketPrice ?? null,
-					graded_prices: poketracePrice.tcgplayer?.graded ?? {},
-					cached_at: new Date().toISOString()
-				},
-				{ onConflict: 'card_id,source' }
-			)
-			.catch(() => {});
-	}
 
 	return {
 		card,

--- a/supabase/migrations/002_price_history.sql
+++ b/supabase/migrations/002_price_history.sql
@@ -1,0 +1,20 @@
+-- Trove: Price History Table
+-- Stores daily price snapshots from TCGPlayer data (via Pokemon TCG API)
+-- One row per card per variant per day — upsert-safe
+
+create table if not exists price_history (
+    id uuid primary key default gen_random_uuid(),
+    card_id text not null,
+    variant text not null,
+    low numeric(10, 2),
+    mid numeric(10, 2),
+    high numeric(10, 2),
+    market numeric(10, 2),
+    direct_low numeric(10, 2),
+    recorded_at date not null default current_date,
+    unique (card_id, variant, recorded_at)
+);
+
+create index if not exists idx_price_history_card_id on price_history (card_id);
+create index if not exists idx_price_history_recorded_at on price_history (recorded_at);
+create index if not exists idx_price_history_card_date on price_history (card_id, recorded_at desc);


### PR DESCRIPTION
## Summary
- Cache TCGPlayer prices from the free Pokemon TCG API into Supabase on every card view
- New `price_history` table stores daily snapshots per card variant
- Price History chart now reads from our cache instead of a broken external API
- External APIs (PokeTrace, PriceTracker) are now conditional on env vars — no wasted timeouts
- Dashboard uses cached prices for portfolio valuation

## What this fixes
- "No price history available" on every card detail page
- Slow page loads from external API timeouts that never succeed
- Empty `price_cache` table (was only populated by non-working PokeTrace API)

## Migration required
Run `supabase/migrations/002_price_history.sql` in the Supabase SQL editor before deploying.

## Test plan
- [x] Build succeeds
- [x] Card detail page loads with TCGPlayer prices
- [x] No console/server errors
- [x] Dashboard loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)