### PR TITLE
fix: default browse to latest set (Perfect Order)

### DIFF
--- a/src/routes/api/cards/+server.ts
+++ b/src/routes/api/cards/+server.ts
@@ -1,11 +1,26 @@
 import { json } from '@sveltejs/kit';
-import { searchCards } from '$services/tcg-api';
+import { searchCards, getSets } from '$services/tcg-api';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url }) => {
-	const query = url.searchParams.get('q') ?? 'set.id:me2pt5';
+	let query = url.searchParams.get('q');
 	const page = parseInt(url.searchParams.get('page') ?? '1');
 	const pageSize = parseInt(url.searchParams.get('pageSize') ?? '24');
+
+	// When no query is supplied, default to the latest set (sorted by release date).
+	if (!query) {
+		try {
+			const sets = await getSets();
+			const latest = sets[0];
+			query = latest ? `set.id:${latest.id}` : '';
+		} catch {
+			query = '';
+		}
+	}
+
+	if (!query) {
+		return json({ data: [], totalCount: 0, page, pageSize, count: 0 });
+	}
 
 	try {
 		const result = await searchCards(query, page, pageSize);

--- a/src/routes/browse/+page.svelte
+++ b/src/routes/browse/+page.svelte
@@ -24,14 +24,17 @@
 	let sets = $derived(data.sets);
 	let hasMore = $derived(cards.length < totalCount);
 
-	// Build query string from current filters
+	// Build query string from current filters. Default to the latest set (first in
+	// the server-loaded list, which is sorted by -releaseDate).
 	function buildQuery(): string {
 		const parts: string[] = [];
 		if (searchInput) parts.push(`name:"${searchInput}*"`);
 		if (selectedSet) parts.push(`set.id:${selectedSet}`);
 		if (selectedType) parts.push(`types:${selectedType}`);
 		if (selectedRarity) parts.push(`rarity:"${selectedRarity}"`);
-		return parts.length > 0 ? parts.join(' ') : 'set.id:me2pt5';
+		if (parts.length > 0) return parts.join(' ');
+		const latestSetId = sets[0]?.id;
+		return latestSetId ? `set.id:${latestSetId}` : '';
 	}
 
 	// Fetch cards from client-side API


### PR DESCRIPTION
## Summary
- Browse page and `/api/cards` endpoint were hardcoded to `set.id:me2pt5` (Ascended Heroes), so the default view never advanced past it
- Both now resolve the latest set dynamically: the API endpoint via `getSets()`, the browse page via the already-loaded `sets[0]` (sorted by `-releaseDate`)
- Future-proof — when a new set drops on the TCG API, Trove picks it up automatically with no code change

## Test plan
- [x] `/browse` defaults to Perfect Order (124 cards, `me3-*`)
- [x] `/browse?set=me3` returns 124 Perfect Order cards
- [x] `/api/cards` (no query) returns set `me3`, totalCount 124
- [x] `/api/cards?q=set.id:me3` returns set `me3`, totalCount 124
- [x] `/card/me3-1` (Spinarak) loads with Perfect Order set name + evolution chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)