### PR TITLE
fix: surface errors on add-to-collection/watchlist

### DIFF
--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -22,17 +22,34 @@
 	let addedToCollection = $state(false);
 	let addedToWatchlist = $state(false);
 	let actionLoading = $state('');
+	let actionError = $state<string | null>(null);
 	let priceTab = $state<'raw' | 'graded'>('raw');
+
+	async function readError(res: Response): Promise<string> {
+		try {
+			const body = await res.clone().json();
+			return body?.message ?? body?.error ?? `Request failed (HTTP ${res.status})`;
+		} catch {
+			return `Request failed (HTTP ${res.status})`;
+		}
+	}
 
 	async function addToCollection() {
 		actionLoading = 'collection';
+		actionError = null;
 		try {
 			const res = await fetch('/api/collection', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ card_id: card.id, quantity: 1, condition: 'NM' })
 			});
-			if (res.ok) addedToCollection = true;
+			if (res.ok) {
+				addedToCollection = true;
+			} else {
+				actionError = await readError(res);
+			}
+		} catch (err) {
+			actionError = err instanceof Error ? err.message : 'Network error';
 		} finally {
 			actionLoading = '';
 		}
@@ -40,13 +57,20 @@
 
 	async function addToWatchlist() {
 		actionLoading = 'watchlist';
+		actionError = null;
 		try {
 			const res = await fetch('/api/watchlist', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ card_id: card.id })
 			});
-			if (res.ok) addedToWatchlist = true;
+			if (res.ok) {
+				addedToWatchlist = true;
+			} else {
+				actionError = await readError(res);
+			}
+		} catch (err) {
+			actionError = err instanceof Error ? err.message : 'Network error';
 		} finally {
 			actionLoading = '';
 		}
@@ -584,13 +608,20 @@
 			{/if}
 
 			<!-- Actions -->
-			<div class="flex gap-3">
-				<button onclick={addToCollection} disabled={actionLoading === 'collection'} class="btn-press rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-6 py-2.5 text-sm font-medium text-white shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40 disabled:opacity-50">
-					{#if addedToCollection}Added!{:else if actionLoading === 'collection'}Adding...{:else}Add to Collection{/if}
-				</button>
-				<button onclick={addToWatchlist} disabled={actionLoading === 'watchlist'} class="btn-press rounded-xl border border-vault-border px-6 py-2.5 text-sm font-medium text-vault-text transition-all hover:border-vault-purple/50 hover:bg-vault-surface-hover disabled:opacity-50">
-					{#if addedToWatchlist}Watching!{:else if actionLoading === 'watchlist'}Adding...{:else}Add to Watchlist{/if}
-				</button>
+			<div class="space-y-3">
+				<div class="flex gap-3">
+					<button onclick={addToCollection} disabled={actionLoading === 'collection'} class="btn-press rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-6 py-2.5 text-sm font-medium text-white shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40 disabled:opacity-50">
+						{#if addedToCollection}Added!{:else if actionLoading === 'collection'}Adding...{:else}Add to Collection{/if}
+					</button>
+					<button onclick={addToWatchlist} disabled={actionLoading === 'watchlist'} class="btn-press rounded-xl border border-vault-border px-6 py-2.5 text-sm font-medium text-vault-text transition-all hover:border-vault-purple/50 hover:bg-vault-surface-hover disabled:opacity-50">
+						{#if addedToWatchlist}Watching!{:else if actionLoading === 'watchlist'}Adding...{:else}Add to Watchlist{/if}
+					</button>
+				</div>
+				{#if actionError}
+					<div class="rounded-xl border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent" data-testid="action-error">
+						<span class="font-semibold">Couldn't save:</span> {actionError}
+					</div>
+				{/if}
 			</div>
 		</div>
 	</div>

--- a/src/routes/collection/+page.svelte
+++ b/src/routes/collection/+page.svelte
@@ -9,6 +9,16 @@
 	let searchQuery = $state('');
 	let showAddModal = $state(false);
 	let editingEntry = $state<CollectionEntry | null>(null);
+	let saveError = $state<string | null>(null);
+
+	async function readError(res: Response): Promise<string> {
+		try {
+			const body = await res.clone().json();
+			return body?.message ?? body?.error ?? `Request failed (HTTP ${res.status})`;
+		} catch {
+			return `Request failed (HTTP ${res.status})`;
+		}
+	}
 
 	// Card search for add modal
 	let cardSearchQuery = $state('');
@@ -87,6 +97,7 @@
 	async function addToCollection() {
 		if (!selectedCard) return;
 		loading = true;
+		saveError = null;
 		try {
 			const res = await fetch('/api/collection', {
 				method: 'POST',
@@ -105,7 +116,11 @@
 				cardCache[selectedCard.id] = selectedCard;
 				closeAddModal();
 				await invalidateAll();
+			} else {
+				saveError = await readError(res);
 			}
+		} catch (err) {
+			saveError = err instanceof Error ? err.message : 'Network error';
 		} finally {
 			loading = false;
 		}
@@ -140,6 +155,7 @@
 		addPurchasePrice = '';
 		addPurchaseDate = '';
 		addNotes = '';
+		saveError = null;
 	}
 
 	function closeAddModal() {
@@ -434,6 +450,12 @@
 				>
 					{loading ? 'Adding...' : 'Add to Collection'}
 				</button>
+
+				{#if saveError}
+					<div class="rounded-lg border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent">
+						<span class="font-semibold">Couldn't save:</span> {saveError}
+					</div>
+				{/if}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- Add to Collection / Add to Watchlist on the card detail page and the Add Card modal on the collection page used to swallow all errors via \`try/finally\` with no \`catch\`. A POST that returned a non-OK status (e.g. Supabase RLS denial, validation error, network failure) silently reset the button and gave the user zero feedback.
- Both flows now read the server's error message from the response and display it in a styled alert below the form.

## Why this matters
Discovered while debugging a real symptom: \"add to collection on the live instance just does nothing\". The actual root cause was a Supabase RLS policy denying inserts — but the UI gave no signal. This fix means future server failures will be visible immediately.

## Test plan
- [x] Click \"Add to Collection\" on a card detail page with RLS still blocking → red alert appears with \"Couldn't save: new row violates row-level security policy for table 'collection'\"
- [x] Page renders cleanly with no console or server errors
- [ ] After RLS is fixed: the alert no longer appears and the card is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)