### PR TITLE
fix: analytics compare search + explicit RLS-off on Trove tables

### DIFF
--- a/src/routes/analytics/+page.svelte
+++ b/src/routes/analytics/+page.svelte
@@ -64,7 +64,7 @@
 		if (!compareSearch.trim() || searchLoading) return;
 		searchLoading = true;
 		try {
-			const res = await fetch(`/api/cards?q=${encodeURIComponent(`name:"${compareSearch.trim}"`)}&pageSize=12`);
+			const res = await fetch(`/api/cards?q=${encodeURIComponent(`name:"${compareSearch.trim()}"`)}&pageSize=12`);
 			const json = await res.json();
 			compareSearchResults = json.data ?? [];
 		} catch {

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -85,3 +85,18 @@ create trigger collection_updated_at
 create trigger grading_updated_at
     before update on grading
     for each row execute function update_updated_at();
+
+-- ============================================
+-- Row Level Security
+-- ============================================
+-- Trove is a single-user app gated by TROVE_PASSWORD at the hooks layer
+-- (src/hooks.server.ts). Auth lives in front of the whole app, not at the
+-- DB row level. Explicitly disable RLS on every table so the publishable
+-- key can read/write — newer Supabase projects default to RLS-enabled and
+-- will silently block writes from the anon key otherwise. These statements
+-- are idempotent: running them on an existing DB where RLS was never enabled
+-- is a no-op.
+alter table collection disable row level security;
+alter table watchlist disable row level security;
+alter table grading disable row level security;
+alter table price_cache disable row level security;

--- a/supabase/migrations/002_price_history.sql
+++ b/supabase/migrations/002_price_history.sql
@@ -18,3 +18,10 @@ create table if not exists price_history (
 create index if not exists idx_price_history_card_id on price_history (card_id);
 create index if not exists idx_price_history_recorded_at on price_history (recorded_at);
 create index if not exists idx_price_history_card_date on price_history (card_id, recorded_at desc);
+
+-- Trove is a single-user app gated by TROVE_PASSWORD at the hooks layer
+-- (src/hooks.server.ts). Auth lives in front of the whole app, not at the DB
+-- row level — matching the RLS posture of the tables in 001_initial_schema.sql.
+-- Without this, newer Supabase projects default to RLS-enabled and silently
+-- block inserts from the publishable key (which is what the app uses).
+alter table price_history disable row level security;


### PR DESCRIPTION
## Summary
Two bug fixes surfaced during a debug pass on the app:

- **`src/routes/analytics/+page.svelte`** — compare tab's card search was calling `compareSearch.trim` (function reference) instead of `compareSearch.trim()` (the trimmed string). The primary fetch silently succeeded with an invalid query and returned zero results forever. A `.catch()` fallback existed but only ran on network errors. Surfaced indirectly by a nearby svelte-check warning. Verified fixed in the browser by searching for "pikachu" and getting 12 results.

- **`supabase/migrations/001_initial_schema.sql`** and **`supabase/migrations/002_price_history.sql`** — explicitly `disable row level security` on all Trove tables. Trove is a single-user app where auth lives at the SvelteKit hooks layer (`TROVE_PASSWORD`), not the DB row level. Both migrations relied implicitly on Supabase's old RLS-off default. Newer Supabase projects default RLS to **on** for new tables, and the `cacheTcgPlayerPrices` service catches and swallows write errors fire-and-forget — so `price_history` was being created, silently rejected on every insert, and the PriceChart component was always empty even after loading card detail pages. Verified end-to-end after running `alter table price_history disable row level security` against the live DB: loading `/card/base1-6` wrote `holofoil $41.33 market` to `price_history` on first try.

## Test plan
- [x] svelte-check passes (2 pre-existing Chart.js typing errors remain, unrelated)
- [x] `/analytics` compare tab search returns results for "pikachu"
- [x] `/browse`, `/card/[id]`, `/collection`, `/watchlist`, `/grading`, `/insights`, `/sets`, `/settings`, `/style-guide` all load 200
- [x] Collection / watchlist / grading CRUD round-trips (POST → GET → DELETE) work end-to-end
- [x] Loading a card detail with known pricing writes a row to `price_history` (confirmed `base1-6` → `$41.33 holofoil`)
- [x] RLS-off alter statements are idempotent, so no-op on existing DB where they were already implicitly off

## Follow-up (not in this PR)
- PokeTrace / PriceTracker / TCG API keys are missing from `.env.local` — features that depend on them degrade gracefully (empty states + "Degraded" API badge), no code change needed.
- 2 pre-existing svelte-check errors in PriceChart.svelte and ComparisonChart.svelte (Chart.js `onMount` async return type) — worth fixing in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)