### PR TITLE
feat: API health monitor + live status badge

### DIFF
--- a/src/lib/components/ApiStatus.svelte
+++ b/src/lib/components/ApiStatus.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import type { MonitorSnapshot, ServiceHealth, ServiceStatus } from '$services/api-monitor';
+
+	const POLL_INTERVAL = 30_000; // 30s
+	let snapshot = $state<MonitorSnapshot | null>(null);
+	let open = $state(false);
+	let now = $state(Date.now());
+	let timer: ReturnType<typeof setInterval> | null = null;
+	let tick: ReturnType<typeof setInterval> | null = null;
+
+	async function refresh() {
+		try {
+			const res = await fetch('/api/health', { cache: 'no-store' });
+			if (res.ok) snapshot = await res.json();
+		} catch {
+			// Network failure to our own /api/health — leave previous snapshot
+		}
+	}
+
+	onMount(() => {
+		refresh();
+		timer = setInterval(refresh, POLL_INTERVAL);
+		// Re-tick once a second so countdowns update without refetching
+		tick = setInterval(() => (now = Date.now()), 1000);
+	});
+
+	onDestroy(() => {
+		if (timer) clearInterval(timer);
+		if (tick) clearInterval(tick);
+	});
+
+	function colorFor(h: ServiceHealth): string {
+		switch (h) {
+			case 'ok':
+				return 'bg-vault-green';
+			case 'error':
+				return 'bg-yellow-500';
+			case 'ratelimited':
+				return 'bg-vault-accent';
+			default:
+				return 'bg-vault-text-muted';
+		}
+	}
+
+	function labelFor(h: ServiceHealth): string {
+		switch (h) {
+			case 'ok':
+				return 'Live';
+			case 'error':
+				return 'Degraded';
+			case 'ratelimited':
+				return 'Rate limited';
+			default:
+				return 'Unknown';
+		}
+	}
+
+	function formatRelative(ts: number | null): string {
+		if (!ts) return 'never';
+		const delta = now - ts;
+		if (delta < 0) return 'in ' + formatDelta(-delta);
+		if (delta < 60_000) return Math.round(delta / 1000) + 's ago';
+		if (delta < 3_600_000) return Math.round(delta / 60_000) + 'm ago';
+		return Math.round(delta / 3_600_000) + 'h ago';
+	}
+
+	function formatDelta(ms: number): string {
+		if (ms < 60_000) return Math.round(ms / 1000) + 's';
+		if (ms < 3_600_000) return Math.round(ms / 60_000) + 'm';
+		return Math.round(ms / 3_600_000) + 'h';
+	}
+
+	function statusDescription(s: ServiceStatus): string {
+		if (s.health === 'ratelimited') {
+			if (s.rateLimitResetAt && s.rateLimitResetAt > now) {
+				return 'Resets in ' + formatDelta(s.rateLimitResetAt - now);
+			}
+			return 'Resetting…';
+		}
+		if (s.health === 'error') return s.lastError ?? 'Recent failure';
+		if (s.health === 'ok') {
+			if (s.rateLimitRemaining !== null && s.rateLimitLimit !== null) {
+				return `${s.rateLimitRemaining}/${s.rateLimitLimit} remaining`;
+			}
+			return s.totalCalls > 0 ? `${s.totalCalls} call${s.totalCalls === 1 ? '' : 's'}` : 'Idle';
+		}
+		return 'No traffic yet';
+	}
+
+	let overall = $derived(snapshot?.overall ?? 'unknown');
+</script>
+
+<div class="relative">
+	<button
+		type="button"
+		onclick={() => (open = !open)}
+		class="flex items-center gap-2 rounded-full px-2 py-1 text-sm text-vault-text-muted transition-colors hover:bg-vault-surface-hover"
+		aria-label="API status"
+		aria-expanded={open}
+	>
+		<span class="relative flex h-2 w-2">
+			{#if overall === 'ok'}
+				<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-vault-green opacity-60"></span>
+			{/if}
+			<span class="relative inline-flex h-2 w-2 rounded-full {colorFor(overall)}"></span>
+		</span>
+		<span class="hidden sm:inline">{labelFor(overall)}</span>
+	</button>
+
+	{#if open}
+		<button
+			type="button"
+			class="fixed inset-0 z-40"
+			aria-label="Close status panel"
+			onclick={() => (open = false)}
+		></button>
+		<div class="absolute right-0 top-full z-50 mt-2 w-72 rounded-2xl border border-vault-border bg-vault-surface p-3 shadow-2xl">
+			<div class="mb-3 flex items-center justify-between border-b border-vault-border pb-2">
+				<span class="text-sm font-semibold text-white">API Status</span>
+				<span class="text-xs text-vault-text-muted">{labelFor(overall)}</span>
+			</div>
+			{#if snapshot}
+				<div class="space-y-2">
+					{#each snapshot.services as s (s.service)}
+						<div class="flex items-start justify-between gap-3 text-xs">
+							<div class="flex items-center gap-2 min-w-0">
+								<span class="h-2 w-2 flex-shrink-0 rounded-full {colorFor(s.health)}"></span>
+								<span class="truncate text-vault-text">{s.label}</span>
+							</div>
+							<div class="flex flex-col items-end text-right">
+								<span class="text-vault-text-muted">{statusDescription(s)}</span>
+								{#if s.lastSuccessAt && s.health === 'ok'}
+									<span class="text-[10px] text-vault-text-muted/70">last ok {formatRelative(s.lastSuccessAt)}</span>
+								{:else if s.lastErrorAt && s.health !== 'ok'}
+									<span class="text-[10px] text-vault-text-muted/70">since {formatRelative(s.lastErrorAt)}</span>
+								{/if}
+							</div>
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<p class="text-xs text-vault-text-muted">Loading…</p>
+			{/if}
+			<p class="mt-3 border-t border-vault-border pt-2 text-[10px] text-vault-text-muted">
+				Counts reset on server restart. Polls every 30s.
+			</p>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -4,3 +4,4 @@ export { default as PriceChart } from './PriceChart.svelte';
 export { default as SetProgress } from './SetProgress.svelte';
 export { default as GradeROICard } from './GradeROICard.svelte';
 export { default as ComparisonChart } from './ComparisonChart.svelte';
+export { default as ApiStatus } from './ApiStatus.svelte';

--- a/src/lib/services/api-monitor.ts
+++ b/src/lib/services/api-monitor.ts
@@ -1,0 +1,200 @@
+/**
+ * api-monitor — lightweight in-memory health tracker for upstream APIs.
+ *
+ * Each API service module reports the result of every fetch via record() or
+ * recordError(). The monitor parses standard rate-limit headers, classifies
+ * the response, and exposes a snapshot consumed by /api/health and the
+ * <ApiStatus /> badge in the header.
+ *
+ * In-memory only — resets on every Vercel cold start. Fine for visibility;
+ * not for billing-grade quota tracking.
+ */
+
+export type ServiceHealth = 'ok' | 'error' | 'ratelimited' | 'unknown';
+
+export interface ServiceStatus {
+	service: string;
+	label: string;
+	health: ServiceHealth;
+	totalCalls: number;
+	errorCount: number;
+	lastStatusCode: number | null;
+	lastSuccessAt: number | null;
+	lastErrorAt: number | null;
+	lastError: string | null;
+	rateLimitRemaining: number | null;
+	rateLimitLimit: number | null;
+	rateLimitResetAt: number | null;
+}
+
+export interface MonitorSnapshot {
+	overall: ServiceHealth;
+	services: ServiceStatus[];
+	generatedAt: number;
+}
+
+const SERVICE_LABELS: Record<string, string> = {
+	tcg: 'Pokémon TCG API',
+	pokeapi: 'PokéAPI',
+	poketrace: 'PokeTrace',
+	'price-tracker': 'Pokémon Price Tracker'
+};
+
+const services = new Map<string, ServiceStatus>();
+
+function getOrCreate(service: string): ServiceStatus {
+	let s = services.get(service);
+	if (!s) {
+		s = {
+			service,
+			label: SERVICE_LABELS[service] ?? service,
+			health: 'unknown',
+			totalCalls: 0,
+			errorCount: 0,
+			lastStatusCode: null,
+			lastSuccessAt: null,
+			lastErrorAt: null,
+			lastError: null,
+			rateLimitRemaining: null,
+			rateLimitLimit: null,
+			rateLimitResetAt: null
+		};
+		services.set(service, s);
+	}
+	return s;
+}
+
+function parseRetryAfter(value: string | null): number | null {
+	if (!value) return null;
+	const seconds = Number(value);
+	if (Number.isFinite(seconds)) return Date.now() + seconds * 1000;
+	const date = Date.parse(value);
+	return Number.isNaN(date) ? null : date;
+}
+
+function parseResetHeader(value: string | null): number | null {
+	if (!value) return null;
+	const num = Number(value);
+	if (!Number.isFinite(num)) return null;
+	// Heuristic: small numbers are seconds-from-now, large numbers are unix epoch.
+	if (num < 1_000_000_000) return Date.now() + num * 1000;
+	// Either seconds or milliseconds since epoch
+	return num > 1e12 ? num : num * 1000;
+}
+
+function readRateLimitHeaders(headers: Headers): {
+	remaining: number | null;
+	limit: number | null;
+	resetAt: number | null;
+} {
+	const remainingRaw =
+		headers.get('x-ratelimit-remaining') ?? headers.get('ratelimit-remaining');
+	const limitRaw = headers.get('x-ratelimit-limit') ?? headers.get('ratelimit-limit');
+	const resetRaw =
+		headers.get('x-ratelimit-reset') ??
+		headers.get('ratelimit-reset') ??
+		headers.get('retry-after');
+
+	return {
+		remaining: remainingRaw !== null && Number.isFinite(Number(remainingRaw))
+			? Number(remainingRaw)
+			: null,
+		limit: limitRaw !== null && Number.isFinite(Number(limitRaw)) ? Number(limitRaw) : null,
+		resetAt: parseResetHeader(resetRaw) ?? parseRetryAfter(headers.get('retry-after'))
+	};
+}
+
+function logTransition(prev: ServiceHealth, next: ServiceHealth, status: ServiceStatus) {
+	if (prev === next) return;
+	if (next === 'ratelimited') {
+		const reset = status.rateLimitResetAt
+			? new Date(status.rateLimitResetAt).toLocaleTimeString()
+			: 'unknown';
+		console.warn(
+			`[api-monitor] ${status.label} is RATE LIMITED (HTTP ${status.lastStatusCode ?? '?'}). Resets at ${reset}.`
+		);
+	} else if (next === 'error') {
+		console.warn(
+			`[api-monitor] ${status.label} reporting ERRORS (HTTP ${status.lastStatusCode ?? '?'}): ${status.lastError ?? 'unknown'}`
+		);
+	} else if (next === 'ok' && (prev === 'error' || prev === 'ratelimited')) {
+		console.info(`[api-monitor] ${status.label} recovered.`);
+	}
+}
+
+/** Record the outcome of a fetch call. Pass the Response (regardless of ok). */
+export function record(service: string, res: Response): void {
+	const status = getOrCreate(service);
+	const prev = status.health;
+
+	status.totalCalls += 1;
+	status.lastStatusCode = res.status;
+
+	const { remaining, limit, resetAt } = readRateLimitHeaders(res.headers);
+	if (remaining !== null) status.rateLimitRemaining = remaining;
+	if (limit !== null) status.rateLimitLimit = limit;
+	if (resetAt !== null) status.rateLimitResetAt = resetAt;
+
+	if (res.status === 429) {
+		status.errorCount += 1;
+		status.lastErrorAt = Date.now();
+		status.lastError = 'Rate limit exceeded (HTTP 429)';
+		status.health = 'ratelimited';
+	} else if (!res.ok) {
+		status.errorCount += 1;
+		status.lastErrorAt = Date.now();
+		status.lastError = `HTTP ${res.status} ${res.statusText || ''}`.trim();
+		status.health = 'error';
+	} else {
+		status.lastSuccessAt = Date.now();
+		// Clear a stale rate-limit state once a successful call comes in
+		if (status.health === 'ratelimited' && status.rateLimitResetAt && status.rateLimitResetAt < Date.now()) {
+			status.rateLimitResetAt = null;
+		}
+		status.health = 'ok';
+		status.lastError = null;
+	}
+
+	logTransition(prev, status.health, status);
+}
+
+/** Record a thrown error (network failure, abort, JSON parse, etc.). */
+export function recordError(service: string, error: unknown): void {
+	const status = getOrCreate(service);
+	const prev = status.health;
+	status.totalCalls += 1;
+	status.errorCount += 1;
+	status.lastErrorAt = Date.now();
+	status.lastError = error instanceof Error ? error.message : String(error);
+	status.health = 'error';
+	logTransition(prev, status.health, status);
+}
+
+/** Pre-register a service so it appears in snapshots before any traffic. */
+export function registerService(service: string, label?: string): void {
+	const s = getOrCreate(service);
+	if (label) s.label = label;
+}
+
+function computeOverall(list: ServiceStatus[]): ServiceHealth {
+	if (list.some((s) => s.health === 'ratelimited')) return 'ratelimited';
+	if (list.some((s) => s.health === 'error')) return 'error';
+	if (list.every((s) => s.health === 'unknown')) return 'unknown';
+	return 'ok';
+}
+
+export function getSnapshot(): MonitorSnapshot {
+	const list = Array.from(services.values());
+	return {
+		overall: computeOverall(list),
+		services: list,
+		generatedAt: Date.now()
+	};
+}
+
+// Pre-register the four main services so the badge has rows to render before
+// any traffic flows through.
+registerService('tcg');
+registerService('pokeapi');
+registerService('poketrace');
+registerService('price-tracker');

--- a/src/lib/services/pokeapi.ts
+++ b/src/lib/services/pokeapi.ts
@@ -1,8 +1,10 @@
 import type { PokedexData, EvolutionNode } from '$types';
+import * as apiMonitor from './api-monitor';
 
 const BASE_URL = 'https://pokeapi.co/api/v2';
 const TIMEOUT_MS = 5000;
 const CACHE_TTL = 1000 * 60 * 60; // 1 hour — Pokedex data never changes
+const SERVICE = 'pokeapi';
 
 // In-memory caches
 const pokemonCache = new Map<number, { data: PokedexData; expires: number }>();
@@ -12,7 +14,12 @@ async function fetchWithTimeout(url: string): Promise<Response> {
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 	try {
-		return await fetch(url, { signal: controller.signal });
+		const res = await fetch(url, { signal: controller.signal });
+		apiMonitor.record(SERVICE, res);
+		return res;
+	} catch (err) {
+		apiMonitor.recordError(SERVICE, err);
+		throw err;
 	} finally {
 		clearTimeout(timer);
 	}

--- a/src/lib/services/poketrace.ts
+++ b/src/lib/services/poketrace.ts
@@ -6,7 +6,10 @@
  * US vs EU arbitrage data, confidence scores
  */
 
+import * as apiMonitor from './api-monitor';
+
 const BASE_URL = 'https://api.poketrace.com/v1';
+const SERVICE = 'poketrace';
 
 export interface PokeTracePrice {
 	card_id: string;
@@ -67,7 +70,14 @@ function getHeaders(): HeadersInit {
 }
 
 async function fetchPokeTrace(endpoint: string): Promise<Response> {
-	return fetch(`${BASE_URL}${endpoint}`, { headers: getHeaders() });
+	try {
+		const res = await fetch(`${BASE_URL}${endpoint}`, { headers: getHeaders() });
+		apiMonitor.record(SERVICE, res);
+		return res;
+	} catch (err) {
+		apiMonitor.recordError(SERVICE, err);
+		throw err;
+	}
 }
 
 export async function getCardPrices(cardId: string): Promise<PokeTracePrice | null> {

--- a/src/lib/services/price-tracker.ts
+++ b/src/lib/services/price-tracker.ts
@@ -6,7 +6,10 @@
  * population reports, 1+ year historical price data
  */
 
+import * as apiMonitor from './api-monitor';
+
 const BASE_URL = 'https://pokemonpricetracker.com/api/v1';
+const SERVICE = 'price-tracker';
 
 export interface GradedPrice {
 	grade: number;
@@ -65,7 +68,14 @@ function getHeaders(): HeadersInit {
 }
 
 async function fetchPriceTracker(endpoint: string): Promise<Response> {
-	return fetch(`${BASE_URL}${endpoint}`, { headers: getHeaders() });
+	try {
+		const res = await fetch(`${BASE_URL}${endpoint}`, { headers: getHeaders() });
+		apiMonitor.record(SERVICE, res);
+		return res;
+	} catch (err) {
+		apiMonitor.recordError(SERVICE, err);
+		throw err;
+	}
 }
 
 export async function getGradedPrices(cardId: string): Promise<GradedPrice[]> {

--- a/src/lib/services/tcg-api.ts
+++ b/src/lib/services/tcg-api.ts
@@ -1,7 +1,9 @@
 import type { PokemonCard, CardSet, PaginatedResponse } from '$types';
+import * as apiMonitor from './api-monitor';
 
 const BASE_URL = 'https://api.pokemontcg.io/v2';
 const TIMEOUT_MS = 15000;
+const SERVICE = 'tcg';
 
 function getHeaders(): HeadersInit {
 	const headers: HeadersInit = { 'Content-Type': 'application/json' };
@@ -18,12 +20,19 @@ function getHeaders(): HeadersInit {
 	return headers;
 }
 
-function fetchWithTimeout(url: string, opts: RequestInit = {}): Promise<Response> {
+async function fetchWithTimeout(url: string, opts: RequestInit = {}): Promise<Response> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-	return fetch(url, { ...opts, signal: controller.signal }).finally(() =>
-		clearTimeout(timeout)
-	);
+	try {
+		const res = await fetch(url, { ...opts, signal: controller.signal });
+		apiMonitor.record(SERVICE, res);
+		return res;
+	} catch (err) {
+		apiMonitor.recordError(SERVICE, err);
+		throw err;
+	} finally {
+		clearTimeout(timeout);
+	}
 }
 
 // ── In-memory cache for sets (rarely changes, saves ~1 API call per page load) ──

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
+	import { ApiStatus } from '$components';
 
 	interface Props {
 		children: import('svelte').Snippet;
@@ -128,10 +129,7 @@
 				</div>
 			</form>
 
-			<div class="flex items-center gap-2 text-sm text-vault-text-muted">
-				<div class="h-2 w-2 rounded-full bg-vault-green animate-pulse"></div>
-				<span class="hidden sm:inline">Live</span>
-			</div>
+			<ApiStatus />
 		</header>
 
 		<!-- Page content -->

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,0 +1,12 @@
+import { json } from '@sveltejs/kit';
+import { getSnapshot } from '$services/api-monitor';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+	return json(getSnapshot(), {
+		headers: {
+			// Never cache — this should always reflect the current server state.
+			'cache-control': 'no-store, max-age=0'
+		}
+	});
+};


### PR DESCRIPTION
## Summary
- New `api-monitor` service tracks per-service health in memory (total calls, errors, last status, rate-limit headers). Detects HTTP 429 explicitly.
- Wired into `tcg-api`, `pokeapi`, `poketrace`, `price-tracker`. Logs `console.warn` on degradation and `console.info` on recovery.
- New `/api/health` endpoint returns the snapshot as JSON.
- Replaces the decorative \"Live\" badge in the header with a real `<ApiStatus />` component. Polls every 30s, shows green/yellow/red, click for per-service detail with last-error and reset countdowns.

## Test plan
- [x] Badge renders \"Live\" with green dot when all services healthy
- [x] Hitting `/card/totallyfake-9999` (404) flips badge to \"Degraded\" yellow
- [x] Console logs `[api-monitor] Pokémon TCG API reporting ERRORS (HTTP 404)`
- [x] Subsequent successful call recovers to green; logs `[api-monitor] Pokémon TCG API recovered.`
- [x] Popover lists all four services with status, counts, and last-success timestamp
- [x] `/api/health` returns full snapshot JSON

## Notes
- In-memory only (resets on Vercel cold start). Sufficient for visibility; not a billing-grade quota tracker.
- Biggest remaining quota mitigation is adding `POKEMON_TCG_API_KEY` to `.env.local` to lift the TCG API limit from 1,000/day → 20,000/day. Free at dev.pokemontcg.io.
- Scrapers (eBay/TCGPlayer/PSA) are not wired into the monitor in this pass; they don't expose useful headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)