### PR TITLE
Perf: speed up page loads with edge caching and cleanup

### DIFF
--- a/src/lib/services/pokeapi.ts
+++ b/src/lib/services/pokeapi.ts
@@ -1,12 +1,32 @@
 import type { PokedexData, EvolutionNode } from '$types';
 
 const BASE_URL = 'https://pokeapi.co/api/v2';
+const TIMEOUT_MS = 5000;
+const CACHE_TTL = 1000 * 60 * 60; // 1 hour — Pokedex data never changes
+
+// In-memory caches
+const pokemonCache = new Map<number, { data: PokedexData; expires: number }>();
+const evoCache = new Map<number, { data: EvolutionNode[]; expires: number }>();
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+	try {
+		return await fetch(url, { signal: controller.signal });
+	} finally {
+		clearTimeout(timer);
+	}
+}
 
 export async function getPokemon(nameOrId: string | number): Promise<PokedexData | null> {
+	const id = typeof nameOrId === 'string' ? parseInt(nameOrId) : nameOrId;
+	const cached = pokemonCache.get(id);
+	if (cached && cached.expires > Date.now()) return cached.data;
+
 	try {
 		const [speciesRes, pokemonRes] = await Promise.all([
-			fetch(`${BASE_URL}/pokemon-species/${nameOrId}`),
-			fetch(`${BASE_URL}/pokemon/${nameOrId}`)
+			fetchWithTimeout(`${BASE_URL}/pokemon-species/${nameOrId}`),
+			fetchWithTimeout(`${BASE_URL}/pokemon/${nameOrId}`)
 		]);
 
 		if (!speciesRes.ok || !pokemonRes.ok) return null;
@@ -21,7 +41,7 @@ export async function getPokemon(nameOrId: string | number): Promise<PokedexData
 			(g: { language: { name: string } }) => g.language.name === 'en'
 		);
 
-		return {
+		const data: PokedexData = {
 			id: pokemon.id,
 			name: pokemon.name,
 			types: pokemon.types.map((t: { type: { name: string } }) => t.type.name),
@@ -30,24 +50,52 @@ export async function getPokemon(nameOrId: string | number): Promise<PokedexData
 			height: pokemon.height,
 			weight: pokemon.weight
 		};
+
+		pokemonCache.set(id, { data, expires: Date.now() + CACHE_TTL });
+
+		// Also cache the evolution chain from this species data (avoids double fetch)
+		if (species.evolution_chain?.url) {
+			cacheEvolutionFromSpecies(id, species.evolution_chain.url);
+		}
+
+		return data;
 	} catch {
 		return null;
 	}
 }
 
 export async function getEvolutionChain(pokemonId: number): Promise<EvolutionNode[] | null> {
+	const cached = evoCache.get(pokemonId);
+	if (cached && cached.expires > Date.now()) return cached.data;
+
 	try {
-		const speciesRes = await fetch(`${BASE_URL}/pokemon-species/${pokemonId}`);
+		const speciesRes = await fetchWithTimeout(`${BASE_URL}/pokemon-species/${pokemonId}`);
 		if (!speciesRes.ok) return null;
 		const species = await speciesRes.json();
 
-		const evoRes = await fetch(species.evolution_chain.url);
+		const evoRes = await fetchWithTimeout(species.evolution_chain.url);
 		if (!evoRes.ok) return null;
 		const evoData = await evoRes.json();
 
-		return [parseChain(evoData.chain)];
+		const data = [parseChain(evoData.chain)];
+		evoCache.set(pokemonId, { data, expires: Date.now() + CACHE_TTL });
+		return data;
 	} catch {
 		return null;
+	}
+}
+
+/** Pre-cache evolution chain when we already have the species URL from getPokemon */
+async function cacheEvolutionFromSpecies(pokemonId: number, evoUrl: string): Promise<void> {
+	if (evoCache.has(pokemonId)) return;
+	try {
+		const evoRes = await fetchWithTimeout(evoUrl);
+		if (!evoRes.ok) return;
+		const evoData = await evoRes.json();
+		const data = [parseChain(evoData.chain)];
+		evoCache.set(pokemonId, { data, expires: Date.now() + CACHE_TTL });
+	} catch {
+		// Ignore
 	}
 }
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -3,7 +3,12 @@ import { getCard } from '$services/tcg-api';
 import { getCachedPricesForCards } from '$services/price-cache';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ setHeaders }) => {
+	// Dashboard is mostly static when collection is empty — cache at edge
+	setHeaders({
+		'cache-control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=300'
+	});
+
 	const [collectionRes, watchlistRes, gradingRes] = await Promise.all([
 		supabase.from('collection').select('*'),
 		supabase.from('watchlist').select('*'),
@@ -27,26 +32,17 @@ export const load: PageServerLoad = async () => {
 	if (collection.length > 0) {
 		const uniqueCardIds = [...new Set(collection.map((e: { card_id: string }) => e.card_id))].slice(0, 20);
 
-		// Try cached prices first, then fall back to TCG API for uncached cards
-		const cachedPrices = await getCachedPricesForCards(uniqueCardIds);
-		const uncachedIds = uniqueCardIds.filter((id) => !cachedPrices.has(id));
-
-		const cardResults = await Promise.all(
-			uncachedIds.map((id) => getCard(id).catch(() => null))
-		);
+		// Get cached prices + fetch card metadata in one pass
+		const [cachedPrices, ...cardResults] = await Promise.all([
+			getCachedPricesForCards(uniqueCardIds),
+			...uniqueCardIds.map((id) => getCard(id).catch(() => null))
+		]);
 
 		const cardMap = new Map<string, { name: string; marketPrice: number; imageUrl: string }>();
 
-		// Add cached prices (need card name/image from API still)
-		// Fetch all cards for metadata but use cached price when available
-		const allCardResults = await Promise.all(
-			uniqueCardIds.map((id) => getCard(id).catch(() => null))
-		);
-
-		for (const card of allCardResults) {
+		for (const card of cardResults) {
 			if (!card) continue;
-			// Prefer cached price, fall back to live TCGPlayer price from card data
-			let marketPrice = cachedPrices.get(card.id) ?? 0;
+			let marketPrice = (cachedPrices as Map<string, number>).get(card.id) ?? 0;
 			if (marketPrice === 0 && card.tcgplayer?.prices) {
 				for (const variant of Object.values(card.tcgplayer.prices)) {
 					if (variant.market) { marketPrice = variant.market; break; }

--- a/src/routes/api/cards/+server.ts
+++ b/src/routes/api/cards/+server.ts
@@ -9,7 +9,9 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	try {
 		const result = await searchCards(query, page, pageSize);
-		return json(result);
+		return json(result, {
+			headers: { 'cache-control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600' }
+		});
 	} catch {
 		return json({ data: [], totalCount: 0, page, pageSize, count: 0 });
 	}

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -1,7 +1,12 @@
 import { getSets } from '$services/tcg-api';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ url }) => {
+export const load: PageServerLoad = async ({ url, setHeaders }) => {
+	// Sets list is stable — cache aggressively at the edge
+	setHeaders({
+		'cache-control': 'public, max-age=600, s-maxage=1800, stale-while-revalidate=3600'
+	});
+
 	const search = url.searchParams.get('q') ?? '';
 	const set = url.searchParams.get('set') ?? '';
 	const type = url.searchParams.get('type') ?? '';

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -2,15 +2,18 @@ import { getCard } from '$services/tcg-api';
 import { getPokemon, getEvolutionChain } from '$services/pokeapi';
 import { getCardPrices } from '$services/poketrace';
 import { getGradedPrices } from '$services/price-tracker';
-import { searchEbaySold } from '$services/ebay-scraper';
-import { searchPSAPop } from '$services/psa-scraper';
 import { cacheTcgPlayerPrices, getPriceHistoryFromCache } from '$services/price-cache';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, setHeaders }) => {
 	const card = await getCard(params.id).catch(() => null);
 	if (!card) throw error(404, 'Card not found');
+
+	// Cache at the edge for 5 min, serve stale for 1 hour while revalidating
+	setHeaders({
+		'cache-control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600'
+	});
 
 	// Cache TCGPlayer prices to Supabase (fire-and-forget, once per day)
 	if (card.tcgplayer?.prices) {
@@ -18,21 +21,17 @@ export const load: PageServerLoad = async ({ params }) => {
 	}
 
 	const dexNumber = card.nationalPokedexNumbers?.[0];
-
-	// Core data: Pokedex enrichment + price history from our cache
-	// External APIs: only attempt if env vars are configured
 	const hasPokeTrace = !!process.env.POKETRACE_API_KEY;
 	const hasPriceTracker = !!process.env.PRICE_TRACKER_API_KEY;
 
-	const [pokedexData, evolutionChain, priceHistory, poketracePrice, gradedPrices, ebaySold, psaPop] =
+	// Only make fast, reliable calls — no scrapers (eBay/PSA always fail from Vercel)
+	const [pokedexData, evolutionChain, priceHistory, poketracePrice, gradedPrices] =
 		await Promise.all([
 			dexNumber ? getPokemon(dexNumber) : Promise.resolve(null),
 			dexNumber ? getEvolutionChain(dexNumber) : Promise.resolve(null),
 			getPriceHistoryFromCache(params.id),
 			hasPokeTrace ? getCardPrices(params.id) : Promise.resolve(null),
-			hasPriceTracker ? getGradedPrices(params.id) : Promise.resolve([]),
-			searchEbaySold(card.name, card.set?.name, 10),
-			searchPSAPop(card.name, card.set?.name)
+			hasPriceTracker ? getGradedPrices(params.id) : Promise.resolve([])
 		]);
 
 	return {
@@ -42,7 +41,7 @@ export const load: PageServerLoad = async ({ params }) => {
 		poketracePrice,
 		gradedPrices,
 		priceHistory,
-		ebaySold,
-		psaPop
+		ebaySold: { query: '', listings: [], averagePrice: 0, medianPrice: 0, lowPrice: 0, highPrice: 0, totalSold: 0 },
+		psaPop: null
 	};
 };


### PR DESCRIPTION
## Summary
- Remove eBay/PSA scraper calls (always fail from Vercel, hung with no timeout)
- Add 5s timeout + 1hr in-memory cache to PokeAPI
- Add Vercel edge cache headers (stale-while-revalidate) to all pages
- Fix dashboard double-fetching all cards

Card detail page: 7 parallel API calls → 3-4 fast ones. Second visits served from Vercel edge cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)