### PR TITLE
fix: /card/[id] Add to Collection / Watchlist work without JS

### DIFF
--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -3,8 +3,9 @@ import { getPokemon, getEvolutionChain } from '$services/pokeapi';
 import { getCardPrices } from '$services/poketrace';
 import { getGradedPrices } from '$services/price-tracker';
 import { cacheTcgPlayerPrices, getPriceHistoryFromCache } from '$services/price-cache';
-import { error } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
+import { supabase } from '$services/supabase';
+import { error, fail } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
 
 export const load: PageServerLoad = async ({ params, setHeaders }) => {
 	const card = await getCard(params.id).catch(() => null);
@@ -36,6 +37,17 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 			hasPriceTracker ? getGradedPrices(params.id) : Promise.resolve([])
 		]);
 
+	// Pre-fetch whether this card is already in the user's collection /
+	// watchlist so the page can show "In Collection" / "Watching" state
+	// on initial render without needing JS. Errors are swallowed — if
+	// Supabase is unreachable the buttons just show their default state.
+	const [collectionRows, watchlistRows] = await Promise.all([
+		supabase.from('collection').select('id').eq('card_id', params.id).limit(1),
+		supabase.from('watchlist').select('id').eq('card_id', params.id).limit(1)
+	]);
+	const inCollection = !!collectionRows.data?.length;
+	const onWatchlist = !!watchlistRows.data?.length;
+
 	return {
 		card,
 		pokedexData,
@@ -44,6 +56,73 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		gradedPrices,
 		priceHistory,
 		ebaySold: { query: '', listings: [], averagePrice: 0, medianPrice: 0, lowPrice: 0, highPrice: 0, totalSold: 0 },
-		psaPop: null
+		psaPop: null,
+		inCollection,
+		onWatchlist
 	};
+};
+
+/**
+ * Form actions for "Add to Collection" and "Add to Watchlist".
+ *
+ * Declared as SvelteKit actions instead of client-side `fetch` calls so the
+ * buttons work without any JavaScript — native `<form method="POST" action="?/…">`
+ * submission falls through to these handlers, the Supabase insert runs on the
+ * server, and the page re-renders with the new state. With JS, `use:enhance`
+ * on the form upgrades this to an inline update (no full reload) while still
+ * hitting the same action.
+ */
+export const actions: Actions = {
+	addToCollection: async ({ params }) => {
+		const cardId = params.id;
+		if (!cardId) return fail(400, { action: 'collection', message: 'Missing card id' });
+
+		// If the user already has this card at NM condition, bump the quantity
+		// instead of creating a duplicate row. Matches the /api/collection POST
+		// handler so the two paths behave identically.
+		const { data: existing } = await supabase
+			.from('collection')
+			.select('id, quantity')
+			.eq('card_id', cardId)
+			.eq('condition', 'NM')
+			.maybeSingle();
+
+		if (existing) {
+			const { error: err } = await supabase
+				.from('collection')
+				.update({ quantity: existing.quantity + 1 })
+				.eq('id', existing.id);
+			if (err) return fail(500, { action: 'collection', message: err.message });
+			return { action: 'collection', success: true, bumped: true };
+		}
+
+		const { error: err } = await supabase
+			.from('collection')
+			.insert({ card_id: cardId, quantity: 1, condition: 'NM' });
+		if (err) return fail(500, { action: 'collection', message: err.message });
+		return { action: 'collection', success: true };
+	},
+
+	addToWatchlist: async ({ params }) => {
+		const cardId = params.id;
+		if (!cardId) return fail(400, { action: 'watchlist', message: 'Missing card id' });
+
+		// watchlist has a unique (card_id) constraint; detect the duplicate and
+		// return a success regardless so the user sees "Watching" either way.
+		const { data: existing } = await supabase
+			.from('watchlist')
+			.select('id')
+			.eq('card_id', cardId)
+			.maybeSingle();
+
+		if (existing) {
+			return { action: 'watchlist', success: true, alreadyWatching: true };
+		}
+
+		const { error: err } = await supabase
+			.from('watchlist')
+			.insert({ card_id: cardId });
+		if (err) return fail(500, { action: 'watchlist', message: err.message });
+		return { action: 'watchlist', success: true };
+	}
 };

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { invalidateAll } from '$app/navigation';
+	import { enhance } from '$app/forms';
 	import { PriceChart } from '$components';
 	import type { PokedexData, EvolutionNode } from '$types';
 	import type { PokeTracePrice } from '$services/poketrace';
@@ -8,7 +8,7 @@
 	import type { EbaySoldResult } from '$services/ebay-scraper';
 	import type { PSAPopData } from '$services/psa-scraper';
 
-	let { data } = $props();
+	let { data, form } = $props();
 
 	let card = $derived(data.card);
 	let pokedexData = $derived(data.pokedexData as PokedexData | null);
@@ -19,62 +19,11 @@
 	let ebaySold = $derived(data.ebaySold as EbaySoldResult);
 	let psaPop = $derived(data.psaPop as PSAPopData | null);
 
-	let addedToCollection = $state(false);
-	let addedToWatchlist = $state(false);
-	let actionLoading = $state('');
-	let actionError = $state<string | null>(null);
-	let priceTab = $state<'raw' | 'graded'>('raw');
-
-	async function readError(res: Response): Promise<string> {
-		try {
-			const body = await res.clone().json();
-			return body?.message ?? body?.error ?? `Request failed (HTTP ${res.status})`;
-		} catch {
-			return `Request failed (HTTP ${res.status})`;
-		}
-	}
-
-	async function addToCollection() {
-		actionLoading = 'collection';
-		actionError = null;
-		try {
-			const res = await fetch('/api/collection', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ card_id: card.id, quantity: 1, condition: 'NM' })
-			});
-			if (res.ok) {
-				addedToCollection = true;
-			} else {
-				actionError = await readError(res);
-			}
-		} catch (err) {
-			actionError = err instanceof Error ? err.message : 'Network error';
-		} finally {
-			actionLoading = '';
-		}
-	}
-
-	async function addToWatchlist() {
-		actionLoading = 'watchlist';
-		actionError = null;
-		try {
-			const res = await fetch('/api/watchlist', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ card_id: card.id })
-			});
-			if (res.ok) {
-				addedToWatchlist = true;
-			} else {
-				actionError = await readError(res);
-			}
-		} catch (err) {
-			actionError = err instanceof Error ? err.message : 'Network error';
-		} finally {
-			actionLoading = '';
-		}
-	}
+	// "Added" state comes from either the server loader (reload-resistant,
+	// works without JS) or the most recent form submission result.
+	let inCollection = $derived(data.inCollection || form?.action === 'collection' && form?.success);
+	let onWatchlist = $derived(data.onWatchlist || form?.action === 'watchlist' && form?.success);
+	let actionError = $derived(form && !form.success ? form.message : null);
 
 	function typeColor(type: string): string {
 		const colors: Record<string, string> = {
@@ -607,15 +556,26 @@
 				</div>
 			{/if}
 
-			<!-- Actions -->
+			<!--
+				Actions — native <form method="POST"> that submits to the
+				SvelteKit form actions in +page.server.ts. Works without JS.
+				With JS, `use:enhance` upgrades it to an inline update (no full
+				reload). "In Collection" / "Watching" state is persisted on the
+				server and re-rendered on reload, so even in the no-JS path the
+				user sees confirmation after the form submit.
+			-->
 			<div class="space-y-3">
 				<div class="flex gap-3">
-					<button onclick={addToCollection} disabled={actionLoading === 'collection'} class="btn-press rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-6 py-2.5 text-sm font-medium text-white shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40 disabled:opacity-50">
-						{#if addedToCollection}Added!{:else if actionLoading === 'collection'}Adding...{:else}Add to Collection{/if}
-					</button>
-					<button onclick={addToWatchlist} disabled={actionLoading === 'watchlist'} class="btn-press rounded-xl border border-vault-border px-6 py-2.5 text-sm font-medium text-vault-text transition-all hover:border-vault-purple/50 hover:bg-vault-surface-hover disabled:opacity-50">
-						{#if addedToWatchlist}Watching!{:else if actionLoading === 'watchlist'}Adding...{:else}Add to Watchlist{/if}
-					</button>
+					<form method="POST" action="?/addToCollection" use:enhance class="contents">
+						<button type="submit" disabled={inCollection} class="btn-press rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-6 py-2.5 text-sm font-medium text-white shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40 disabled:opacity-70">
+							{inCollection ? 'In Collection' : 'Add to Collection'}
+						</button>
+					</form>
+					<form method="POST" action="?/addToWatchlist" use:enhance class="contents">
+						<button type="submit" disabled={onWatchlist} class="btn-press rounded-xl border border-vault-border px-6 py-2.5 text-sm font-medium text-vault-text transition-all hover:border-vault-purple/50 hover:bg-vault-surface-hover disabled:opacity-70">
+							{onWatchlist ? 'Watching' : 'Add to Watchlist'}
+						</button>
+					</form>
 				</div>
 				{#if actionError}
 					<div class="rounded-xl border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent" data-testid="action-error">


### PR DESCRIPTION
## Summary

Continuation of the progressive-enhancement pass from #18. /card/[id] already SSRs everything the user reads (card image, price ladder, attacks, Pokédex, evolution chain). The two interactive buttons — **Add to Collection** and **Add to Watchlist** — were still JS-only, wired as `<button onclick={fetch(...)}>`. In a browser where hydration doesn't run, they did nothing.

This PR makes both buttons native form POSTs via SvelteKit form actions, with `use:enhance` on top for inline updates when JS is available.

## Changes

- **`src/routes/card/[id]/+page.server.ts`** — added `actions.addToCollection` and `actions.addToWatchlist`. Both read `params.id`, perform the Supabase insert (with the same bump-quantity-on-duplicate dedupe logic as `/api/collection` POST), and return a typed result. `load` now also pre-fetches `inCollection` / `onWatchlist` from Supabase so the initial SSR render shows the right button state ("In Collection" vs "Add to Collection") without needing any JS at all.
- **`src/routes/card/[id]/+page.svelte`** — replaced the two onclick buttons with `<form method="POST" action="?/addToCollection" use:enhance>` and `<form method="POST" action="?/addToWatchlist" use:enhance>`. Removed the dead `addToCollection` / `addToWatchlist` helpers, the unused `priceTab` state, and the `invalidateAll` import.

## Test plan

Verified with playwright against local dev:

**No-JS** (Chromium with `javaScriptEnabled: false`):
- [x] GET `/card/base1-4` — full price ladder renders ($497.99 / $719.99 / $1499.66 / $500.90), Price History / Pokédex / Evolution Chain all present
- [x] Click **Add to Collection** → native form POST to `?/addToCollection` → server inserts → page re-renders with button text "In Collection"
- [x] Click **Add to Watchlist** → button reads "Watching"
- [x] Full reload → both buttons still show the persisted state because the loader pre-fetches from Supabase

**JS on** (Chromium, Firefox, WebKit):
- [x] `use:enhance` intercepts submit, button updates without full reload
- [x] Zero console or page errors in any engine

## Follow-up (not in this PR)
- `/collection/+page.svelte` still has a JS-only "Add a card" modal with a multi-field form. The `use:enhance` pattern works there too, but it's a bigger rewrite — worth a separate PR.
- 2 pre-existing svelte-check errors in PriceChart/ComparisonChart are still there (Chart.js onMount typing), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)