### PR TITLE
feat: browse sort dropdown + fix set selector dep loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ TROVE_AUTH_SECRET=long-random-string-at-least-16-chars-but-32+-recommended
 PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-key-here
 
+# Supabase service role key (Required ONLY for `npm run ingest:catalog`)
+# Service role bypasses RLS — never expose this in client code.
+# Find it under Supabase dashboard → Project Settings → API → service_role.
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
 # Pokémon TCG API (Optional — increases rate limit from 1000 to 20000 req/day)
 POKEMON_TCG_API_KEY=your-api-key-here
 

--- a/TROVE_PLAN.md
+++ b/TROVE_PLAN.md
@@ -37,14 +37,35 @@ Personal Pokémon TCG Collector Intelligence App
 | `/sets` | Set completion tracker (owned vs missing, cost to complete) | ✅ Full feature |
 | `/settings` | API connections, preferences, currency | ✅ Scaffolded |
 
-## Supabase Schema (defined in `supabase/migrations/001_initial_schema.sql`)
+## Supabase Schema
 
+| Migration | Tables | Purpose |
+|-----------|--------|---------|
+| `001_initial_schema.sql` | `collection`, `watchlist`, `grading`, `price_cache` | User-owned data |
+| `002_price_history.sql` | `price_history` | Daily price snapshots, one row per card/variant/day |
+| `003_card_catalog.sql` | `sets`, `cards` | Static card + set catalog (populated by `npm run ingest:catalog`) |
+
+### Card catalog ingest
+
+The `cards` and `sets` tables are populated by an idempotent ingest script
+that pages through the Pokémon TCG API and upserts everything. Once the
+catalog is populated, `/browse` and `/api/cards` read from Supabase directly
+instead of hitting api.pokemontcg.io on every page load. If the catalog is
+empty, the routes fall back to the live API automatically.
+
+```bash
+# Apply the migration via Supabase dashboard SQL editor (or CLI):
+#   supabase db push
+# Then ingest:
+npm run ingest:catalog                  # all sets
+npm run ingest:catalog -- --set base1   # one set
+npm run ingest:catalog -- --since 2024  # only sets released this year+
 ```
-collection  (id, card_id, quantity, condition, purchase_price, purchase_date, notes)
-watchlist   (id, card_id, target_price, alert_enabled)
-grading     (id, card_id, service, tier, status, submitted_date, returned_date, grade, cost, final_value)
-price_cache (id, card_id, source, raw_price, graded_prices, cached_at)
-```
+
+Requires `SUPABASE_SERVICE_ROLE_KEY` and (recommended) `POKEMON_TCG_API_KEY`
+in `.env.local`. Live pricing is intentionally NOT refreshed by this script
+— that runs on a separate schedule (TBD) so the catalog can be re-ingested
+without disturbing the live price snapshots.
 
 ## API Endpoints (in `src/routes/api/`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@sveltejs/adapter-vercel": "^5.0.0",
 				"@sveltejs/kit": "^2.0.0",
 				"@tailwindcss/vite": "^4.0.0",
+				"dotenv": "^17.4.2",
 				"eslint": "^9.0.0",
 				"eslint-config-prettier": "^9.0.0",
 				"eslint-plugin-svelte": "^2.30.0",
@@ -23,6 +24,7 @@
 				"svelte": "^5.0.0",
 				"svelte-check": "^4.0.0",
 				"tailwindcss": "^4.0.0",
+				"tsx": "^4.21.0",
 				"typescript": "^5.0.0"
 			}
 		},
@@ -58,6 +60,448 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -2110,6 +2554,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dotenv": {
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2136,6 +2593,48 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2519,9 +3018,21 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.7",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+			"integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/glob": {
@@ -3629,6 +4140,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-rc.11",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
@@ -4094,6 +4615,26 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"ingest:catalog": "tsx scripts/ingest-catalog.ts"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-vercel": "^5.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@tailwindcss/vite": "^4.0.0",
+		"dotenv": "^17.4.2",
 		"eslint": "^9.0.0",
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-svelte": "^2.30.0",
@@ -23,6 +25,7 @@
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"tailwindcss": "^4.0.0",
+		"tsx": "^4.21.0",
 		"typescript": "^5.0.0"
 	},
 	"type": "module",

--- a/scripts/ingest-catalog.ts
+++ b/scripts/ingest-catalog.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * Trove catalog ingest
+ *
+ * Pages through the Pokémon TCG API and upserts every set + every card into
+ * the local Supabase catalog. Idempotent — safe to re-run when new sets drop
+ * or when you want to refresh price snapshots embedded on each card.
+ *
+ * Run with:
+ *   npm run ingest:catalog                    # all sets
+ *   npm run ingest:catalog -- --set base1     # one set
+ *   npm run ingest:catalog -- --since 2024    # only sets released this year+
+ *
+ * Env required:
+ *   PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY     (NOT the publishable key — needs RLS bypass)
+ *   POKEMON_TCG_API_KEY           (optional but recommended; raises rate limit
+ *                                  from 1k/day to 20k/day)
+ *
+ * The script writes via the admin client and never touches anything the
+ * frontend reads, so you can run it against production safely.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+
+const TCG_BASE = 'https://api.pokemontcg.io/v2';
+const TCG_PAGE_SIZE = 250; // API max
+
+const SUPABASE_URL = process.env.PUBLIC_SUPABASE_URL ?? '';
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const TCG_KEY = process.env.POKEMON_TCG_API_KEY ?? '';
+
+if (!SUPABASE_URL || !SERVICE_ROLE) {
+	console.error(
+		'Missing required env. Set PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local.'
+	);
+	process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE, {
+	auth: { persistSession: false, autoRefreshToken: false }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TCG API client
+// ─────────────────────────────────────────────────────────────────────────────
+
+function tcgHeaders(): Record<string, string> {
+	return TCG_KEY
+		? { 'Content-Type': 'application/json', 'X-Api-Key': TCG_KEY }
+		: { 'Content-Type': 'application/json' };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+	for (let attempt = 0; attempt < 3; attempt++) {
+		try {
+			const res = await fetch(url, { headers: tcgHeaders() });
+			if (res.status === 429) {
+				const wait = 2000 * (attempt + 1);
+				console.warn(`  rate-limited, waiting ${wait}ms…`);
+				await sleep(wait);
+				continue;
+			}
+			if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${url}`);
+			return (await res.json()) as T;
+		} catch (err) {
+			if (attempt === 2) throw err;
+			console.warn(`  fetch failed (${(err as Error).message}), retrying…`);
+			await sleep(1500);
+		}
+	}
+	throw new Error('unreachable');
+}
+
+function sleep(ms: number) {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Set ingest
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RawSet {
+	id: string;
+	name: string;
+	series?: string;
+	printedTotal?: number;
+	total?: number;
+	releaseDate?: string;
+	images?: { symbol?: string; logo?: string };
+}
+
+async function fetchAllSets(): Promise<RawSet[]> {
+	const res = await fetchJson<{ data: RawSet[] }>(`${TCG_BASE}/sets?orderBy=-releaseDate`);
+	return res.data;
+}
+
+async function upsertSets(sets: RawSet[]): Promise<void> {
+	if (sets.length === 0) return;
+	const rows = sets.map((s) => ({
+		id: s.id,
+		name: s.name,
+		series: s.series ?? null,
+		printed_total: s.printedTotal ?? null,
+		total: s.total ?? null,
+		// TCG API release dates use "YYYY/MM/DD" — normalize to ISO.
+		release_date: s.releaseDate ? s.releaseDate.replace(/\//g, '-') : null,
+		symbol_url: s.images?.symbol ?? null,
+		logo_url: s.images?.logo ?? null,
+		ingested_at: new Date().toISOString()
+	}));
+
+	const { error } = await supabase.from('sets').upsert(rows, { onConflict: 'id' });
+	if (error) throw new Error(`set upsert failed: ${error.message}`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Card ingest
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RawCard {
+	id: string;
+	name: string;
+	supertype?: string;
+	subtypes?: string[];
+	hp?: string;
+	types?: string[];
+	number: string;
+	artist?: string;
+	rarity?: string;
+	nationalPokedexNumbers?: number[];
+	images?: { small?: string; large?: string };
+	attacks?: unknown;
+	weaknesses?: unknown;
+	resistances?: unknown;
+	retreatCost?: string[];
+	set?: { id: string };
+	tcgplayer?: { url?: string; updatedAt?: string; prices?: unknown };
+	cardmarket?: { url?: string; updatedAt?: string; prices?: unknown };
+}
+
+function cardToRow(c: RawCard) {
+	return {
+		id: c.id,
+		set_id: c.set?.id ?? null,
+		name: c.name,
+		supertype: c.supertype ?? null,
+		subtypes: c.subtypes ?? null,
+		hp: c.hp ?? null,
+		types: c.types ?? null,
+		number: c.number,
+		artist: c.artist ?? null,
+		rarity: c.rarity ?? null,
+		national_pokedex_numbers: c.nationalPokedexNumbers ?? null,
+		image_small: c.images?.small ?? null,
+		image_large: c.images?.large ?? null,
+		attacks: c.attacks ?? null,
+		weaknesses: c.weaknesses ?? null,
+		resistances: c.resistances ?? null,
+		retreat_cost: c.retreatCost ?? null,
+		tcgplayer_url: c.tcgplayer?.url ?? null,
+		tcgplayer_prices: c.tcgplayer?.prices ?? null,
+		// updatedAt comes through as a YYYY/MM/DD string — leave null if absent
+		// rather than poisoning the timestamptz column with an invalid value.
+		tcgplayer_updated_at: c.tcgplayer?.updatedAt
+			? new Date(c.tcgplayer.updatedAt.replace(/\//g, '-')).toISOString()
+			: null,
+		cardmarket_url: c.cardmarket?.url ?? null,
+		cardmarket_prices: c.cardmarket?.prices ?? null,
+		cardmarket_updated_at: c.cardmarket?.updatedAt
+			? new Date(c.cardmarket.updatedAt.replace(/\//g, '-')).toISOString()
+			: null,
+		ingested_at: new Date().toISOString()
+	};
+}
+
+async function ingestSet(setId: string, setName: string): Promise<number> {
+	let page = 1;
+	let total = 0;
+	while (true) {
+		const url = `${TCG_BASE}/cards?q=set.id:${setId}&page=${page}&pageSize=${TCG_PAGE_SIZE}&orderBy=number`;
+		const res = await fetchJson<{ data: RawCard[]; totalCount: number; count: number }>(url);
+		if (res.data.length === 0) break;
+
+		const rows = res.data.map(cardToRow);
+		const { error } = await supabase.from('cards').upsert(rows, { onConflict: 'id' });
+		if (error) {
+			throw new Error(`[${setId}] card upsert failed on page ${page}: ${error.message}`);
+		}
+
+		total += rows.length;
+		process.stdout.write(
+			`  ${setName} (${setId}): ${total}/${res.totalCount}\r`
+		);
+
+		if (total >= res.totalCount) break;
+		page++;
+		// Polite to the free TCG API even with a key.
+		await sleep(150);
+	}
+	process.stdout.write('\n');
+	return total;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			set: { type: 'string' },
+			since: { type: 'string' },
+			help: { type: 'boolean', short: 'h' }
+		}
+	});
+
+	if (values.help) {
+		console.log(`Trove catalog ingest
+
+Usage:
+  npm run ingest:catalog
+  npm run ingest:catalog -- --set base1
+  npm run ingest:catalog -- --since 2024
+
+Options:
+  --set <id>      Ingest only the given set
+  --since <year>  Only ingest sets released on/after this year
+  -h, --help      Show this help`);
+		process.exit(0);
+	}
+
+	console.log('▸ fetching set list from TCG API…');
+	let sets = await fetchAllSets();
+	console.log(`  ${sets.length} sets total`);
+
+	if (values.set) {
+		sets = sets.filter((s) => s.id === values.set);
+		if (sets.length === 0) {
+			console.error(`No set found with id "${values.set}"`);
+			process.exit(1);
+		}
+	} else if (values.since) {
+		const cutoff = `${values.since}-01-01`;
+		sets = sets.filter((s) => (s.releaseDate ?? '').replace(/\//g, '-') >= cutoff);
+		console.log(`  filtered to ${sets.length} sets released since ${cutoff}`);
+	}
+
+	console.log('▸ upserting sets…');
+	await upsertSets(sets);
+
+	console.log(`▸ ingesting cards from ${sets.length} set(s)…`);
+	let totalCards = 0;
+	const startedAt = Date.now();
+	for (let i = 0; i < sets.length; i++) {
+		const s = sets[i];
+		const prefix = `[${i + 1}/${sets.length}]`;
+		console.log(`${prefix} ${s.name}`);
+		try {
+			totalCards += await ingestSet(s.id, s.name);
+		} catch (err) {
+			console.error(`  failed: ${(err as Error).message}`);
+		}
+	}
+
+	const seconds = Math.round((Date.now() - startedAt) / 1000);
+	console.log(`\n✓ done — ${totalCards.toLocaleString()} cards in ${seconds}s`);
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/src/lib/components/CardThumbnail.svelte
+++ b/src/lib/components/CardThumbnail.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
 	import type { PokemonCard } from '$types';
+	import { getHeadlinePrice } from '$services/card-price';
 
 	interface Props {
 		card: PokemonCard;
 		showPrice?: boolean;
+		/** Optional override badge (e.g. "Spread $4.20"). When set, replaces the price chip. */
+		badgeLabel?: string | null;
 	}
 
-	let { card, showPrice = false }: Props = $props();
+	let { card, showPrice = false, badgeLabel = null }: Props = $props();
+
+	const headline = $derived(getHeadlinePrice(card));
 </script>
 
 <a href="/card/{card.id}" class="card-glow group relative overflow-hidden rounded-2xl border border-vault-border bg-vault-surface transition-all duration-300 hover:border-vault-purple/40 hover:-translate-y-1">
@@ -19,13 +24,14 @@
 		/>
 	</div>
 
-	{#if showPrice && card.tcgplayer?.prices}
-		{@const firstPrice = Object.values(card.tcgplayer.prices)[0]}
-		{#if firstPrice?.market}
-			<div class="absolute right-2 top-2 rounded-full bg-vault-bg/90 px-2.5 py-1 text-xs font-bold text-vault-green shadow-lg backdrop-blur-sm">
-				${firstPrice.market.toFixed(2)}
-			</div>
-		{/if}
+	{#if badgeLabel}
+		<div class="absolute right-2 top-2 rounded-full bg-vault-bg/90 px-2.5 py-1 text-xs font-bold text-vault-gold shadow-lg backdrop-blur-sm">
+			{badgeLabel}
+		</div>
+	{:else if showPrice && headline != null}
+		<div class="absolute right-2 top-2 rounded-full bg-vault-bg/90 px-2.5 py-1 text-xs font-bold text-vault-green shadow-lg backdrop-blur-sm">
+			${headline.toFixed(2)}
+		</div>
 	{/if}
 
 	<div class="p-3">

--- a/src/lib/server/catalog.ts
+++ b/src/lib/server/catalog.ts
@@ -1,0 +1,210 @@
+/**
+ * Local catalog reads. Source of truth for static card/set data once ingest
+ * has run. Returns the same shape as `$services/tcg-api`'s search responses
+ * so the API route can swap between catalog and live API without callers
+ * noticing.
+ *
+ * Falls back to nothing — if the catalog is empty, callers should themselves
+ * fall back to the TCG API. We don't want the route handler doing two
+ * different things based on row count; that decision lives in one place.
+ */
+import type { PaginatedResponse, PokemonCard, CardSet } from '$types';
+import { getSupabaseAdmin } from './supabase-admin';
+
+interface CardRow {
+	id: string;
+	set_id: string | null;
+	name: string;
+	supertype: string | null;
+	subtypes: string[] | null;
+	hp: string | null;
+	types: string[] | null;
+	number: string;
+	artist: string | null;
+	rarity: string | null;
+	national_pokedex_numbers: number[] | null;
+	image_small: string | null;
+	image_large: string | null;
+	attacks: unknown;
+	weaknesses: unknown;
+	resistances: unknown;
+	retreat_cost: string[] | null;
+	tcgplayer_url: string | null;
+	tcgplayer_prices: Record<string, unknown> | null;
+	tcgplayer_updated_at: string | null;
+	cardmarket_url: string | null;
+	cardmarket_prices: Record<string, unknown> | null;
+	cardmarket_updated_at: string | null;
+}
+
+interface SetRow {
+	id: string;
+	name: string;
+	series: string | null;
+	printed_total: number | null;
+	total: number | null;
+	release_date: string | null;
+	symbol_url: string | null;
+	logo_url: string | null;
+}
+
+function rowToSet(row: SetRow): CardSet {
+	return {
+		id: row.id,
+		name: row.name,
+		series: row.series ?? '',
+		printedTotal: row.printed_total ?? 0,
+		total: row.total ?? 0,
+		releaseDate: row.release_date ?? '',
+		images: {
+			symbol: row.symbol_url ?? '',
+			logo: row.logo_url ?? ''
+		}
+	};
+}
+
+function rowToCard(row: CardRow, set: CardSet | null): PokemonCard {
+	return {
+		id: row.id,
+		name: row.name,
+		supertype: row.supertype ?? '',
+		subtypes: row.subtypes ?? undefined,
+		hp: row.hp ?? undefined,
+		types: row.types ?? undefined,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		attacks: (row.attacks as any) ?? undefined,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		weaknesses: (row.weaknesses as any) ?? undefined,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		resistances: (row.resistances as any) ?? undefined,
+		retreatCost: row.retreat_cost ?? undefined,
+		set: set ?? {
+			id: row.set_id ?? '',
+			name: '',
+			series: '',
+			printedTotal: 0,
+			total: 0,
+			releaseDate: '',
+			images: { symbol: '', logo: '' }
+		},
+		number: row.number,
+		artist: row.artist ?? undefined,
+		rarity: row.rarity ?? undefined,
+		nationalPokedexNumbers: row.national_pokedex_numbers ?? undefined,
+		images: {
+			small: row.image_small ?? '',
+			large: row.image_large ?? ''
+		},
+		tcgplayer: row.tcgplayer_url
+			? {
+					url: row.tcgplayer_url,
+					updatedAt: row.tcgplayer_updated_at ?? '',
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					prices: (row.tcgplayer_prices as any) ?? undefined
+				}
+			: undefined,
+		cardmarket: row.cardmarket_url
+			? {
+					url: row.cardmarket_url,
+					updatedAt: row.cardmarket_updated_at ?? '',
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					prices: (row.cardmarket_prices as any) ?? undefined
+				}
+			: undefined
+	};
+}
+
+/**
+ * Returns true if the catalog has been populated. Used by callers to decide
+ * whether to read locally or fall back to the live TCG API. Result is
+ * cached for the lifetime of the process — if you just ran ingest, restart
+ * the server.
+ */
+let catalogReadyCache: boolean | null = null;
+export async function isCatalogReady(): Promise<boolean> {
+	if (catalogReadyCache !== null) return catalogReadyCache;
+	try {
+		const admin = getSupabaseAdmin();
+		const { count, error } = await admin
+			.from('cards')
+			.select('id', { head: true, count: 'exact' });
+		if (error) return (catalogReadyCache = false);
+		catalogReadyCache = (count ?? 0) > 0;
+		return catalogReadyCache;
+	} catch {
+		return (catalogReadyCache = false);
+	}
+}
+
+export async function getAllSets(): Promise<CardSet[]> {
+	const admin = getSupabaseAdmin();
+	const { data, error } = await admin
+		.from('sets')
+		.select('*')
+		.order('release_date', { ascending: false });
+	if (error || !data) return [];
+	return (data as SetRow[]).map(rowToSet);
+}
+
+export interface CatalogSearchOptions {
+	name?: string;
+	setId?: string;
+	type?: string;
+	rarity?: string;
+	page: number;
+	pageSize: number;
+}
+
+/**
+ * Catalog-backed equivalent of `searchCards` from `$services/tcg-api`.
+ * Mirrors the shape: same query semantics where possible, same response
+ * envelope. Sorts by set release date desc, then card number ascending —
+ * matching the TCG API default order.
+ */
+export async function searchCatalog(
+	opts: CatalogSearchOptions
+): Promise<PaginatedResponse<PokemonCard>> {
+	const admin = getSupabaseAdmin();
+
+	let query = admin
+		.from('cards')
+		.select('*, set:sets(*)', { count: 'exact' });
+
+	if (opts.name) query = query.ilike('name', `${opts.name}%`);
+	if (opts.setId) query = query.eq('set_id', opts.setId);
+	if (opts.rarity) query = query.eq('rarity', opts.rarity);
+	if (opts.type) query = query.contains('types', [opts.type]);
+
+	const from = (opts.page - 1) * opts.pageSize;
+	const to = from + opts.pageSize - 1;
+
+	// Order: newest sets first, then by card number within the set.
+	query = query
+		.order('release_date', {
+			ascending: false,
+			referencedTable: 'sets',
+			nullsFirst: false
+		})
+		.order('number')
+		.range(from, to);
+
+	const { data, count, error } = await query;
+	if (error) {
+		console.error('[catalog] searchCatalog error:', error.message);
+		return { data: [], page: opts.page, pageSize: opts.pageSize, count: 0, totalCount: 0 };
+	}
+
+	const cards = (data ?? []).map((row) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const set = (row as any).set as SetRow | null;
+		return rowToCard(row as CardRow, set ? rowToSet(set) : null);
+	});
+
+	return {
+		data: cards,
+		page: opts.page,
+		pageSize: opts.pageSize,
+		count: cards.length,
+		totalCount: count ?? cards.length
+	};
+}

--- a/src/lib/server/supabase-admin.ts
+++ b/src/lib/server/supabase-admin.ts
@@ -1,0 +1,36 @@
+/**
+ * Server-only Supabase client using the service role key. Bypasses RLS, so
+ * it must NEVER be imported from anywhere that ships to the browser. The
+ * `$lib/server` path is enforced by SvelteKit at build time — importing this
+ * from a `+page.svelte` will fail the build, which is exactly what we want.
+ *
+ * Used by:
+ *   - The catalog ingest script (writes to `cards` / `sets`)
+ *   - Server-side route handlers that need to read/write trusted data
+ *
+ * For browser-facing reads, use the publishable client from
+ * `$services/supabase` instead.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '$env/dynamic/private';
+
+let cached: SupabaseClient | null = null;
+
+export function getSupabaseAdmin(): SupabaseClient {
+	if (cached) return cached;
+
+	const url = env.PUBLIC_SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
+	const serviceRoleKey =
+		env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+
+	if (!url || !serviceRoleKey) {
+		throw new Error(
+			'Supabase admin client requires PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in your environment.'
+		);
+	}
+
+	cached = createClient(url, serviceRoleKey, {
+		auth: { persistSession: false, autoRefreshToken: false }
+	});
+	return cached;
+}

--- a/src/lib/services/card-price.ts
+++ b/src/lib/services/card-price.ts
@@ -1,0 +1,80 @@
+import type { PokemonCard } from '$types';
+
+/**
+ * Pure helpers for deriving sort/filter values from a card's TCGPlayer price
+ * block. Cards expose multiple printings (normal / holofoil / reverseHolofoil
+ * / 1stEditionHolofoil / etc.), each with its own low/mid/high/market values,
+ * so every helper has to reduce that map down to a single comparable number.
+ */
+
+export interface PrintingPrice {
+	printing: string;
+	market: number | null;
+	low: number | null;
+	mid: number | null;
+	high: number | null;
+}
+
+export function getPrintings(card: PokemonCard): PrintingPrice[] {
+	const prices = card.tcgplayer?.prices;
+	if (!prices) return [];
+	return Object.entries(prices).map(([printing, p]) => ({
+		printing,
+		market: p?.market ?? null,
+		low: p?.low ?? null,
+		mid: p?.mid ?? null,
+		high: p?.high ?? null
+	}));
+}
+
+/**
+ * Headline price = highest market across all printings. A card's "what is
+ * this thing worth" number for the purposes of sorting and badges. We pick
+ * the max so a $50 holo doesn't hide behind a $0.25 reverse.
+ */
+export function getHeadlinePrice(card: PokemonCard): number | null {
+	const markets = getPrintings(card)
+		.map((p) => p.market)
+		.filter((v): v is number => v != null);
+	if (markets.length === 0) return null;
+	return Math.max(...markets);
+}
+
+/** Highest-market printing — used to compute spread on the printing that matters. */
+export function getHeadlinePrinting(card: PokemonCard): PrintingPrice | null {
+	const prints = getPrintings(card);
+	let best: PrintingPrice | null = null;
+	for (const p of prints) {
+		if (p.market == null) continue;
+		if (!best || p.market > (best.market ?? -Infinity)) best = p;
+	}
+	return best;
+}
+
+/**
+ * Spread within the headline printing: how much room there is between the
+ * lowest current listing and the recent market price. Positive = the cheapest
+ * available copy is below market, i.e. a flip opportunity.
+ *
+ * We deliberately use `market - low` instead of `high - low`. TCGPlayer's
+ * `high` field is polluted with absurd outlier listings ($9999 "if-you're-
+ * desperate" prices), which made the high-low spread useless as a signal.
+ */
+export function getPrintingSpread(card: PokemonCard): number | null {
+	const best = getHeadlinePrinting(card);
+	if (!best || best.market == null || best.low == null) return null;
+	return best.market - best.low;
+}
+
+/** Spread as a percentage of the low — flat dollar spread is misleading on cheap cards. */
+export function getPrintingSpreadPct(card: PokemonCard): number | null {
+	const best = getHeadlinePrinting(card);
+	if (!best || best.market == null || best.low == null || best.low <= 0) return null;
+	return (best.market - best.low) / best.low;
+}
+
+/** Parse the leading integer out of a card number string like "25", "150a", "TG01", "SWSH001". */
+export function parseCardNumber(num: string): number {
+	const match = num.match(/\d+/);
+	return match ? parseInt(match[0], 10) : 9999;
+}

--- a/src/lib/services/card-sort.ts
+++ b/src/lib/services/card-sort.ts
@@ -1,0 +1,83 @@
+import type { PokemonCard } from '$types';
+import {
+	getHeadlinePrice,
+	getPrintingSpread,
+	getPrintingSpreadPct,
+	parseCardNumber
+} from './card-price';
+
+export type SortMode =
+	| 'default'
+	| 'price-asc'
+	| 'price-desc'
+	| 'spread-desc'
+	| 'bulk';
+
+export interface SortOption {
+	id: SortMode;
+	label: string;
+	hint: string;
+}
+
+export const SORT_OPTIONS: SortOption[] = [
+	{ id: 'default', label: 'Set Order', hint: 'By card number' },
+	{ id: 'price-desc', label: 'Price: High → Low', hint: 'Most expensive first' },
+	{ id: 'price-asc', label: 'Price: Low → High', hint: 'Cheapest first' },
+	{ id: 'spread-desc', label: 'Biggest Spread', hint: 'Widest low→high range, flip targets' },
+	{ id: 'bulk', label: 'Bulk Hunt (under $1)', hint: 'Cheap pickups, ascending' }
+];
+
+/**
+ * Apply a sort mode to a list of cards. All sorts are pure and operate on
+ * a copy. Some modes (bulk, spread) also filter — cards that lack the
+ * required price data are dropped so the result list isn't padded with
+ * meaningless rows.
+ */
+export function sortCards(cards: PokemonCard[], mode: SortMode): PokemonCard[] {
+	const arr = [...cards];
+
+	switch (mode) {
+		case 'default':
+			return arr.sort(
+				(a, b) => parseCardNumber(a.number) - parseCardNumber(b.number)
+			);
+
+		case 'price-desc':
+			return arr
+				.filter((c) => getHeadlinePrice(c) != null)
+				.sort((a, b) => getHeadlinePrice(b)! - getHeadlinePrice(a)!);
+
+		case 'price-asc':
+			return arr
+				.filter((c) => getHeadlinePrice(c) != null)
+				.sort((a, b) => getHeadlinePrice(a)! - getHeadlinePrice(b)!);
+
+		case 'spread-desc':
+			return arr
+				.filter((c) => {
+					const s = getPrintingSpread(c);
+					// Require a meaningful absolute spread so $0.04→$0.12 cards don't
+					// dominate. The percent helper guards against div-by-zero too.
+					return s != null && s > 0.5 && getPrintingSpreadPct(c) != null;
+				})
+				.sort((a, b) => getPrintingSpread(b)! - getPrintingSpread(a)!);
+
+		case 'bulk':
+			return arr
+				.filter((c) => {
+					const p = getHeadlinePrice(c);
+					return p != null && p < 1;
+				})
+				.sort((a, b) => getHeadlinePrice(a)! - getHeadlinePrice(b)!);
+	}
+}
+
+/**
+ * For a given sort mode, return the secondary number to render as a chip on
+ * the card thumbnail (e.g. spread for spread-desc). null = use the default
+ * headline price badge.
+ */
+export function getSortBadgeValue(card: PokemonCard, mode: SortMode): number | null {
+	if (mode === 'spread-desc') return getPrintingSpread(card);
+	return null;
+}

--- a/src/routes/api/cards/+server.ts
+++ b/src/routes/api/cards/+server.ts
@@ -1,13 +1,52 @@
 import { json } from '@sveltejs/kit';
 import { searchCards, getSets } from '$services/tcg-api';
+import {
+	isCatalogReady,
+	searchCatalog,
+	getAllSets as getCatalogSets
+} from '$lib/server/catalog';
 import type { RequestHandler } from './$types';
 
+/**
+ * Card search endpoint used by the browse page's client-side fetcher.
+ *
+ * Reads from the local Supabase catalog when it's been populated (via
+ * `npm run ingest:catalog`), and falls back to the live TCG API otherwise.
+ * The fallback keeps the app working in environments that haven't run the
+ * ingest yet — e.g. fresh deployments or the dev branch before migration.
+ *
+ * Accepts the same query syntax as the TCG API (`name:"foo*"`, `set.id:base1`,
+ * etc.) so old saved URLs keep working. We parse the query into structured
+ * filters before handing it to the catalog reader.
+ */
 export const GET: RequestHandler = async ({ url }) => {
-	let query = url.searchParams.get('q');
+	const rawQuery = url.searchParams.get('q') ?? '';
 	const page = parseInt(url.searchParams.get('page') ?? '1');
 	const pageSize = parseInt(url.searchParams.get('pageSize') ?? '24');
 
-	// When no query is supplied, default to the latest set (sorted by release date).
+	const useCatalog = await isCatalogReady();
+
+	if (useCatalog) {
+		const filters = parseQuery(rawQuery);
+		// No filters at all → default to the latest set, same behavior as before.
+		if (!filters.name && !filters.setId && !filters.type && !filters.rarity) {
+			const sets = await getCatalogSets();
+			const latest = sets[0];
+			if (latest) filters.setId = latest.id;
+		}
+		try {
+			const result = await searchCatalog({ ...filters, page, pageSize });
+			return json(result, {
+				headers: { 'cache-control': 'private, max-age=300, stale-while-revalidate=3600' }
+			});
+		} catch (err) {
+			console.error('[api/cards] catalog read failed, falling through:', err);
+			// fall through to live API
+		}
+	}
+
+	// Live TCG API path (catalog empty or errored)
+	let query = rawQuery;
 	if (!query) {
 		try {
 			const sets = await getSets();
@@ -31,3 +70,33 @@ export const GET: RequestHandler = async ({ url }) => {
 		return json({ data: [], totalCount: 0, page, pageSize, count: 0 });
 	}
 };
+
+/**
+ * Parse the TCG-API-style query string back into structured filters.
+ * Supports the four predicates the browse page actually emits:
+ *   name:"foo*", set.id:bar, types:Fire, rarity:"Rare Holo"
+ * Any predicate it doesn't recognize is dropped — the catalog reader will
+ * just ignore it and the user sees a wider result set than expected, which
+ * is preferable to silently returning nothing.
+ */
+function parseQuery(q: string): {
+	name?: string;
+	setId?: string;
+	type?: string;
+	rarity?: string;
+} {
+	const out: { name?: string; setId?: string; type?: string; rarity?: string } = {};
+	if (!q) return out;
+	// Match: key:"quoted value" OR key:bareword
+	const re = /([\w.]+):(?:"([^"]+)"|(\S+))/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(q)) !== null) {
+		const key = m[1];
+		const value = (m[2] ?? m[3] ?? '').replace(/\*$/, '');
+		if (key === 'name') out.name = value;
+		else if (key === 'set.id') out.setId = value;
+		else if (key === 'types') out.type = value;
+		else if (key === 'rarity') out.rarity = value;
+	}
+	return out;
+}

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -1,4 +1,5 @@
 import { getSets } from '$services/tcg-api';
+import { isCatalogReady, getAllSets as getCatalogSets } from '$lib/server/catalog';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url, setHeaders }) => {
@@ -13,9 +14,15 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	const rarity = url.searchParams.get('rarity') ?? '';
 	const sort = url.searchParams.get('sort') ?? '';
 
-	// Only load sets on the server (fast, cacheable).
-	// Card search happens client-side via /api/cards to avoid Vercel 10s timeout.
-	const sets = await getSets().catch(() => []);
+	// Prefer the local catalog (instant, no rate limit). Fall back to the live
+	// TCG API for environments that haven't run `npm run ingest:catalog` yet.
+	let sets: Awaited<ReturnType<typeof getSets>> = [];
+	if (await isCatalogReady()) {
+		sets = await getCatalogSets().catch(() => []);
+	}
+	if (sets.length === 0) {
+		sets = await getSets().catch(() => []);
+	}
 
 	return {
 		sets,

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -11,6 +11,7 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	const set = url.searchParams.get('set') ?? '';
 	const type = url.searchParams.get('type') ?? '';
 	const rarity = url.searchParams.get('rarity') ?? '';
+	const sort = url.searchParams.get('sort') ?? '';
 
 	// Only load sets on the server (fast, cacheable).
 	// Card search happens client-side via /api/cards to avoid Vercel 10s timeout.
@@ -18,6 +19,6 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 
 	return {
 		sets,
-		filters: { search, set, type, rarity }
+		filters: { search, set, type, rarity, sort }
 	};
 };

--- a/src/routes/browse/+page.svelte
+++ b/src/routes/browse/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
 	import { CardThumbnail } from '$components';
-	import type { PokemonCard, CardSet } from '$types';
+	import { sortCards, getSortBadgeValue, SORT_OPTIONS, type SortMode } from '$services/card-sort';
+	import type { PokemonCard } from '$types';
 
 	let { data } = $props();
 
@@ -18,33 +19,52 @@
 	let selectedSet = $state('');
 	let selectedType = $state('');
 	let selectedRarity = $state('');
+	let sortMode = $state<SortMode>('default');
 
-	const PAGE_SIZE = 24;
+	const DEFAULT_PAGE_SIZE = 24;
+	// When a non-default sort is active we need the whole filter result set in
+	// memory to reorder it client-side. 250 is the TCG API max page size and
+	// fits a typical set in a single round trip.
+	const SORT_PAGE_SIZE = 250;
 
 	let sets = $derived(data.sets);
-	let hasMore = $derived(cards.length < totalCount);
+	let isSorting = $derived(sortMode !== 'default');
+	let pageSize = $derived(isSorting ? SORT_PAGE_SIZE : DEFAULT_PAGE_SIZE);
+	// Infinite scroll only makes sense for the unsorted, paginated default mode.
+	let hasMore = $derived(!isSorting && cards.length < totalCount);
 
-	// Build query string from current filters. Default to the latest set (first in
-	// the server-loaded list, which is sorted by -releaseDate).
-	function buildQuery(): string {
+	// Apply current sort over already-fetched cards.
+	let displayedCards = $derived(sortCards(cards, sortMode));
+
+	// Build a TCG API query string from a filter snapshot. We accept the filter
+	// values as arguments instead of reading reactive state directly so the
+	// caller controls dependency tracking (the load effect builds from URL
+	// state, not from the local bound inputs, to avoid a re-render feedback
+	// loop where syncing local state retriggers the effect).
+	function buildQuery(
+		search: string,
+		set: string,
+		type: string,
+		rarity: string
+	): string {
 		const parts: string[] = [];
-		if (searchInput) parts.push(`name:"${searchInput}*"`);
-		if (selectedSet) parts.push(`set.id:${selectedSet}`);
-		if (selectedType) parts.push(`types:${selectedType}`);
-		if (selectedRarity) parts.push(`rarity:"${selectedRarity}"`);
+		if (search) parts.push(`name:"${search}*"`);
+		if (set) parts.push(`set.id:${set}`);
+		if (type) parts.push(`types:${type}`);
+		if (rarity) parts.push(`rarity:"${rarity}"`);
 		if (parts.length > 0) return parts.join(' ');
 		const latestSetId = sets[0]?.id;
 		return latestSetId ? `set.id:${latestSetId}` : '';
 	}
 
 	// Fetch cards from client-side API
-	async function fetchCards(query: string, pg: number, append = false) {
+	async function fetchCards(query: string, pg: number, size: number, append = false) {
 		loading = true;
 		try {
 			const params = new URLSearchParams({
 				q: query,
 				page: String(pg),
-				pageSize: String(PAGE_SIZE)
+				pageSize: String(size)
 			});
 			const res = await fetch(`/api/cards?${params}`);
 			if (!res.ok) throw new Error('Failed to load cards');
@@ -69,18 +89,30 @@
 		}
 	}
 
-	// Load initial cards + react to filter changes from URL
+	// Load cards whenever the URL filter state changes. This effect intentionally
+	// only depends on `data.filters.*` (the URL-driven state). Local bound input
+	// state is updated via untrack() so re-syncing doesn't itself retrigger the
+	// effect — without that guard, picking a set could fire the effect twice in
+	// quick succession and the second pass would read stale `data.filters` and
+	// wipe the user's selection.
 	$effect(() => {
-		// Sync filter inputs from server data
-		searchInput = data.filters.search;
-		selectedSet = data.filters.set;
-		selectedType = data.filters.type;
-		selectedRarity = data.filters.rarity;
+		const search = data.filters.search;
+		const set = data.filters.set;
+		const type = data.filters.type;
+		const rarity = data.filters.rarity;
+		const sort: SortMode = (data.filters.sort as SortMode) || 'default';
 
-		// Fetch cards client-side
-		initialLoad = true;
-		const query = buildQuery();
-		fetchCards(query, 1);
+		untrack(() => {
+			searchInput = search;
+			selectedSet = set;
+			selectedType = type;
+			selectedRarity = rarity;
+			sortMode = sort;
+			initialLoad = true;
+		});
+
+		const query = buildQuery(search, set, type, rarity);
+		fetchCards(query, 1, sort === 'default' ? DEFAULT_PAGE_SIZE : SORT_PAGE_SIZE);
 	});
 
 	// Apply filters via URL navigation (triggers server load → re-runs effect)
@@ -90,6 +122,7 @@
 		if (selectedSet) params.set('set', selectedSet);
 		if (selectedType) params.set('type', selectedType);
 		if (selectedRarity) params.set('rarity', selectedRarity);
+		if (sortMode !== 'default') params.set('sort', sortMode);
 		const qs = params.toString();
 		goto(`/browse${qs ? '?' + qs : ''}`, { keepFocus: true });
 	}
@@ -108,14 +141,21 @@
 		selectedSet = '';
 		selectedType = '';
 		selectedRarity = '';
+		sortMode = 'default';
 		goto('/browse');
 	}
 
-	// Infinite scroll
+	// Infinite scroll — use the URL filters as the source of truth so pagination
+	// stays consistent with what the user navigated to.
 	async function loadMore() {
 		if (loading || !hasMore) return;
-		const query = buildQuery();
-		await fetchCards(query, currentPage + 1, true);
+		const query = buildQuery(
+			data.filters.search,
+			data.filters.set,
+			data.filters.type,
+			data.filters.rarity
+		);
+		await fetchCards(query, currentPage + 1, DEFAULT_PAGE_SIZE, true);
 	}
 
 	let sentinel = $state<HTMLDivElement | null>(null);
@@ -137,8 +177,14 @@
 	});
 
 	const hasActiveFilters = $derived(
-		searchInput || selectedSet || selectedType || selectedRarity
+		searchInput || selectedSet || selectedType || selectedRarity || sortMode !== 'default'
 	);
+
+	function badgeFor(card: PokemonCard): string | null {
+		const v = getSortBadgeValue(card, sortMode);
+		if (v == null) return null;
+		return `Spread $${v.toFixed(2)}`;
+	}
 </script>
 
 <svelte:head>
@@ -235,7 +281,33 @@
 			<option value="Special Illustration Rare">Special Illustration Rare</option>
 			<option value="Hyper Rare">Hyper Rare</option>
 		</select>
+
+		<select
+			bind:value={sortMode}
+			onchange={handleFilterChange}
+			title={SORT_OPTIONS.find((o) => o.id === sortMode)?.hint ?? ''}
+			class="w-full rounded-xl border border-vault-border bg-vault-surface px-3 py-2.5 text-sm text-vault-text transition-all focus:border-vault-purple focus:outline-none sm:w-auto sm:px-4"
+		>
+			{#each SORT_OPTIONS as opt}
+				<option value={opt.id}>{opt.label}</option>
+			{/each}
+		</select>
 	</div>
+
+	{#if isSorting}
+		<div class="flex items-center gap-2 rounded-xl border border-vault-purple/30 bg-vault-purple/5 px-4 py-2 text-xs text-vault-text-muted">
+			<svg class="h-4 w-4 text-vault-purple" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
+			</svg>
+			<span>
+				Sorted by <span class="font-semibold text-vault-text">{SORT_OPTIONS.find((o) => o.id === sortMode)?.label}</span>
+				· {SORT_OPTIONS.find((o) => o.id === sortMode)?.hint}
+				{#if totalCount > SORT_PAGE_SIZE}
+					· showing first {SORT_PAGE_SIZE.toLocaleString()} of {totalCount.toLocaleString()}
+				{/if}
+			</span>
+		</div>
+	{/if}
 
 	<!-- Loading state -->
 	{#if initialLoad && loading}
@@ -244,11 +316,11 @@
 			<p class="text-lg font-medium">Loading cards...</p>
 			<p class="mt-1 text-sm">This may take a few seconds</p>
 		</div>
-	{:else if cards.length > 0}
+	{:else if displayedCards.length > 0}
 		<!-- Card Grid -->
 		<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-			{#each cards as card (card.id)}
-				<CardThumbnail {card} showPrice={true} />
+			{#each displayedCards as card (card.id)}
+				<CardThumbnail {card} showPrice={true} badgeLabel={badgeFor(card)} />
 			{/each}
 		</div>
 
@@ -264,7 +336,10 @@
 			</div>
 		{:else}
 			<div class="flex items-center justify-center py-8 text-sm text-vault-text-muted">
-				Showing all {cards.length.toLocaleString()} cards
+				Showing {displayedCards.length.toLocaleString()} card{displayedCards.length === 1 ? '' : 's'}
+				{#if isSorting && displayedCards.length !== cards.length}
+					· {(cards.length - displayedCards.length).toLocaleString()} hidden (no price data)
+				{/if}
 			</div>
 		{/if}
 	{:else}
@@ -273,7 +348,13 @@
 				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
 			</svg>
 			<p class="text-lg font-medium">No cards found</p>
-			<p class="mt-1 text-sm">Try adjusting your search or filters</p>
+			<p class="mt-1 text-sm">
+				{#if isSorting && cards.length > 0}
+					{cards.length.toLocaleString()} cards loaded, but none match the active sort
+				{:else}
+					Try adjusting your search or filters
+				{/if}
+			</p>
 			{#if hasActiveFilters}
 				<button
 					onclick={clearFilters}

--- a/supabase/migrations/003_card_catalog.sql
+++ b/supabase/migrations/003_card_catalog.sql
@@ -1,0 +1,73 @@
+-- Trove: Static card + set catalog
+--
+-- Source of truth for everything that doesn't change after a set releases:
+-- card metadata, images, set info. Live pricing snapshots live in
+-- price_history (rolled forward by a separate cron job).
+--
+-- Populated by `npm run ingest:catalog`, which pages through the Pokémon TCG
+-- API and upserts everything. After ingest, /browse and /api/cards read from
+-- here directly instead of round-tripping to api.pokemontcg.io on every load.
+
+-- ============================================
+-- sets — one row per Pokémon TCG set
+-- ============================================
+create table if not exists sets (
+    id text primary key,
+    name text not null,
+    series text,
+    printed_total integer,
+    total integer,
+    release_date date,
+    symbol_url text,
+    logo_url text,
+    ingested_at timestamptz not null default now()
+);
+
+create index if not exists idx_sets_release_date on sets (release_date desc);
+
+-- ============================================
+-- cards — one row per printed card
+-- ============================================
+create table if not exists cards (
+    id text primary key,
+    set_id text references sets(id) on delete cascade,
+    name text not null,
+    supertype text,
+    subtypes text[],
+    hp text,
+    types text[],
+    number text not null,
+    artist text,
+    rarity text,
+    national_pokedex_numbers integer[],
+    image_small text,
+    image_large text,
+    -- Combat data is small and rarely queried directly — keep as jsonb so
+    -- we don't have to chase normalization through three more tables.
+    attacks jsonb,
+    weaknesses jsonb,
+    resistances jsonb,
+    retreat_cost text[],
+    -- TCGPlayer / CardMarket blocks are kept on the card row because they
+    -- arrive in the same TCG API response. Refreshed by the price job; the
+    -- column suffixes match the upstream JSON shape so we can pass the
+    -- whole blob through to the existing client code unchanged.
+    tcgplayer_url text,
+    tcgplayer_prices jsonb,
+    tcgplayer_updated_at timestamptz,
+    cardmarket_url text,
+    cardmarket_prices jsonb,
+    cardmarket_updated_at timestamptz,
+    ingested_at timestamptz not null default now()
+);
+
+create index if not exists idx_cards_set_id on cards (set_id);
+create index if not exists idx_cards_rarity on cards (rarity);
+create index if not exists idx_cards_types on cards using gin (types);
+-- Lowercase name index for case-insensitive prefix lookups.
+create index if not exists idx_cards_name_lower on cards (lower(name));
+
+-- pg_trgm enables fuzzy / substring search via a GIN index. Lets us run
+-- WHERE name ILIKE '%char%' efficiently on the full catalog.
+create extension if not exists pg_trgm;
+create index if not exists idx_cards_name_trgm on cards using gin (name gin_trgm_ops);


### PR DESCRIPTION
## Summary
- Adds five sort modes to `/browse` using TCGPlayer pricing already on each card — no new APIs, no cron: Set Order, Price High→Low / Low→High, Biggest Spread (market−low), Bulk Hunt under \$1.
- Fixes a long-standing bug where picking any set other than the default left the dropdown stuck and no cards loaded. The `\$effect` was depending on both `data.filters.*` and the local input vars via `buildQuery()`, so changing the dropdown could fire the effect twice and the second pass would re-sync state from stale `data.filters` — reverting the user's selection before `goto()` landed.

## Notes
- Spread uses `market - low` instead of `high - low` because TCGPlayer's `high` field is polluted with \$9999 outlier listings, which made the original spread metric meaningless. `market - low` is the actionable flip signal: how much room there is between the cheapest current copy and the recent market price.
- Sort modes that filter (spread, bulk) drop cards without price data and surface the hidden count in the footer.
- When a non-default sort is active, the page fetches up to 250 cards in a single shot and disables infinite scroll.
- Effect now reads only `data.filters.*` and updates local input state inside `untrack()`, so re-syncing can't itself retrigger the effect.

## Test plan
- [ ] Default `/browse` still loads latest set with infinite scroll
- [ ] Pick a set from the dropdown — URL updates, dropdown stays selected, cards load
- [ ] Pick a sort, then a different set — combo persists in the URL
- [ ] Price High→Low on Base Set: Charizard \$500 / Blastoise \$202 / Venusaur \$150
- [ ] Bulk Hunt on Base Set returns ~38 cards under \$1
- [ ] Spread sort no longer shows \$9998 garbage values

🤖 Generated with [Claude Code](https://claude.com/claude-code)