### PR TITLE
fix: broken hydration after deploy + TCG API retry

### DIFF
--- a/src/lib/services/tcg-api.ts
+++ b/src/lib/services/tcg-api.ts
@@ -2,7 +2,16 @@ import type { PokemonCard, CardSet, PaginatedResponse } from '$types';
 import * as apiMonitor from './api-monitor';
 
 const BASE_URL = 'https://api.pokemontcg.io/v2';
-const TIMEOUT_MS = 15000;
+// Total budget for a single logical request, across all retry attempts.
+const TOTAL_TIMEOUT_MS = 15000;
+// Per-attempt cap so a single slow call can't consume the whole budget.
+const ATTEMPT_TIMEOUT_MS = 6000;
+// Retries are cheap for a read-only API and the upstream is observably flaky
+// (intermittently returns 404/5xx for queries that are valid). 2 retries with
+// exponential backoff absorb ~3 consecutive failures without doubling latency
+// on the happy path.
+const MAX_ATTEMPTS = 3;
+const BASE_BACKOFF_MS = 200;
 const SERVICE = 'tcg';
 
 function getHeaders(): HeadersInit {
@@ -20,19 +29,58 @@ function getHeaders(): HeadersInit {
 	return headers;
 }
 
+/**
+ * Retry on transient upstream failures: network errors, timeouts, 5xx, 429,
+ * and 404 (the pokemontcg.io v2 API has been observed to return 404 for valid
+ * queries under load, then succeed on immediate retry).
+ *
+ * Does NOT retry on 400/401/403 because those are deterministic client errors
+ * — retrying just delays the inevitable failure.
+ */
+function isRetryableStatus(status: number): boolean {
+	if (status === 404 || status === 429) return true;
+	return status >= 500 && status < 600;
+}
+
 async function fetchWithTimeout(url: string, opts: RequestInit = {}): Promise<Response> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-	try {
-		const res = await fetch(url, { ...opts, signal: controller.signal });
-		apiMonitor.record(SERVICE, res);
-		return res;
-	} catch (err) {
-		apiMonitor.recordError(SERVICE, err);
-		throw err;
-	} finally {
-		clearTimeout(timeout);
+	const deadline = Date.now() + TOTAL_TIMEOUT_MS;
+	let lastError: unknown = null;
+
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) break;
+		const attemptTimeout = Math.min(ATTEMPT_TIMEOUT_MS, remaining);
+
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), attemptTimeout);
+		try {
+			const res = await fetch(url, { ...opts, signal: controller.signal });
+			apiMonitor.record(SERVICE, res);
+			// Retry transient failures; return everything else (including 2xx and
+			// deterministic 4xx) so the caller can decide what to do.
+			if (attempt < MAX_ATTEMPTS && isRetryableStatus(res.status)) {
+				lastError = new Error(`TCG API transient HTTP ${res.status}`);
+				// Drain the body so the connection can be reused.
+				await res.body?.cancel().catch(() => {});
+			} else {
+				return res;
+			}
+		} catch (err) {
+			apiMonitor.recordError(SERVICE, err);
+			lastError = err;
+			// AbortError + network errors are retryable.
+		} finally {
+			clearTimeout(timer);
+		}
+
+		// Exponential backoff: 200ms, 600ms — capped by remaining deadline.
+		if (attempt < MAX_ATTEMPTS) {
+			const backoff = Math.min(BASE_BACKOFF_MS * 3 ** (attempt - 1), deadline - Date.now());
+			if (backoff > 0) await new Promise((r) => setTimeout(r, backoff));
+		}
 	}
+
+	throw lastError instanceof Error ? lastError : new Error('TCG API request failed');
 }
 
 // ── In-memory cache for sets (rarely changes, saves ~1 API call per page load) ──

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,10 +4,11 @@ import { getCachedPricesForCards } from '$services/price-cache';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ setHeaders }) => {
-	// Per-user data — cache in the user's browser only, never share across users
-	// or via shared CDNs. (Dashboard reflects the logged-in user's collection.)
+	// Do NOT cache the HTML document. See src/routes/browse/+page.server.ts
+	// for the full rationale — cached HTML referencing deleted immutable
+	// JS hashes after a Vercel deploy silently breaks hydration.
 	setHeaders({
-		'cache-control': 'private, max-age=60, stale-while-revalidate=300'
+		'cache-control': 'private, no-cache, must-revalidate'
 	});
 
 	const [collectionRes, watchlistRes, gradingRes] = await Promise.all([

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -2,9 +2,18 @@ import { getSets } from '$services/tcg-api';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url, setHeaders }) => {
-	// Sets list is stable — cache aggressively at the edge
+	// Do NOT cache the HTML document. The HTML references hashed JS bundles
+	// (`_app/immutable/entry/*.{hash}.js`), and when Vercel promotes a new
+	// deployment the old hashes 404. A browser holding cached HTML from a
+	// previous deploy then fails to hydrate — the page renders, but every
+	// interaction is a no-op because `kit.start()` never runs. ETag-based
+	// revalidation (`no-cache` + must-revalidate) keeps reloads fast while
+	// guaranteeing the browser always checks with the server first.
+	// The sets list itself is cached via in-memory setsCache in tcg-api.ts,
+	// and /api/cards has its own cache-control header, so losing the HTML
+	// cache has negligible cost.
 	setHeaders({
-		'cache-control': 'private, max-age=600, stale-while-revalidate=3600'
+		'cache-control': 'private, no-cache, must-revalidate'
 	});
 
 	const search = url.searchParams.get('q') ?? '';

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -10,9 +10,11 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 	const card = await getCard(params.id).catch(() => null);
 	if (!card) throw error(404, 'Card not found');
 
-	// Per-user (auth-gated) — cache in the user's browser only.
+	// Do NOT cache the HTML document. See src/routes/browse/+page.server.ts
+	// for the full rationale — cached HTML referencing deleted immutable
+	// JS hashes after a Vercel deploy silently breaks hydration.
 	setHeaders({
-		'cache-control': 'private, max-age=300, stale-while-revalidate=3600'
+		'cache-control': 'private, no-cache, must-revalidate'
 	});
 
 	// Cache TCGPlayer prices to Supabase (fire-and-forget, once per day)


### PR DESCRIPTION
## Summary

Two fixes, both surfacing from an investigation into "browse is broken on rsmc.tech — can't search, can't switch sets":

### 1. HTML caching after deploy broke client hydration (the reported bug)

`/`, `/browse`, and `/card/[id]` page loaders set `Cache-Control: private, max-age=60..600, stale-while-revalidate`. The SSR'd HTML references hashed JS bundles under `_app/immutable/entry/*.js`. When Vercel promotes a new deployment, old hashes 404. A browser holding cached HTML from a previous visit then:

1. Parses the HTML shell
2. Runs the inline bootstrap script which does `import("./_app/immutable/entry/start.OLD_HASH.js")`
3. Gets 404
4. `kit.start()` never runs
5. Every search, select, and button is inert — **the page renders but does nothing**, exactly what the user reported.

Fix: switch the three page loaders to `private, no-cache, must-revalidate`. Browsers still cache, but revalidate on every request. SvelteKit already emits an ETag, so revalidation is a cheap 304 when the deployment hasn't changed, and gets the fresh HTML as soon as a new deployment lands. API caches are unchanged — they cache data, not JS hashes.

**Note**: anyone already holding stale cached HTML needs one hard reload (Cmd+Shift+R) to clear it. After that, the browser stays current automatically.

### 2. TCG API retry on transient failures

Caught in the api-monitor log during diagnosis:

```
[api-monitor] Pokémon TCG API reporting ERRORS (HTTP 404): HTTP 404 Not Found
[api-monitor] Pokémon TCG API recovered.
```

`pokemontcg.io v2` intermittently returns 404/5xx for valid queries then succeeds on retry. Previous code did a single fetch with no retry — on failure, `/api/cards` silently returned `{data: [], totalCount: 0}` and the user saw an empty grid. Now: up to 3 attempts with 200ms → 600ms exponential backoff, retry on network errors / 5xx / 429 / 404, per-attempt timeout 6s, total budget 15s.

## Test plan
- [x] svelte-check passes (2 pre-existing Chart.js typing errors remain, unrelated)
- [x] Puppeteer against **rsmc.tech** (before fix): HTML loads, all JS bundles load, `kit.start()` runs, set selector + search bar both work end-to-end — ruling out a code bug on main. Problem is client-side cached HTML in the user's browser.
- [x] Puppeteer against **local dev with the cache fix**: initial 24 cards → search "charizard" → 108 cards → set=base1 → 1 card ($500.90 Charizard Base·#4). No console errors.
- [x] `cache-control: private, no-cache, must-revalidate` served by all three page routes after fix
- [x] TCG API retry: happy path still works (5x curl, consistent 102 cards for `set.id:base1`)

## Follow-up
- Consider applying the same retry pattern to `pokeapi.ts`, `poketrace.ts`, and `price-tracker.ts` if those start showing flakiness.
- 2 pre-existing Chart.js typing errors in PriceChart/ComparisonChart still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)