### PR TITLE
feat: password-gate the entire app (single-user auth)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Trove Environment Variables
 # Copy this file to .env.local and fill in your values
 
+# Auth (Required) — Trove is a single-user app gated by a password.
+# Pick any password you want. Pick any random string of 32+ chars for the secret.
+# Generate a secret with:  openssl rand -hex 32
+TROVE_PASSWORD=your-password-here
+TROVE_AUTH_SECRET=long-random-string-at-least-16-chars-but-32+-recommended
+
 # Supabase (Required)
 PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-key-here

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,6 +3,8 @@
 declare namespace App {
 	interface Locals {
 		supabase: import('@supabase/supabase-js').SupabaseClient;
+		authConfigured: boolean;
+		authenticated: boolean;
 	}
 
 	interface PageData {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,50 @@
+import type { Handle } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
+import {
+	isAuthConfigured,
+	verifySessionCookie,
+	SESSION_COOKIE_NAME
+} from '$lib/server/auth';
+
+// Paths that don't require an authenticated session.
+// Everything else (pages AND api routes) requires login.
+const PUBLIC_PATHS = new Set(['/login', '/logout']);
+
+function isPublicPath(pathname: string): boolean {
+	if (PUBLIC_PATHS.has(pathname)) return true;
+	// SvelteKit internals and static assets
+	if (pathname.startsWith('/_app/')) return true;
+	if (pathname === '/favicon.png' || pathname === '/favicon.ico') return true;
+	return false;
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	// If auth env vars aren't set, the gate is effectively off — let everything
+	// through and let the login page show a setup banner instead.
+	if (!isAuthConfigured()) {
+		event.locals.authConfigured = false;
+		event.locals.authenticated = false;
+		return resolve(event);
+	}
+
+	event.locals.authConfigured = true;
+
+	const cookie = event.cookies.get(SESSION_COOKIE_NAME);
+	const authenticated = verifySessionCookie(cookie);
+	event.locals.authenticated = authenticated;
+
+	if (authenticated || isPublicPath(event.url.pathname)) {
+		return resolve(event);
+	}
+
+	// Unauthenticated request to a protected route.
+	if (event.url.pathname.startsWith('/api/')) {
+		return new Response(JSON.stringify({ message: 'Unauthorized' }), {
+			status: 401,
+			headers: { 'content-type': 'application/json' }
+		});
+	}
+
+	const next = encodeURIComponent(event.url.pathname + event.url.search);
+	throw redirect(303, `/login?next=${next}`);
+};

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,0 +1,97 @@
+/**
+ * Trove auth — single-user, env-var password, signed-cookie session.
+ *
+ * Personal app, no user table. The "account" is whoever knows TROVE_PASSWORD.
+ * The session cookie is just a signed expiry timestamp — there is no userId
+ * because there is one user.
+ *
+ * To swap this out for real multi-user auth (Supabase Auth, Lucia, etc.):
+ *   1. Replace verifyPassword() with a DB lookup
+ *   2. Encode the userId into createSession() / verifySession()
+ *   3. Add /signup if you want self-serve registration
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { env } from '$env/dynamic/private';
+
+const COOKIE_NAME = 'trove_session';
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
+function getSecret(): string {
+	const secret = env.TROVE_AUTH_SECRET;
+	if (!secret || secret.length < 16) {
+		throw new Error(
+			'TROVE_AUTH_SECRET is not set or too short. Set it to a random string of at least 16 characters in .env.local and your hosting provider env vars.'
+		);
+	}
+	return secret;
+}
+
+function getPassword(): string | null {
+	const pw = env.TROVE_PASSWORD;
+	return pw && pw.length > 0 ? pw : null;
+}
+
+/** True when the app has been configured with a password. */
+export function isAuthConfigured(): boolean {
+	return !!env.TROVE_PASSWORD && !!env.TROVE_AUTH_SECRET;
+}
+
+/** Constant-time password comparison. */
+export function verifyPassword(candidate: string): boolean {
+	const expected = getPassword();
+	if (!expected) return false;
+	const a = Buffer.from(candidate);
+	const b = Buffer.from(expected);
+	if (a.length !== b.length) return false;
+	try {
+		return timingSafeEqual(a, b);
+	} catch {
+		return false;
+	}
+}
+
+function sign(payload: string): string {
+	const sig = createHmac('sha256', getSecret()).update(payload).digest('hex');
+	return `${payload}.${sig}`;
+}
+
+function unsign(signed: string): string | null {
+	const lastDot = signed.lastIndexOf('.');
+	if (lastDot < 0) return null;
+	const payload = signed.slice(0, lastDot);
+	const sig = signed.slice(lastDot + 1);
+	if (!payload || !sig) return null;
+	let expected: string;
+	try {
+		expected = createHmac('sha256', getSecret()).update(payload).digest('hex');
+	} catch {
+		return null;
+	}
+	if (sig.length !== expected.length) return null;
+	try {
+		const ok = timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'));
+		return ok ? payload : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Create a new signed-session cookie value. */
+export function createSessionCookie(): string {
+	const expiresAt = Date.now() + SESSION_TTL_MS;
+	return sign(String(expiresAt));
+}
+
+/** Returns true if the cookie value is a valid, unexpired session. */
+export function verifySessionCookie(value: string | undefined): boolean {
+	if (!value) return false;
+	const payload = unsign(value);
+	if (!payload) return false;
+	const expiresAt = Number(payload);
+	if (!Number.isFinite(expiresAt)) return false;
+	return expiresAt > Date.now();
+}
+
+export const SESSION_COOKIE_NAME = COOKIE_NAME;
+export const SESSION_TTL_SECONDS = Math.floor(SESSION_TTL_MS / 1000);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,6 +24,9 @@
 	let mobileMenuOpen = $state(false);
 	let globalSearch = $state('');
 
+	// /login uses its own standalone layout — skip the sidebar chrome there.
+	let isLoginPage = $derived($page.url.pathname === '/login');
+
 	function handleGlobalSearch(e: Event) {
 		e.preventDefault();
 		if (globalSearch.trim()) {
@@ -40,6 +43,9 @@
 	}
 </script>
 
+{#if isLoginPage}
+	{@render children()}
+{:else}
 <div class="flex h-screen overflow-hidden bg-vault-bg">
 	<!-- Sidebar (desktop) -->
 	<aside class="hidden w-64 flex-shrink-0 flex-col border-r border-vault-border bg-vault-surface lg:flex">
@@ -95,6 +101,17 @@
 				</svg>
 				Style Guide
 			</a>
+			<form method="POST" action="/logout" class="contents">
+				<button
+					type="submit"
+					class="mt-1 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium text-vault-text-muted transition-all duration-200 hover:bg-vault-surface-hover hover:text-white"
+				>
+					<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+					</svg>
+					Sign Out
+				</button>
+			</form>
 		</div>
 	</aside>
 
@@ -172,4 +189,5 @@
 			</nav>
 		</div>
 	</div>
+{/if}
 {/if}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,9 +4,10 @@ import { getCachedPricesForCards } from '$services/price-cache';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ setHeaders }) => {
-	// Dashboard is mostly static when collection is empty — cache at edge
+	// Per-user data — cache in the user's browser only, never share across users
+	// or via shared CDNs. (Dashboard reflects the logged-in user's collection.)
 	setHeaders({
-		'cache-control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=300'
+		'cache-control': 'private, max-age=60, stale-while-revalidate=300'
 	});
 
 	const [collectionRes, watchlistRes, gradingRes] = await Promise.all([

--- a/src/routes/api/cards/+server.ts
+++ b/src/routes/api/cards/+server.ts
@@ -25,7 +25,7 @@ export const GET: RequestHandler = async ({ url }) => {
 	try {
 		const result = await searchCards(query, page, pageSize);
 		return json(result, {
-			headers: { 'cache-control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600' }
+			headers: { 'cache-control': 'private, max-age=300, stale-while-revalidate=3600' }
 		});
 	} catch {
 		return json({ data: [], totalCount: 0, page, pageSize, count: 0 });

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -4,7 +4,7 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	// Sets list is stable — cache aggressively at the edge
 	setHeaders({
-		'cache-control': 'public, max-age=600, s-maxage=1800, stale-while-revalidate=3600'
+		'cache-control': 'private, max-age=600, stale-while-revalidate=3600'
 	});
 
 	const search = url.searchParams.get('q') ?? '';

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -10,9 +10,9 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 	const card = await getCard(params.id).catch(() => null);
 	if (!card) throw error(404, 'Card not found');
 
-	// Cache at the edge for 5 min, serve stale for 1 hour while revalidating
+	// Per-user (auth-gated) — cache in the user's browser only.
 	setHeaders({
-		'cache-control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600'
+		'cache-control': 'private, max-age=300, stale-while-revalidate=3600'
 	});
 
 	// Cache TCGPlayer prices to Supabase (fire-and-forget, once per day)

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,58 @@
+import { fail, redirect } from '@sveltejs/kit';
+import {
+	verifyPassword,
+	createSessionCookie,
+	isAuthConfigured,
+	verifySessionCookie,
+	SESSION_COOKIE_NAME,
+	SESSION_TTL_SECONDS
+} from '$lib/server/auth';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ url, cookies }) => {
+	// If already logged in, bounce to the dashboard (or to ?next=).
+	const authConfigured = isAuthConfigured();
+	if (authConfigured && verifySessionCookie(cookies.get(SESSION_COOKIE_NAME))) {
+		const next = url.searchParams.get('next') || '/';
+		throw redirect(303, next);
+	}
+	return {
+		authConfigured,
+		next: url.searchParams.get('next') ?? ''
+	};
+};
+
+export const actions: Actions = {
+	default: async ({ request, cookies, url }) => {
+		if (!isAuthConfigured()) {
+			return fail(503, {
+				error:
+					'Auth is not configured. Set TROVE_PASSWORD and TROVE_AUTH_SECRET in your environment.'
+			});
+		}
+
+		const data = await request.formData();
+		const password = String(data.get('password') ?? '');
+
+		if (!password) {
+			return fail(400, { error: 'Password is required.' });
+		}
+
+		if (!verifyPassword(password)) {
+			return fail(401, { error: 'Incorrect password.' });
+		}
+
+		cookies.set(SESSION_COOKIE_NAME, createSessionCookie(), {
+			path: '/',
+			httpOnly: true,
+			sameSite: 'lax',
+			secure: url.protocol === 'https:',
+			maxAge: SESSION_TTL_SECONDS
+		});
+
+		const next = (data.get('next') as string) || '/';
+		// Only allow same-origin redirects
+		const safeNext = next.startsWith('/') && !next.startsWith('//') ? next : '/';
+		throw redirect(303, safeNext);
+	}
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { ActionData, PageData } from './$types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	let submitting = $state(false);
+</script>
+
+<svelte:head>
+	<title>Sign in — Trove</title>
+</svelte:head>
+
+<div class="flex min-h-screen items-center justify-center bg-vault-bg px-4">
+	<div class="w-full max-w-sm space-y-6 rounded-2xl border border-vault-border bg-vault-surface p-8 shadow-2xl">
+		<div class="flex items-center gap-3">
+			<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-vault-accent to-vault-purple">
+				<svg class="h-6 w-6 text-white" viewBox="0 0 24 24" fill="currentColor">
+					<circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" />
+					<line x1="2" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="2" />
+					<circle cx="12" cy="12" r="3" fill="currentColor" />
+				</svg>
+			</div>
+			<div>
+				<h1 class="text-xl font-bold text-gradient">Trove</h1>
+				<p class="text-xs text-vault-text-muted">Sign in to continue</p>
+			</div>
+		</div>
+
+		{#if !data.authConfigured}
+			<div class="rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-xs text-yellow-200">
+				<p class="font-semibold">Auth not configured</p>
+				<p class="mt-1">
+					Set <code>TROVE_PASSWORD</code> and <code>TROVE_AUTH_SECRET</code> in your environment, then restart the server.
+				</p>
+			</div>
+		{/if}
+
+		<form
+			method="POST"
+			use:enhance={() => {
+				submitting = true;
+				return async ({ update }) => {
+					await update();
+					submitting = false;
+				};
+			}}
+			class="space-y-4"
+		>
+			<input type="hidden" name="next" value={data.next} />
+
+			<label class="block">
+				<span class="text-sm font-medium text-vault-text-muted">Password</span>
+				<input
+					type="password"
+					name="password"
+					autocomplete="current-password"
+					required
+					autofocus
+					class="mt-1 w-full rounded-xl border border-vault-border bg-vault-bg px-4 py-2.5 text-sm text-vault-text placeholder-vault-text-muted transition-all focus:border-vault-purple focus:outline-none focus:ring-1 focus:ring-vault-purple/50"
+				/>
+			</label>
+
+			{#if form?.error}
+				<div class="rounded-xl border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent">
+					{form.error}
+				</div>
+			{/if}
+
+			<button
+				type="submit"
+				disabled={submitting || !data.authConfigured}
+				class="btn-press w-full rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-4 py-2.5 text-sm font-medium text-white shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40 disabled:opacity-50"
+			>
+				{submitting ? 'Signing in…' : 'Sign in'}
+			</button>
+		</form>
+	</div>
+</div>

--- a/src/routes/logout/+server.ts
+++ b/src/routes/logout/+server.ts
@@ -1,0 +1,13 @@
+import { redirect } from '@sveltejs/kit';
+import { SESSION_COOKIE_NAME } from '$lib/server/auth';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ cookies }) => {
+	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
+	throw redirect(303, '/login');
+};
+
+export const GET: RequestHandler = async ({ cookies }) => {
+	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
+	throw redirect(303, '/login');
+};


### PR DESCRIPTION
## Summary
- Adds a hard auth gate so the live deployment isn't accessible to anyone who knows the URL.
- Single-user, password-from-env, signed-cookie session — no DB table, no Supabase Auth complexity. Easy to swap to multi-user later.
- **Bundled security fix**: switches every \`cache-control: public\` header in the app to \`private\`. Without this, the browser was serving previously-loaded pages and \`/api/cards\` responses from disk after sign-out, completely bypassing the gate.

## What you need to do after merging
1. Pick a password (anything you want).
2. In your local \`.env.local\`:
   \`\`\`
   TROVE_PASSWORD=your-password-here
   TROVE_AUTH_SECRET=run \"openssl rand -hex 32\" and paste the output
   \`\`\`
3. In Vercel → Project Settings → Environment Variables, add the same two for Production.
4. Redeploy.

If \`TROVE_PASSWORD\` or \`TROVE_AUTH_SECRET\` is missing, the gate is bypassed (fail-open) and the login page shows a setup banner — so you don't get locked out during initial setup.

## Architecture
- \`src/lib/server/auth.ts\` — HMAC-SHA256 signed-cookie helpers (constant-time compare, 30d TTL).
- \`src/hooks.server.ts\` — middleware. Redirects unauth'd pages to \`/login?next=<path>\`, returns JSON 401 for unauth'd \`/api/*\`.
- \`src/routes/login/\` — standalone login form.
- \`src/routes/logout/\` — POST or GET, clears cookie, redirects.
- \`+layout.svelte\` — sidebar chrome hidden on \`/login\`; Sign Out button in sidebar footer.

## Cache fix detail
Previously: \`/\`, \`/browse\`, \`/card/[id]\`, \`/api/cards\` all set \`cache-control: public, max-age=...\`. After sign-out the browser kept serving the cached responses. **Now all use \`private\`** — caches per-browser, never via shared CDNs, and the browser correctly re-validates after sign-out.

## Test plan
- [x] Unauthenticated GET / → 303 to /login?next=%2F
- [x] Wrong password → \"Incorrect password\" error, stays on /login
- [x] Right password → redirect to /, dashboard renders, sidebar visible
- [x] /api/health, /api/cards return 200 while authenticated
- [x] Sign out → /api/health and /api/cards return 401, /browse 303s to /login
- [x] After sign-out, navigating to /browse redirects to /login (cache-fix verified)
- [x] /login standalone layout (no sidebar leaking through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)