### PR TITLE
fix: /collection works without JS + feat: /browse sort dropdown (8 modes + Spread/Bulk Hunt)

### DIFF
--- a/src/lib/services/sort.ts
+++ b/src/lib/services/sort.ts
@@ -1,48 +1,166 @@
-// Sort options for the card browser. The `value` is what goes in the URL as
-// ?sort=…; the `orderBy` is what gets passed to the Pokémon TCG API. The API
-// supports dot-notation on nested fields, so price sorts lean on
-// `cardmarket.prices.averageSellPrice` — this is the closest thing the API
-// has to a "market price" that's cheap and available on every card with any
-// pricing data.
+import type { PokemonCard } from '$types';
+
+// Sort options for the card browser.
+//
+// There are two flavours:
+//
+//   kind: 'api'     — the TCG API does the sort via its orderBy parameter.
+//                     Works for any query size; server-paginated; fast.
+//
+//   kind: 'client'  — the TCG API can't sort by this criterion, so we fetch
+//                     a bigger page up front, then filter / sort in memory
+//                     from the TCGPlayer printing data that's already on
+//                     each card. Used for flip-hunting modes like "Biggest
+//                     Spread" (market − low on the headline printing) and
+//                     "Bulk Hunt" (headline market < $1). Done on the server
+//                     so no-JS and JS paths return identical results and
+//                     there's no duplicated client/server logic.
 //
 // Rarity sort is alphabetical, not value-based — the TCG API has no concept
-// of rarity tiering, so "Common" < "Uncommon" < "Rare" isn't guaranteed. It's
-// still useful for grouping but is labelled A–Z to make the behaviour clear.
+// of rarity tiering, so "Common" < "Uncommon" < "Rare" isn't guaranteed.
+// Labelled A–Z to make that clear.
 //
 // Kept in $lib/services (not a route) so the browse page server loader, the
 // /api/cards endpoint (used for infinite scroll), and the browse page itself
 // can all share the same mapping.
 
+export type SortKind = 'api' | 'client';
+
 export interface SortOption {
 	value: string;
 	label: string;
-	orderBy: string;
+	kind: SortKind;
+	/** TCG API orderBy string when kind = 'api'. Ignored otherwise. */
+	orderBy?: string;
 }
 
 export const SORT_OPTIONS: SortOption[] = [
-	{ value: '', label: 'Newest first', orderBy: '-set.releaseDate' },
-	{ value: 'oldest', label: 'Oldest first', orderBy: 'set.releaseDate' },
-	{ value: 'name', label: 'Name (A–Z)', orderBy: 'name' },
-	{ value: 'name_desc', label: 'Name (Z–A)', orderBy: '-name' },
+	{ value: '', label: 'Newest first', kind: 'api', orderBy: '-set.releaseDate' },
+	{ value: 'oldest', label: 'Oldest first', kind: 'api', orderBy: 'set.releaseDate' },
+	{ value: 'name', label: 'Name (A–Z)', kind: 'api', orderBy: 'name' },
+	{ value: 'name_desc', label: 'Name (Z–A)', kind: 'api', orderBy: '-name' },
 	{
 		value: 'price_high',
 		label: 'Price (high to low)',
+		kind: 'api',
 		orderBy: '-cardmarket.prices.averageSellPrice'
 	},
 	{
 		value: 'price_low',
 		label: 'Price (low to high)',
+		kind: 'api',
 		orderBy: 'cardmarket.prices.averageSellPrice'
 	},
-	{ value: 'rarity', label: 'Rarity (A–Z)', orderBy: 'rarity' },
-	{ value: 'number', label: 'Card number', orderBy: 'number' }
+	{ value: 'rarity', label: 'Rarity (A–Z)', kind: 'api', orderBy: 'rarity' },
+	{ value: 'number', label: 'Card number', kind: 'api', orderBy: 'number' },
+	{ value: 'spread', label: 'Biggest Spread', kind: 'client' },
+	{ value: 'bulk', label: 'Bulk Hunt (under $1)', kind: 'client' }
 ];
 
-const DEFAULT_ORDER_BY = SORT_OPTIONS[0].orderBy;
+const DEFAULT_OPTION = SORT_OPTIONS[0];
 
-/** Map a URL sort value (possibly empty or unknown) to a TCG API orderBy string. */
+/** Look up a sort option by its URL value, falling back to the default. */
+export function resolveSortOption(sort: string | null | undefined): SortOption {
+	if (!sort) return DEFAULT_OPTION;
+	return SORT_OPTIONS.find((o) => o.value === sort) ?? DEFAULT_OPTION;
+}
+
+/**
+ * The TCG API orderBy to use for a given URL sort value.
+ *
+ * For client-side sort modes we still need SOMETHING to pass to the API —
+ * we fetch the raw page with card-number ordering so the in-memory sort has
+ * a stable baseline before filtering.
+ */
 export function resolveSortOrderBy(sort: string | null | undefined): string {
-	if (!sort) return DEFAULT_ORDER_BY;
-	const match = SORT_OPTIONS.find((o) => o.value === sort);
-	return match ? match.orderBy : DEFAULT_ORDER_BY;
+	const opt = resolveSortOption(sort);
+	if (opt.kind === 'api') return opt.orderBy ?? '-set.releaseDate';
+	return 'number';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers for deriving sort/filter values from a card's TCGPlayer price
+// block. Each card exposes several printings (normal / holofoil / reverse /
+// 1stEditionHolofoil / etc), each with its own low/mid/high/market. These
+// helpers reduce that map down to a single comparable number.
+
+interface PrintingPrice {
+	printing: string;
+	market: number | null;
+	low: number | null;
+}
+
+function getPrintings(card: PokemonCard): PrintingPrice[] {
+	const prices = card.tcgplayer?.prices;
+	if (!prices) return [];
+	return Object.entries(prices).map(([printing, p]) => ({
+		printing,
+		market: p?.market ?? null,
+		low: p?.low ?? null
+	}));
+}
+
+/**
+ * Headline printing = the one with the highest market price. Picking the
+ * max so a $50 holo doesn't hide behind a $0.25 reverse-holo printing.
+ */
+function getHeadlinePrinting(card: PokemonCard): PrintingPrice | null {
+	let best: PrintingPrice | null = null;
+	for (const p of getPrintings(card)) {
+		if (p.market == null) continue;
+		if (!best || p.market > (best.market ?? -Infinity)) best = p;
+	}
+	return best;
+}
+
+/** Headline market price — the card's "what is this worth" number. */
+function getHeadlineMarket(card: PokemonCard): number | null {
+	return getHeadlinePrinting(card)?.market ?? null;
+}
+
+/**
+ * Spread within the headline printing. Uses `market - low`, NOT `high - low`:
+ * TCGPlayer's `high` field is polluted with $9999-style outlier listings,
+ * which made the high–low spread useless as a signal. `market - low` is the
+ * actionable number — how much room there is between the cheapest current
+ * copy and the recent market price.
+ */
+function getHeadlineSpread(card: PokemonCard): number | null {
+	const best = getHeadlinePrinting(card);
+	if (!best || best.market == null || best.low == null) return null;
+	return best.market - best.low;
+}
+
+/**
+ * Apply a client-side sort mode to a fetched card list. Pure — operates on
+ * a copy. These modes also filter: cards without the required price data
+ * are dropped so the result isn't padded with meaningless rows.
+ *
+ * For api-kind sort modes or the default, returns the input unchanged.
+ */
+export function applyClientSort(cards: PokemonCard[], sort: string | null | undefined): PokemonCard[] {
+	const opt = resolveSortOption(sort);
+	if (opt.kind !== 'client') return cards;
+
+	if (opt.value === 'spread') {
+		return cards
+			.filter((c) => {
+				const s = getHeadlineSpread(c);
+				// Require a meaningful absolute spread so $0.04→$0.12 pennies
+				// don't dominate the list.
+				return s != null && s > 0.5;
+			})
+			.sort((a, b) => (getHeadlineSpread(b) ?? 0) - (getHeadlineSpread(a) ?? 0));
+	}
+
+	if (opt.value === 'bulk') {
+		return cards
+			.filter((c) => {
+				const p = getHeadlineMarket(c);
+				return p != null && p < 1;
+			})
+			.sort((a, b) => (getHeadlineMarket(a) ?? 0) - (getHeadlineMarket(b) ?? 0));
+	}
+
+	return cards;
 }

--- a/src/lib/services/sort.ts
+++ b/src/lib/services/sort.ts
@@ -1,0 +1,48 @@
+// Sort options for the card browser. The `value` is what goes in the URL as
+// ?sort=…; the `orderBy` is what gets passed to the Pokémon TCG API. The API
+// supports dot-notation on nested fields, so price sorts lean on
+// `cardmarket.prices.averageSellPrice` — this is the closest thing the API
+// has to a "market price" that's cheap and available on every card with any
+// pricing data.
+//
+// Rarity sort is alphabetical, not value-based — the TCG API has no concept
+// of rarity tiering, so "Common" < "Uncommon" < "Rare" isn't guaranteed. It's
+// still useful for grouping but is labelled A–Z to make the behaviour clear.
+//
+// Kept in $lib/services (not a route) so the browse page server loader, the
+// /api/cards endpoint (used for infinite scroll), and the browse page itself
+// can all share the same mapping.
+
+export interface SortOption {
+	value: string;
+	label: string;
+	orderBy: string;
+}
+
+export const SORT_OPTIONS: SortOption[] = [
+	{ value: '', label: 'Newest first', orderBy: '-set.releaseDate' },
+	{ value: 'oldest', label: 'Oldest first', orderBy: 'set.releaseDate' },
+	{ value: 'name', label: 'Name (A–Z)', orderBy: 'name' },
+	{ value: 'name_desc', label: 'Name (Z–A)', orderBy: '-name' },
+	{
+		value: 'price_high',
+		label: 'Price (high to low)',
+		orderBy: '-cardmarket.prices.averageSellPrice'
+	},
+	{
+		value: 'price_low',
+		label: 'Price (low to high)',
+		orderBy: 'cardmarket.prices.averageSellPrice'
+	},
+	{ value: 'rarity', label: 'Rarity (A–Z)', orderBy: 'rarity' },
+	{ value: 'number', label: 'Card number', orderBy: 'number' }
+];
+
+const DEFAULT_ORDER_BY = SORT_OPTIONS[0].orderBy;
+
+/** Map a URL sort value (possibly empty or unknown) to a TCG API orderBy string. */
+export function resolveSortOrderBy(sort: string | null | undefined): string {
+	if (!sort) return DEFAULT_ORDER_BY;
+	const match = SORT_OPTIONS.find((o) => o.value === sort);
+	return match ? match.orderBy : DEFAULT_ORDER_BY;
+}

--- a/src/lib/services/tcg-api.ts
+++ b/src/lib/services/tcg-api.ts
@@ -94,13 +94,14 @@ const CARD_CACHE_TTL = 1000 * 60 * 10; // 10 minutes
 export async function searchCards(
 	query: string,
 	page = 1,
-	pageSize = 20
+	pageSize = 20,
+	orderBy = '-set.releaseDate'
 ): Promise<PaginatedResponse<PokemonCard>> {
 	const params = new URLSearchParams({
 		q: query,
 		page: String(page),
 		pageSize: String(pageSize),
-		orderBy: '-set.releaseDate'
+		orderBy
 	});
 
 	const res = await fetchWithTimeout(`${BASE_URL}/cards?${params}`, {

--- a/src/routes/api/cards/+server.ts
+++ b/src/routes/api/cards/+server.ts
@@ -1,13 +1,22 @@
 import { json } from '@sveltejs/kit';
 import { searchCards, getSets } from '$services/tcg-api';
-import { resolveSortOrderBy } from '$services/sort';
+import { applyClientSort, resolveSortOption, resolveSortOrderBy } from '$services/sort';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url }) => {
 	let query = url.searchParams.get('q');
+	const sortParam = url.searchParams.get('sort');
+	const sortOption = resolveSortOption(sortParam);
+	const isClientSort = sortOption.kind === 'client';
+
 	const page = parseInt(url.searchParams.get('page') ?? '1');
-	const pageSize = parseInt(url.searchParams.get('pageSize') ?? '24');
-	const orderBy = resolveSortOrderBy(url.searchParams.get('sort'));
+	// Client-side sort modes always return the full filtered set in one
+	// shot (up to the TCG API's 250 cap) so infinite scroll has nothing to
+	// request. For api-kind sorts the caller picks the page size.
+	const pageSize = isClientSort
+		? 250
+		: parseInt(url.searchParams.get('pageSize') ?? '24');
+	const orderBy = resolveSortOrderBy(sortParam);
 
 	// When no query is supplied, default to the latest set (sorted by release date).
 	if (!query) {
@@ -26,6 +35,19 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	try {
 		const result = await searchCards(query, page, pageSize, orderBy);
+		if (isClientSort) {
+			const filtered = applyClientSort(result.data, sortParam);
+			return json(
+				{
+					data: filtered,
+					totalCount: filtered.length,
+					page: 1,
+					pageSize: filtered.length,
+					count: filtered.length
+				},
+				{ headers: { 'cache-control': 'private, max-age=300, stale-while-revalidate=3600' } }
+			);
+		}
 		return json(result, {
 			headers: { 'cache-control': 'private, max-age=300, stale-while-revalidate=3600' }
 		});

--- a/src/routes/api/cards/+server.ts
+++ b/src/routes/api/cards/+server.ts
@@ -1,11 +1,13 @@
 import { json } from '@sveltejs/kit';
 import { searchCards, getSets } from '$services/tcg-api';
+import { resolveSortOrderBy } from '$services/sort';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url }) => {
 	let query = url.searchParams.get('q');
 	const page = parseInt(url.searchParams.get('page') ?? '1');
 	const pageSize = parseInt(url.searchParams.get('pageSize') ?? '24');
+	const orderBy = resolveSortOrderBy(url.searchParams.get('sort'));
 
 	// When no query is supplied, default to the latest set (sorted by release date).
 	if (!query) {
@@ -23,7 +25,7 @@ export const GET: RequestHandler = async ({ url }) => {
 	}
 
 	try {
-		const result = await searchCards(query, page, pageSize);
+		const result = await searchCards(query, page, pageSize, orderBy);
 		return json(result, {
 			headers: { 'cache-control': 'private, max-age=300, stale-while-revalidate=3600' }
 		});

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -1,4 +1,5 @@
 import { getSets, searchCards } from '$services/tcg-api';
+import { resolveSortOrderBy } from '$services/sort';
 import type { PageServerLoad } from './$types';
 import type { PokemonCard } from '$types';
 
@@ -20,6 +21,8 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	const set = url.searchParams.get('set') ?? '';
 	const type = url.searchParams.get('type') ?? '';
 	const rarity = url.searchParams.get('rarity') ?? '';
+	const sort = url.searchParams.get('sort') ?? '';
+	const orderBy = resolveSortOrderBy(sort);
 
 	// Build the TCG API query from the current filters. If no filters are
 	// applied, default to the newest set (first in the release-sorted list).
@@ -45,7 +48,7 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	let totalCount = 0;
 	if (query) {
 		try {
-			const result = await searchCards(query, 1, INITIAL_PAGE_SIZE);
+			const result = await searchCards(query, 1, INITIAL_PAGE_SIZE, orderBy);
 			initialCards = result.data;
 			totalCount = result.totalCount;
 		} catch {
@@ -55,7 +58,7 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 
 	return {
 		sets,
-		filters: { search, set, type, rarity },
+		filters: { search, set, type, rarity, sort },
 		initialCards,
 		initialTotalCount: totalCount
 	};

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -1,9 +1,13 @@
 import { getSets, searchCards } from '$services/tcg-api';
-import { resolveSortOrderBy } from '$services/sort';
+import { applyClientSort, resolveSortOption, resolveSortOrderBy } from '$services/sort';
 import type { PageServerLoad } from './$types';
 import type { PokemonCard } from '$types';
 
 const INITIAL_PAGE_SIZE = 24;
+// When a client-side sort mode is active we fetch a bigger slice up front
+// (TCG API max is 250) and do the filter + sort in memory. Infinite scroll
+// is naturally disabled because the full result set is on the page.
+const CLIENT_SORT_PAGE_SIZE = 250;
 
 export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	// Do NOT cache the HTML document. The HTML references hashed JS bundles
@@ -22,7 +26,10 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	const type = url.searchParams.get('type') ?? '';
 	const rarity = url.searchParams.get('rarity') ?? '';
 	const sort = url.searchParams.get('sort') ?? '';
+	const sortOption = resolveSortOption(sort);
 	const orderBy = resolveSortOrderBy(sort);
+	const isClientSort = sortOption.kind === 'client';
+	const pageSize = isClientSort ? CLIENT_SORT_PAGE_SIZE : INITIAL_PAGE_SIZE;
 
 	// Build the TCG API query from the current filters. If no filters are
 	// applied, default to the newest set (first in the release-sorted list).
@@ -46,11 +53,21 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	const query = buildQuery();
 	let initialCards: PokemonCard[] = [];
 	let totalCount = 0;
+	let hiddenByClientSort = 0;
 	if (query) {
 		try {
-			const result = await searchCards(query, 1, INITIAL_PAGE_SIZE, orderBy);
-			initialCards = result.data;
-			totalCount = result.totalCount;
+			const result = await searchCards(query, 1, pageSize, orderBy);
+			if (isClientSort) {
+				// Apply the in-memory sort + filter. totalCount becomes the
+				// size of the filtered list so the client doesn't try to
+				// infinite-scroll past it.
+				initialCards = applyClientSort(result.data, sort);
+				totalCount = initialCards.length;
+				hiddenByClientSort = result.data.length - initialCards.length;
+			} else {
+				initialCards = result.data;
+				totalCount = result.totalCount;
+			}
 		} catch {
 			// Swallow — the client will retry via /api/cards on hydration.
 		}
@@ -60,6 +77,8 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 		sets,
 		filters: { search, set, type, rarity, sort },
 		initialCards,
-		initialTotalCount: totalCount
+		initialTotalCount: totalCount,
+		clientSort: isClientSort,
+		hiddenByClientSort
 	};
 };

--- a/src/routes/browse/+page.svelte
+++ b/src/routes/browse/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { CardThumbnail } from '$components';
+	import { SORT_OPTIONS } from '$services/sort';
 	import type { PokemonCard } from '$types';
 
 	let { data } = $props();
@@ -54,6 +55,7 @@
 				page: String(currentPage + 1),
 				pageSize: String(PAGE_SIZE)
 			});
+			if (data.filters.sort) params.set('sort', data.filters.sort);
 			const res = await fetch(`/api/cards?${params}`);
 			if (!res.ok) throw new Error('Failed to load more cards');
 			const result = await res.json();
@@ -89,7 +91,13 @@
 	}
 
 	let hasActiveFilters = $derived(
-		!!(data.filters.search || data.filters.set || data.filters.type || data.filters.rarity)
+		!!(
+			data.filters.search ||
+			data.filters.set ||
+			data.filters.type ||
+			data.filters.rarity ||
+			data.filters.sort
+		)
 	);
 </script>
 
@@ -189,6 +197,18 @@
 			<option value="Illustration Rare">Illustration Rare</option>
 			<option value="Special Illustration Rare">Special Illustration Rare</option>
 			<option value="Hyper Rare">Hyper Rare</option>
+		</select>
+
+		<select
+			name="sort"
+			value={data.filters.sort}
+			onchange={autoSubmit}
+			class="w-[calc(50%-4px)] rounded-xl border border-vault-border bg-vault-surface px-3 py-2.5 text-sm text-vault-text transition-all focus:border-vault-purple focus:outline-none sm:w-auto sm:px-4"
+			aria-label="Sort cards"
+		>
+			{#each SORT_OPTIONS as opt}
+				<option value={opt.value}>{opt.label}</option>
+			{/each}
 		</select>
 
 		<!--

--- a/src/routes/browse/+page.svelte
+++ b/src/routes/browse/+page.svelte
@@ -245,6 +245,9 @@
 		{:else}
 			<div class="flex items-center justify-center py-8 text-sm text-vault-text-muted">
 				Showing all {allCards.length.toLocaleString()} cards
+				{#if data.clientSort && data.hiddenByClientSort > 0}
+					<span class="ml-2">({data.hiddenByClientSort.toLocaleString()} hidden — missing price data)</span>
+				{/if}
 			</div>
 		{/if}
 	{:else}

--- a/src/routes/collection/+page.server.ts
+++ b/src/routes/collection/+page.server.ts
@@ -1,13 +1,194 @@
 import { supabase } from '$services/supabase';
-import type { PageServerLoad } from './$types';
+import { getCard, searchCards } from '$services/tcg-api';
+import { fail, redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+import type { PokemonCard, CollectionEntry } from '$types';
 
-export const load: PageServerLoad = async () => {
-	const { data: entries, error } = await supabase
+const ADD_SEARCH_PAGE_SIZE = 12;
+
+export const load: PageServerLoad = async ({ url, setHeaders }) => {
+	// Do NOT cache the HTML document. See src/routes/browse/+page.server.ts
+	// for the full rationale — cached HTML referencing deleted immutable JS
+	// hashes after a Vercel deploy silently breaks hydration.
+	setHeaders({
+		'cache-control': 'private, no-cache, must-revalidate'
+	});
+
+	const { data: rawEntries } = await supabase
 		.from('collection')
 		.select('*')
 		.order('created_at', { ascending: false });
 
+	const entries = (rawEntries ?? []) as CollectionEntry[];
+
+	// Fetch card metadata for each entry server-side so the list renders
+	// without JS. getCard() has an in-memory TTL cache so repeat loads are
+	// cheap; a failed lookup degrades to just the card_id being shown.
+	const uniqueCardIds = Array.from(new Set(entries.map((e) => e.card_id)));
+	const cardLookups = await Promise.all(
+		uniqueCardIds.map((id) => getCard(id).catch(() => null))
+	);
+	const cardCache: Record<string, PokemonCard> = {};
+	for (let i = 0; i < uniqueCardIds.length; i++) {
+		const card = cardLookups[i];
+		if (card) cardCache[uniqueCardIds[i]] = card;
+	}
+
+	// Add-modal state is driven by URL params so the whole flow works without
+	// JS: `?add=1` opens the modal, `?addSearch=<q>` runs a server-side card
+	// search, `?selectedCard=<id>` pre-fetches that card so the detail preview
+	// renders on the same round-trip. Option (b) from the task spec — keeping
+	// the modal in-page and using query params for each step is less
+	// disruptive than a separate /collection/add route.
+	const addMode = url.searchParams.get('add') === '1';
+	const addSearch = url.searchParams.get('addSearch') ?? '';
+	const selectedCardId = url.searchParams.get('selectedCard') ?? '';
+
+	let addSearchResults: PokemonCard[] = [];
+	if (addMode && addSearch.trim()) {
+		try {
+			const result = await searchCards(`name:"${addSearch}*"`, 1, ADD_SEARCH_PAGE_SIZE);
+			addSearchResults = result.data;
+		} catch {
+			// swallow — show empty results rather than crashing the page
+		}
+	}
+
+	let selectedCard: PokemonCard | null = null;
+	if (addMode && selectedCardId) {
+		selectedCard = await getCard(selectedCardId).catch(() => null);
+	}
+
 	return {
-		entries: entries ?? []
+		entries,
+		cardCache,
+		addMode,
+		addSearch,
+		addSearchResults,
+		selectedCard
 	};
+};
+
+/**
+ * Form actions for the collection page.
+ *
+ * Declared as SvelteKit actions instead of client-side fetch() calls so the
+ * page works without any JavaScript — native <form method="POST" action="?/…">
+ * submission falls through to these handlers, the Supabase mutation runs on
+ * the server, and the page re-renders with the new state. With JS,
+ * `use:enhance` upgrades each form to an inline update hitting the same
+ * action.
+ *
+ * The dedupe rules (bump quantity on matching (card_id, condition)) mirror
+ * the /api/collection POST handler so both paths behave identically.
+ */
+export const actions: Actions = {
+	addEntry: async ({ request }) => {
+		const form = await request.formData();
+		const cardId = (form.get('card_id') ?? '').toString().trim();
+		if (!cardId) return fail(400, { action: 'add', message: 'Card is required' });
+
+		const conditionRaw = (form.get('condition') ?? 'NM').toString();
+		const condition = ['NM', 'LP', 'MP', 'HP', 'DMG'].includes(conditionRaw)
+			? conditionRaw
+			: 'NM';
+
+		const quantityRaw = parseInt((form.get('quantity') ?? '1').toString(), 10);
+		const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? quantityRaw : 1;
+
+		const priceRaw = (form.get('purchase_price') ?? '').toString().trim();
+		const purchasePrice = priceRaw ? parseFloat(priceRaw) : null;
+
+		const dateRaw = (form.get('purchase_date') ?? '').toString().trim();
+		const purchaseDate = dateRaw || null;
+
+		const notesRaw = (form.get('notes') ?? '').toString().trim();
+		const notes = notesRaw || null;
+
+		const { data: existing } = await supabase
+			.from('collection')
+			.select('id, quantity')
+			.eq('card_id', cardId)
+			.eq('condition', condition)
+			.maybeSingle();
+
+		if (existing) {
+			const { error: err } = await supabase
+				.from('collection')
+				.update({ quantity: existing.quantity + quantity })
+				.eq('id', existing.id);
+			if (err) return fail(500, { action: 'add', message: err.message });
+		} else {
+			const { error: err } = await supabase.from('collection').insert({
+				card_id: cardId,
+				quantity,
+				condition,
+				purchase_price: purchasePrice,
+				purchase_date: purchaseDate,
+				notes
+			});
+			if (err) return fail(500, { action: 'add', message: err.message });
+		}
+
+		throw redirect(303, '/collection');
+	},
+
+	increment: async ({ request }) => {
+		const form = await request.formData();
+		const id = (form.get('id') ?? '').toString();
+		if (!id) return fail(400, { action: 'increment', message: 'Missing id' });
+
+		const { data: existing } = await supabase
+			.from('collection')
+			.select('quantity')
+			.eq('id', id)
+			.maybeSingle();
+		if (!existing) return fail(404, { action: 'increment', message: 'Entry not found' });
+
+		const { error: err } = await supabase
+			.from('collection')
+			.update({ quantity: existing.quantity + 1 })
+			.eq('id', id);
+		if (err) return fail(500, { action: 'increment', message: err.message });
+
+		return { action: 'increment', success: true };
+	},
+
+	decrement: async ({ request }) => {
+		const form = await request.formData();
+		const id = (form.get('id') ?? '').toString();
+		if (!id) return fail(400, { action: 'decrement', message: 'Missing id' });
+
+		const { data: existing } = await supabase
+			.from('collection')
+			.select('quantity')
+			.eq('id', id)
+			.maybeSingle();
+		if (!existing) return fail(404, { action: 'decrement', message: 'Entry not found' });
+
+		if (existing.quantity <= 1) {
+			const { error: err } = await supabase.from('collection').delete().eq('id', id);
+			if (err) return fail(500, { action: 'decrement', message: err.message });
+			return { action: 'decrement', success: true, removed: true };
+		}
+
+		const { error: err } = await supabase
+			.from('collection')
+			.update({ quantity: existing.quantity - 1 })
+			.eq('id', id);
+		if (err) return fail(500, { action: 'decrement', message: err.message });
+
+		return { action: 'decrement', success: true };
+	},
+
+	remove: async ({ request }) => {
+		const form = await request.formData();
+		const id = (form.get('id') ?? '').toString();
+		if (!id) return fail(400, { action: 'remove', message: 'Missing id' });
+
+		const { error: err } = await supabase.from('collection').delete().eq('id', id);
+		if (err) return fail(500, { action: 'remove', message: err.message });
+
+		return { action: 'remove', success: true };
+	}
 };

--- a/src/routes/collection/+page.svelte
+++ b/src/routes/collection/+page.svelte
@@ -1,44 +1,17 @@
 <script lang="ts">
-	import { invalidateAll } from '$app/navigation';
+	import { enhance } from '$app/forms';
 	import type { CollectionEntry, PokemonCard, CardCondition } from '$types';
 
-	let { data } = $props();
+	let { data, form } = $props();
 
 	let entries = $derived(data.entries as CollectionEntry[]);
-	let loading = $state(false);
-	let searchQuery = $state('');
-	let showAddModal = $state(false);
-	let editingEntry = $state<CollectionEntry | null>(null);
-	let saveError = $state<string | null>(null);
+	let cardCache = $derived(data.cardCache as Record<string, PokemonCard>);
+	let addMode = $derived(data.addMode);
+	let selectedCard = $derived(data.selectedCard as PokemonCard | null);
+	let addSearchResults = $derived(data.addSearchResults as PokemonCard[]);
+	let addSearchQuery = $derived(data.addSearch ?? '');
 
-	async function readError(res: Response): Promise<string> {
-		try {
-			const body = await res.clone().json();
-			return body?.message ?? body?.error ?? `Request failed (HTTP ${res.status})`;
-		} catch {
-			return `Request failed (HTTP ${res.status})`;
-		}
-	}
-
-	// Card search for add modal
-	let cardSearchQuery = $state('');
-	let cardSearchResults = $state<PokemonCard[]>([]);
-	let searchingCards = $state(false);
-	let selectedCard = $state<PokemonCard | null>(null);
-
-	// Add form state
-	let addQuantity = $state(1);
-	let addCondition = $state<CardCondition>('NM');
-	let addPurchasePrice = $state('');
-	let addPurchaseDate = $state('');
-	let addNotes = $state('');
-
-	// Filtered entries
-	let filteredEntries = $derived(
-		searchQuery
-			? entries.filter((e) => e.card_id.toLowerCase().includes(searchQuery.toLowerCase()))
-			: entries
-	);
+	let saveError = $derived(form && !form.success ? form.message : null);
 
 	// Stats
 	let totalCards = $derived(entries.reduce((sum, e) => sum + e.quantity, 0));
@@ -47,121 +20,21 @@
 	);
 	let uniqueCards = $derived(new Set(entries.map((e) => e.card_id)).size);
 
-	// Card lookup cache — maps card_id to card data for display
-	let cardCache = $state<Record<string, PokemonCard>>({});
-
-	// Fetch card data for display
-	async function lookupCard(cardId: string): Promise<PokemonCard | null> {
-		if (cardCache[cardId]) return cardCache[cardId];
-		try {
-			const res = await fetch(`https://api.pokemontcg.io/v2/cards/${cardId}`);
-			if (!res.ok) return null;
-			const json = await res.json();
-			cardCache[cardId] = json.data;
-			return json.data;
-		} catch {
-			return null;
-		}
-	}
-
-	// Load card data for all entries on mount
-	$effect(() => {
-		for (const entry of entries) {
-			if (!cardCache[entry.card_id]) {
-				lookupCard(entry.card_id);
-			}
-		}
-	});
-
-	// Search for cards to add
-	async function searchCards() {
-		if (!cardSearchQuery.trim()) return;
-		searchingCards = true;
-		try {
-			const res = await fetch(`/api/cards?q=name:"${cardSearchQuery}*"&pageSize=12`);
-			const result = await res.json();
-			cardSearchResults = result.data ?? [];
-		} catch {
-			cardSearchResults = [];
-		} finally {
-			searchingCards = false;
-		}
-	}
-
-	function selectCard(card: PokemonCard) {
-		selectedCard = card;
-		cardSearchResults = [];
-		cardSearchQuery = card.name;
-	}
-
-	async function addToCollection() {
-		if (!selectedCard) return;
-		loading = true;
-		saveError = null;
-		try {
-			const res = await fetch('/api/collection', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					card_id: selectedCard.id,
-					quantity: addQuantity,
-					condition: addCondition,
-					purchase_price: addPurchasePrice ? parseFloat(addPurchasePrice) : null,
-					purchase_date: addPurchaseDate || null,
-					notes: addNotes || null
+	// Client-side filter over the server-rendered list. The input is a plain
+	// field (no form submission) — filtering is purely cosmetic, no data
+	// changes, so it's fine to skip the server round-trip when JS is on. The
+	// entire list is already server-rendered so without JS the user simply
+	// sees every row.
+	let searchQuery = $state('');
+	let filteredEntries = $derived(
+		searchQuery
+			? entries.filter((e) => {
+					const card = cardCache[e.card_id];
+					const haystack = `${e.card_id} ${card?.name ?? ''} ${card?.set.name ?? ''}`.toLowerCase();
+					return haystack.includes(searchQuery.toLowerCase());
 				})
-			});
-			if (res.ok) {
-				// Cache the card data
-				cardCache[selectedCard.id] = selectedCard;
-				closeAddModal();
-				await invalidateAll();
-			} else {
-				saveError = await readError(res);
-			}
-		} catch (err) {
-			saveError = err instanceof Error ? err.message : 'Network error';
-		} finally {
-			loading = false;
-		}
-	}
-
-	async function removeEntry(id: string) {
-		const res = await fetch(`/api/collection?id=${id}`, { method: 'DELETE' });
-		if (res.ok) await invalidateAll();
-	}
-
-	async function updateQuantity(entry: CollectionEntry, delta: number) {
-		const newQty = entry.quantity + delta;
-		if (newQty <= 0) {
-			removeEntry(entry.id);
-			return;
-		}
-		await fetch('/api/collection', {
-			method: 'PATCH',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ id: entry.id, quantity: newQty })
-		});
-		await invalidateAll();
-	}
-
-	function openAddModal() {
-		showAddModal = true;
-		selectedCard = null;
-		cardSearchQuery = '';
-		cardSearchResults = [];
-		addQuantity = 1;
-		addCondition = 'NM';
-		addPurchasePrice = '';
-		addPurchaseDate = '';
-		addNotes = '';
-		saveError = null;
-	}
-
-	function closeAddModal() {
-		showAddModal = false;
-		selectedCard = null;
-	}
+			: entries
+	);
 
 	const conditionLabels: Record<CardCondition, string> = {
 		NM: 'Near Mint',
@@ -182,12 +55,20 @@
 			<h1 class="text-2xl font-bold text-gradient sm:text-3xl">My Collection</h1>
 			<p class="mt-1 text-vault-text-muted">Track every card you own</p>
 		</div>
-		<button
-			onclick={openAddModal}
+		<!--
+			"+ Add Card" is a plain link to ?add=1 so the modal opens server-side.
+			The modal's card-search form submits back to the same route with
+			?addSearch=<q>; the loader populates results. Option (b) from the task
+			spec — less disruptive than a separate /collection/add route and keeps
+			the existing in-page modal UX.
+		-->
+		<a
+			href="/collection?add=1"
+			data-testid="open-add-modal"
 			class="btn-press rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-4 py-2 text-sm font-medium text-white shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40"
 		>
 			+ Add Card
-		</button>
+		</a>
 	</div>
 
 	<!-- Summary -->
@@ -222,10 +103,10 @@
 		</div>
 
 		{#if filteredEntries.length > 0}
-			<div class="divide-y divide-vault-border">
+			<div class="divide-y divide-vault-border" data-testid="collection-list">
 				{#each filteredEntries as entry (entry.id)}
 					{@const card = cardCache[entry.card_id]}
-					<div class="flex items-center gap-3 px-3 py-3 sm:gap-4 sm:px-6 sm:py-4">
+					<div class="flex items-center gap-3 px-3 py-3 sm:gap-4 sm:px-6 sm:py-4" data-testid="collection-row" data-card-id={entry.card_id}>
 						<!-- Card thumbnail -->
 						{#if card}
 							<a href="/card/{card.id}" class="flex-shrink-0">
@@ -268,33 +149,47 @@
 							</div>
 						</div>
 
-						<!-- Quantity controls -->
+						<!-- Quantity controls (tiny forms) -->
 						<div class="flex items-center gap-2">
-							<button
-								onclick={() => updateQuantity(entry, -1)}
-								class="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border text-vault-text-muted transition-colors hover:bg-vault-surface-hover hover:text-white"
-							>
-								-
-							</button>
-							<span class="w-8 text-center text-sm font-bold text-white">{entry.quantity}</span>
-							<button
-								onclick={() => updateQuantity(entry, 1)}
-								class="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border text-vault-text-muted transition-colors hover:bg-vault-surface-hover hover:text-white"
-							>
-								+
-							</button>
+							<form method="POST" action="?/decrement" use:enhance class="contents">
+								<input type="hidden" name="id" value={entry.id} />
+								<button
+									type="submit"
+									data-testid="qty-decrement"
+									class="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border text-vault-text-muted transition-colors hover:bg-vault-surface-hover hover:text-white"
+									aria-label="Decrease quantity"
+								>
+									-
+								</button>
+							</form>
+							<span class="w-8 text-center text-sm font-bold text-white" data-testid="qty">{entry.quantity}</span>
+							<form method="POST" action="?/increment" use:enhance class="contents">
+								<input type="hidden" name="id" value={entry.id} />
+								<button
+									type="submit"
+									data-testid="qty-increment"
+									class="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border text-vault-text-muted transition-colors hover:bg-vault-surface-hover hover:text-white"
+									aria-label="Increase quantity"
+								>
+									+
+								</button>
+							</form>
 						</div>
 
 						<!-- Delete -->
-						<button
-							onclick={() => removeEntry(entry.id)}
-							class="flex-shrink-0 rounded-lg p-2 text-vault-text-muted transition-colors hover:bg-vault-red/10 hover:text-vault-red"
-							aria-label="Remove from collection"
-						>
-							<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-							</svg>
-						</button>
+						<form method="POST" action="?/remove" use:enhance class="contents">
+							<input type="hidden" name="id" value={entry.id} />
+							<button
+								type="submit"
+								data-testid="remove-entry"
+								class="flex-shrink-0 rounded-lg p-2 text-vault-text-muted transition-colors hover:bg-vault-red/10 hover:text-vault-red"
+								aria-label="Remove from collection"
+							>
+								<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+								</svg>
+							</button>
+						</form>
 					</div>
 				{/each}
 			</div>
@@ -317,142 +212,164 @@
 	</div>
 </div>
 
-<!-- Add Card Modal -->
-{#if showAddModal}
-	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
-		<button aria-label="Close modal" class="fixed inset-0 bg-black/60" onclick={closeAddModal}></button>
+<!-- Add Card Modal — rendered when ?add=1 is in the URL. Closing is a link back
+     to /collection (which re-runs load without the add params). -->
+{#if addMode}
+	<div class="fixed inset-0 z-50 flex items-center justify-center p-4" data-testid="add-modal">
+		<a href="/collection" aria-label="Close modal" class="fixed inset-0 bg-black/60"></a>
 		<div class="relative w-full max-w-sm rounded-2xl border border-vault-border bg-vault-surface p-4 shadow-2xl sm:max-w-lg sm:p-6">
 			<div class="flex items-center justify-between">
 				<h2 class="text-lg font-semibold text-white">Add Card to Collection</h2>
-				<button onclick={closeAddModal} class="text-vault-text-muted hover:text-white" aria-label="Close">
+				<a href="/collection" class="text-vault-text-muted hover:text-white" aria-label="Close">
 					<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
 					</svg>
-				</button>
+				</a>
 			</div>
 
 			<div class="mt-4 space-y-4">
-				<!-- Card search -->
-				<div>
+				<!-- Card search — plain GET form back to /collection?add=1&addSearch=<q>.
+				     Loader runs the TCG search and returns results in data.addSearchResults. -->
+				<form method="GET" action="/collection" class="space-y-2">
+					<input type="hidden" name="add" value="1" />
 					<label class="block text-sm font-medium text-vault-text-muted" for="card-search">Search Card</label>
-					<div class="relative mt-1">
+					<div class="flex gap-2">
 						<input
 							id="card-search"
+							name="addSearch"
 							type="text"
-							bind:value={cardSearchQuery}
-							oninput={() => { if (cardSearchQuery.length >= 2) searchCards(); }}
+							value={addSearchQuery}
 							placeholder="Type a card name..."
-							class="w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text placeholder-vault-text-muted focus:border-vault-purple focus:outline-none"
+							data-testid="card-search-input"
+							class="flex-1 rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text placeholder-vault-text-muted focus:border-vault-purple focus:outline-none"
 						/>
-						{#if searchingCards}
-							<div class="absolute right-3 top-2.5">
-								<div class="h-4 w-4 animate-spin rounded-full border-2 border-vault-accent border-t-transparent"></div>
-							</div>
-						{/if}
+						<button
+							type="submit"
+							data-testid="card-search-submit"
+							class="rounded-lg bg-vault-accent px-4 py-2 text-sm font-medium text-white hover:bg-vault-accent-hover"
+						>
+							Search
+						</button>
 					</div>
+				</form>
 
-					<!-- Search results dropdown -->
-					{#if cardSearchResults.length > 0}
-						<div class="mt-1 max-h-48 overflow-y-auto rounded-lg border border-vault-border bg-vault-bg">
-							{#each cardSearchResults as result}
-								<button
-									onclick={() => selectCard(result)}
-									class="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-vault-surface-hover"
-								>
-									<img src={result.images.small} alt={result.name} class="h-10 w-7 rounded object-cover" />
-									<div>
-										<p class="text-sm text-white">{result.name}</p>
-										<p class="text-xs text-vault-text-muted">{result.set.name} · #{result.number}</p>
-									</div>
-								</button>
-							{/each}
-						</div>
-					{/if}
-				</div>
-
-				<!-- Selected card preview -->
-				{#if selectedCard}
-					<div class="flex items-center gap-3 rounded-lg border border-vault-purple/30 bg-vault-purple/5 p-3">
-						<img src={selectedCard.images.small} alt={selectedCard.name} class="h-16 w-11 rounded object-cover" />
-						<div>
-							<p class="font-medium text-white">{selectedCard.name}</p>
-							<p class="text-xs text-vault-text-muted">{selectedCard.set.name} · {selectedCard.rarity ?? 'Unknown'}</p>
-						</div>
+				<!-- Search results — each result is a link to ?add=1&selectedCard=<id>,
+				     so picking one is a normal navigation. -->
+				{#if addSearchResults.length > 0 && !selectedCard}
+					<div class="max-h-48 overflow-y-auto rounded-lg border border-vault-border bg-vault-bg" data-testid="card-search-results">
+						{#each addSearchResults as result}
+							<a
+								href="/collection?add=1&selectedCard={encodeURIComponent(result.id)}&addSearch={encodeURIComponent(addSearchQuery)}"
+								data-testid="card-search-result"
+								data-card-id={result.id}
+								class="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-vault-surface-hover"
+							>
+								<img src={result.images.small} alt={result.name} class="h-10 w-7 rounded object-cover" />
+								<div>
+									<p class="text-sm text-white">{result.name}</p>
+									<p class="text-xs text-vault-text-muted">{result.set.name} · #{result.number}</p>
+								</div>
+							</a>
+						{/each}
 					</div>
 				{/if}
 
-				<div class="grid grid-cols-2 gap-4">
-					<div>
-						<label class="block text-sm font-medium text-vault-text-muted" for="quantity">Quantity</label>
-						<input
-							id="quantity"
-							type="number"
-							min="1"
-							bind:value={addQuantity}
-							class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-						/>
+				{#if addSearchQuery && addSearchResults.length === 0 && !selectedCard}
+					<p class="text-sm text-vault-text-muted">No cards found for "{addSearchQuery}"</p>
+				{/if}
+
+				<!-- Selected card preview + add form. The final submit is a POST to
+				     ?/addEntry with all fields in FormData. -->
+				{#if selectedCard}
+					<div class="flex items-center gap-3 rounded-lg border border-vault-purple/30 bg-vault-purple/5 p-3" data-testid="selected-card">
+						<img src={selectedCard.images.small} alt={selectedCard.name} class="h-16 w-11 rounded object-cover" />
+						<div class="flex-1">
+							<p class="font-medium text-white">{selectedCard.name}</p>
+							<p class="text-xs text-vault-text-muted">{selectedCard.set.name} · {selectedCard.rarity ?? 'Unknown'}</p>
+						</div>
+						<a href="/collection?add=1&addSearch={encodeURIComponent(addSearchQuery)}" class="text-xs text-vault-text-muted hover:text-white">
+							Change
+						</a>
 					</div>
-					<div>
-						<label class="block text-sm font-medium text-vault-text-muted" for="condition">Condition</label>
-						<select
-							id="condition"
-							bind:value={addCondition}
-							class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+
+					<form method="POST" action="?/addEntry" use:enhance class="space-y-4">
+						<input type="hidden" name="card_id" value={selectedCard.id} />
+
+						<div class="grid grid-cols-2 gap-4">
+							<div>
+								<label class="block text-sm font-medium text-vault-text-muted" for="quantity">Quantity</label>
+								<input
+									id="quantity"
+									name="quantity"
+									type="number"
+									min="1"
+									value="1"
+									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+								/>
+							</div>
+							<div>
+								<label class="block text-sm font-medium text-vault-text-muted" for="condition">Condition</label>
+								<select
+									id="condition"
+									name="condition"
+									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+								>
+									<option value="NM">Near Mint</option>
+									<option value="LP">Lightly Played</option>
+									<option value="MP">Moderately Played</option>
+									<option value="HP">Heavily Played</option>
+									<option value="DMG">Damaged</option>
+								</select>
+							</div>
+						</div>
+
+						<div class="grid grid-cols-2 gap-4">
+							<div>
+								<label class="block text-sm font-medium text-vault-text-muted" for="purchase-price">Purchase Price ($)</label>
+								<input
+									id="purchase-price"
+									name="purchase_price"
+									type="number"
+									step="0.01"
+									min="0"
+									placeholder="0.00"
+									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+								/>
+							</div>
+							<div>
+								<label class="block text-sm font-medium text-vault-text-muted" for="purchase-date">Purchase Date</label>
+								<input
+									id="purchase-date"
+									name="purchase_date"
+									type="date"
+									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+								/>
+							</div>
+						</div>
+
+						<div>
+							<label class="block text-sm font-medium text-vault-text-muted" for="notes">Notes</label>
+							<input
+								id="notes"
+								name="notes"
+								type="text"
+								placeholder="Optional notes..."
+								class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+							/>
+						</div>
+
+						<button
+							type="submit"
+							data-testid="submit-add-entry"
+							class="w-full rounded-lg bg-vault-accent px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-vault-accent-hover disabled:opacity-50"
 						>
-							<option value="NM">Near Mint</option>
-							<option value="LP">Lightly Played</option>
-							<option value="MP">Moderately Played</option>
-							<option value="HP">Heavily Played</option>
-							<option value="DMG">Damaged</option>
-						</select>
-					</div>
-				</div>
-
-				<div class="grid grid-cols-2 gap-4">
-					<div>
-						<label class="block text-sm font-medium text-vault-text-muted" for="purchase-price">Purchase Price ($)</label>
-						<input
-							id="purchase-price"
-							type="number"
-							step="0.01"
-							min="0"
-							bind:value={addPurchasePrice}
-							placeholder="0.00"
-							class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-						/>
-					</div>
-					<div>
-						<label class="block text-sm font-medium text-vault-text-muted" for="purchase-date">Purchase Date</label>
-						<input
-							id="purchase-date"
-							type="date"
-							bind:value={addPurchaseDate}
-							class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-						/>
-					</div>
-				</div>
-
-				<div>
-					<label class="block text-sm font-medium text-vault-text-muted" for="notes">Notes</label>
-					<input
-						id="notes"
-						type="text"
-						bind:value={addNotes}
-						placeholder="Optional notes..."
-						class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-					/>
-				</div>
-
-				<button
-					onclick={addToCollection}
-					disabled={!selectedCard || loading}
-					class="w-full rounded-lg bg-vault-accent px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-vault-accent-hover disabled:opacity-50"
-				>
-					{loading ? 'Adding...' : 'Add to Collection'}
-				</button>
+							Add to Collection
+						</button>
+					</form>
+				{/if}
 
 				{#if saveError}
-					<div class="rounded-lg border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent">
+					<div class="rounded-lg border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent" data-testid="save-error">
 						<span class="font-semibold">Couldn't save:</span> {saveError}
 					</div>
 				{/if}


### PR DESCRIPTION
## Summary

Consolidates #15 and the original /collection no-JS scope into one branch. #15 is closed — it was cut from before #16–#19 landed and most of its changes would have regressed those fixes; the genuinely-novel ideas are preserved here.

### 1. /collection works without JS
Ports the SvelteKit-actions pattern from #19 to `/collection`. Add / +/- / remove all go through server form actions, the loader pre-fetches card metadata, and the add-modal state is driven by URL params (`?add=1&addSearch=…&selectedCard=…`). With JS, `use:enhance` layers inline updates on top. One-line comments in each file explain why option (b) (in-page modal via query params) was picked.

### 2. /browse sort dropdown — 10 modes
Sort select in the existing filter form. Two kinds of sort:

**API-kind (server-paginated, infinite scroll):**
- Newest first (default) / Oldest first (release date)
- Name A–Z / Z–A
- Price high to low / low to high (via `cardmarket.prices.averageSellPrice`)
- Rarity A–Z (alphabetical — TCG API has no rarity tiering)
- Card number

**Client-kind (filter + sort in-memory, from TCGPlayer printing data on the fetched page):**
- **Biggest Spread** — market − low on the headline printing, descending. Uses `market - low` not `high - low` because TCGPlayer's `high` is polluted with $9999 outlier listings. Drops cards with < $0.50 spread so pennies don't dominate.
- **Bulk Hunt (under $1)** — headline market < $1, ascending. Shows the drop count in the footer.

Client-kind sorts run on the **server**, not in the browser, so no-JS and JS paths return identical already-sorted results and there's no duplicated logic. They also fetch up to 250 cards in one shot (TCG API max) so infinite scroll naturally disables.

The URL-value → behavior mapping lives in a new `$services/sort` module shared by the browse loader, `/api/cards`, and the browse page itself.

## Test plan

### /collection
Playwright multi-browser script (created, run, deleted — not committed) against `http://localhost:5179`:
- [x] Chromium JS off / JS on — add → row in DB → + → qty=2 → remove → row gone
- [x] Firefox JS off / JS on — same flow
- [x] WebKit JS off / JS on — same flow

Authoritative row state checked against Supabase via the service-role key between steps. All six pass.

### /browse sort
- [x] `?set=base1&sort=price_high` → Charizard ($1954), Venusaur ($374), Raichu ($324), Alakazam ($183), Mewtwo ($163)
- [x] `?set=base1&sort=name` → Abra, Alakazam, Arcanine, Beedrill, Bill
- [x] `?set=base1&sort=spread` → Blastoise, Mewtwo, Venusaur, Raichu, Magneton (77 cards, 25 hidden)
- [x] `?set=base1&sort=bulk` → Potion ($0.25), Energy Removal ($0.32), Switch ($0.33), Bill, Gust of Wind (36 cards)
- [x] Server-rendered HTML (raw `curl`) matches in-browser order — no-JS path works
- [x] `/api/cards?q=set.id:base1&sort=spread` returns the same 77 cards with `totalCount: 77` (infinite scroll disabled)
- [x] `/api/cards?q=set.id:base1&sort=name` returns 102 total (api-kind sort still server-paginates)
- [x] Sort select value persists across navigation

### After merge
- [ ] Wait for Vercel deploy (~30s)
- [ ] Smoke test /collection on rsmc.tech — add / bump / remove with JS off
- [ ] Smoke test /browse — price_high, spread, bulk modes on Base Set

## What's not in this PR (flagged for follow-up)
- **Supabase card catalog** from #15 (migration 003, `scripts/ingest-catalog.ts`, `supabase-admin.ts`, `catalog.ts` with live-API fallback). That's a bigger unrelated feature; worth shipping as its own PR on top of current `main`.
- `/watchlist` and `/grading` pages still use `fetch` for mutations — same no-JS problem as `/collection` before this PR. Watchlist is small and straightforward; grading is a bigger surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)