### PR TITLE
feat: Phase 1 per-condition pricing — NM/LP/MP/HP/DMG ladder from TCGPlayer listings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@sveltejs/adapter-vercel": "^5.0.0",
 				"@sveltejs/kit": "^2.0.0",
 				"@tailwindcss/vite": "^4.0.0",
+				"@vitest/ui": "^4.1.4",
 				"dotenv": "^17.4.2",
 				"eslint": "^9.0.0",
 				"eslint-config-prettier": "^9.0.0",
@@ -25,7 +26,8 @@
 				"svelte-check": "^4.0.0",
 				"tailwindcss": "^4.0.0",
 				"tsx": "^4.21.0",
-				"typescript": "^5.0.0"
+				"typescript": "^5.0.0",
+				"vitest": "^4.1.4"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -832,7 +834,6 @@
 			"integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			}
@@ -868,7 +869,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -886,7 +886,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -904,7 +903,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -922,7 +920,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -940,7 +937,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -958,7 +954,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -976,7 +971,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -994,7 +988,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1012,7 +1005,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1030,7 +1022,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1048,7 +1039,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1066,7 +1056,6 @@
 			"os": [
 				"openharmony"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1081,7 +1070,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@napi-rs/wasm-runtime": "^1.1.1"
 			},
@@ -1102,7 +1090,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1120,7 +1107,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
@@ -1130,8 +1116,7 @@
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
 			"integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "5.3.0",
@@ -2103,10 +2088,28 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2188,6 +2191,151 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+			"integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+			"integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/mocker/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+			"integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+			"integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.4",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+			"integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+			"integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/ui": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
+			"integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.4",
+				"fflate": "^0.8.2",
+				"flatted": "^3.4.2",
+				"pathe": "^2.0.3",
+				"sirv": "^3.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"vitest": "4.1.4"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+			"integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.4",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/abbrev": {
@@ -2306,6 +2454,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/async-sema": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
@@ -2359,6 +2517,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chalk": {
@@ -2462,6 +2630,13 @@
 			"engines": {
 				"node": "^14.18.0 || >=16.10.0"
 			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -2594,6 +2769,13 @@
 			"engines": {
 				"node": ">=10.13.0"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.7",
@@ -2893,6 +3075,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2931,6 +3123,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
@@ -3812,8 +4011,7 @@
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -3921,6 +4119,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -4156,7 +4361,6 @@
 			"integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@oxc-project/types": "=0.122.0",
 				"@rolldown/pluginutils": "1.0.0-rc.11"
@@ -4241,6 +4445,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4278,6 +4489,20 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "5.1.2",
@@ -4575,13 +4800,29 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
 			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fdir": "^6.5.0",
 				"picomatch": "^4.0.3"
@@ -4591,6 +4832,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/totalist": {
@@ -4692,7 +4943,6 @@
 			"integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.3",
@@ -4786,6 +5036,96 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+			"integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.4",
+				"@vitest/mocker": "4.1.4",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/runner": "4.1.4",
+				"@vitest/snapshot": "4.1.4",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.4",
+				"@vitest/browser-preview": "4.1.4",
+				"@vitest/browser-webdriverio": "4.1.4",
+				"@vitest/coverage-istanbul": "4.1.4",
+				"@vitest/coverage-v8": "4.1.4",
+				"@vitest/ui": "4.1.4",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -4818,6 +5158,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-vercel": "^5.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@tailwindcss/vite": "^4.0.0",
+		"@vitest/ui": "^4.1.4",
 		"dotenv": "^17.4.2",
 		"eslint": "^9.0.0",
 		"eslint-config-prettier": "^9.0.0",
@@ -25,7 +28,8 @@
 		"svelte-check": "^4.0.0",
 		"tailwindcss": "^4.0.0",
 		"tsx": "^4.21.0",
-		"typescript": "^5.0.0"
+		"typescript": "^5.0.0",
+		"vitest": "^4.1.4"
 	},
 	"type": "module",
 	"dependencies": {

--- a/scripts/ingest-condition-prices.ts
+++ b/scripts/ingest-condition-prices.ts
@@ -1,0 +1,474 @@
+#!/usr/bin/env tsx
+/**
+ * Trove — per-condition price ingestion (Phase 1)
+ *
+ * Walks tracked sets (or a subset via --set / --card / --limit), resolves
+ * each card_index row to a TCGPlayer productId, fetches active listings,
+ * writes confident events to sale_events, then derives today's snapshot in
+ * condition_price_snapshots per (card_id, condition).
+ *
+ * Usage:
+ *   tsx scripts/ingest-condition-prices.ts --card base1-4       # one card
+ *   tsx scripts/ingest-condition-prices.ts --set base1          # one set
+ *   tsx scripts/ingest-condition-prices.ts --limit 20           # first 20 cards (debug)
+ *   tsx scripts/ingest-condition-prices.ts --all                # everything tracked
+ *   tsx scripts/ingest-condition-prices.ts --dry-run            # no writes
+ *   tsx scripts/ingest-condition-prices.ts --no-resume          # rescrape today's cards
+ *
+ * Env vars required (.env.local):
+ *   PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY   (or PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY)
+ *
+ * Optional:
+ *   POKEMON_TCG_API_KEY — improves rate limits on productId resolution
+ */
+
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+import {
+	fetchTCGPlayerListings,
+	type TCGListing
+} from '../src/lib/services/tcgplayer-listings-scraper.js';
+import { MIN_SNAPSHOT_CONFIDENCE } from '../src/lib/services/condition-detector.js';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY =
+	process.env.SUPABASE_SERVICE_ROLE_KEY ??
+	process.env.PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ??
+	'';
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+	console.error('Missing SUPABASE_URL or SUPABASE_KEY. Check .env.local');
+	process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+// ---------------------------------------------------------------------------
+// Tuning knobs
+// ---------------------------------------------------------------------------
+
+const PER_CARD_LIMIT = 200; // max listings pulled per card (endpoint hard-ish cap)
+const PER_CARD_DELAY_MS = 200; // roadmap: 200ms polite delay between cards
+const MAX_RETRIES = 4;
+const BATCH_SIZE = 50; // sale_events insert batch
+
+// Events older than this are excluded from today's snapshot math.
+const SNAPSHOT_WINDOW_DAYS = 30;
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface CliOptions {
+	setIds?: string[];
+	cardId?: string;
+	limit?: number;
+	all: boolean;
+	dryRun: boolean;
+	resume: boolean;
+}
+
+function parseCli(): CliOptions {
+	const { values } = parseArgs({
+		options: {
+			set: { type: 'string' },
+			card: { type: 'string' },
+			limit: { type: 'string' },
+			all: { type: 'boolean', default: false },
+			'dry-run': { type: 'boolean', default: false },
+			'no-resume': { type: 'boolean', default: false }
+		},
+		strict: false
+	});
+	return {
+		setIds: values.set ? String(values.set).split(',').map((s) => s.trim()) : undefined,
+		cardId: values.card ? String(values.card) : undefined,
+		limit: values.limit ? parseInt(String(values.limit), 10) : undefined,
+		all: !!values.all,
+		dryRun: !!values['dry-run'],
+		resume: !values['no-resume']
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Card loading
+// ---------------------------------------------------------------------------
+
+interface CardRow {
+	card_id: string;
+	name: string;
+	set_id: string;
+	set_name: string;
+	card_number: string | null;
+}
+
+async function loadCards(opts: CliOptions): Promise<CardRow[]> {
+	if (opts.cardId) {
+		const { data, error } = await supabase
+			.from('card_index')
+			.select('card_id, name, set_id, set_name, card_number')
+			.eq('card_id', opts.cardId)
+			.limit(1);
+		if (error) throw error;
+		return (data ?? []) as CardRow[];
+	}
+
+	let query = supabase
+		.from('card_index')
+		.select('card_id, name, set_id, set_name, card_number')
+		.order('card_id', { ascending: true });
+
+	if (opts.setIds && opts.setIds.length > 0) {
+		query = query.in('set_id', opts.setIds);
+	} else if (opts.all) {
+		// walk all tracked sets
+		const { data: tracked } = await supabase
+			.from('tracked_sets')
+			.select('set_id')
+			.eq('enabled', true);
+		const ids = (tracked ?? []).map((r: { set_id: string }) => r.set_id);
+		if (ids.length === 0) return [];
+		query = query.in('set_id', ids);
+	} else {
+		// no filter: just cap via limit flag so accidental runs don't scrape
+		// the entire tracked universe
+	}
+
+	if (opts.limit != null) query = query.limit(opts.limit);
+
+	const { data, error } = await query;
+	if (error) throw error;
+	return (data ?? []) as CardRow[];
+}
+
+// ---------------------------------------------------------------------------
+// productId resolution (pokemontcg.io redirect → /product/{id}/…)
+// ---------------------------------------------------------------------------
+
+const productIdCache = new Map<string, string | null>();
+
+async function resolveProductId(cardId: string): Promise<string | null> {
+	if (productIdCache.has(cardId)) return productIdCache.get(cardId) ?? null;
+	try {
+		const res = await fetch(`https://prices.pokemontcg.io/tcgplayer/${cardId}`, {
+			redirect: 'manual',
+			headers: {
+				'User-Agent':
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36'
+			}
+		});
+		const location = res.headers.get('location');
+		const match = location?.match(/\/product\/(\d+)(?:[\/?]|$)/);
+		const pid = match?.[1] ?? null;
+		productIdCache.set(cardId, pid);
+		return pid;
+	} catch {
+		productIdCache.set(cardId, null);
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resume: skip cards already ingested today
+// ---------------------------------------------------------------------------
+
+async function alreadyIngestedToday(cardId: string): Promise<boolean> {
+	const startOfDay = new Date();
+	startOfDay.setHours(0, 0, 0, 0);
+	const { count, error } = await supabase
+		.from('sale_events')
+		.select('id', { head: true, count: 'exact' })
+		.eq('card_id', cardId)
+		.eq('marketplace', 'tcgplayer')
+		.gte('observed_at', startOfDay.toISOString());
+	if (error) return false;
+	return (count ?? 0) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Scrape + write
+// ---------------------------------------------------------------------------
+
+async function withBackoff<T>(fn: () => Promise<T>): Promise<T | null> {
+	let delayMs = 400;
+	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			if (attempt === MAX_RETRIES) {
+				console.error(`    giving up: ${(err as Error).message}`);
+				return null;
+			}
+			await sleep(delayMs);
+			delayMs *= 2;
+		}
+	}
+	return null;
+}
+
+interface SaleEventRow {
+	card_id: string;
+	marketplace: string;
+	external_id: string | null;
+	title: string | null;
+	price_cents: number;
+	currency: string;
+	condition: string | null;
+	condition_confidence: number | null;
+	event_type: 'listing' | 'sold';
+	observed_at: string;
+}
+
+function listingsToEvents(cardId: string, listings: TCGListing[], now: string): SaleEventRow[] {
+	return listings.map((l) => ({
+		card_id: cardId,
+		marketplace: 'tcgplayer',
+		external_id: l.listingId,
+		title: buildTitle(l),
+		price_cents: l.price_cents,
+		currency: 'USD',
+		// NULL out low-confidence conditions so the check constraint is happy
+		// AND the aggregate filter excludes them. The raw condition string is
+		// still preserved in `title` for future re-analysis.
+		condition:
+			l.condition != null && l.confidence >= MIN_SNAPSHOT_CONFIDENCE ? l.condition : null,
+		condition_confidence: l.confidence > 0 ? roundTo(l.confidence, 2) : null,
+		event_type: 'listing',
+		observed_at: now
+	}));
+}
+
+function buildTitle(l: TCGListing): string {
+	const bits: string[] = [];
+	if (l.printing) bits.push(l.printing);
+	if (l.rawCondition) bits.push(l.rawCondition);
+	if (l.seller) bits.push(`by ${l.seller}`);
+	return bits.join(' | ');
+}
+
+async function insertEvents(rows: SaleEventRow[], dryRun: boolean): Promise<number> {
+	if (rows.length === 0) return 0;
+	if (dryRun) return rows.length;
+
+	let written = 0;
+	for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+		const batch = rows.slice(i, i + BATCH_SIZE);
+		// Plain insert. Same-day reruns are blocked by `alreadyIngestedToday`,
+		// and within a single run the scraper already dedupes by listingId.
+		// The partial unique index on (marketplace, external_id) is a
+		// belt-and-suspenders safety net — Supabase can't target it from
+		// `.upsert()` because partial indexes aren't full constraints.
+		const { error, count } = await supabase
+			.from('sale_events')
+			.insert(batch, { count: 'exact' });
+		if (error) {
+			console.error(`    insert error: ${error.message}`);
+			continue;
+		}
+		written += count ?? batch.length;
+	}
+	return written;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot derivation
+// ---------------------------------------------------------------------------
+
+interface SnapshotRow {
+	card_id: string;
+	condition: string;
+	snapshot_date: string;
+	median_cents: number;
+	p25_cents: number;
+	p75_cents: number;
+	sample_count: number;
+	freshness_score: number;
+}
+
+async function computeSnapshots(cardId: string): Promise<SnapshotRow[]> {
+	const windowStart = new Date(Date.now() - SNAPSHOT_WINDOW_DAYS * 86_400_000).toISOString();
+	const { data, error } = await supabase
+		.from('sale_events')
+		.select('condition, price_cents, observed_at')
+		.eq('card_id', cardId)
+		.gte('observed_at', windowStart)
+		.not('condition', 'is', null);
+	if (error) {
+		console.error(`    snapshot query error: ${error.message}`);
+		return [];
+	}
+
+	const buckets = new Map<
+		string,
+		Array<{ price: number; age_days: number }>
+	>();
+	const today = new Date();
+	for (const row of (data ?? []) as Array<{
+		condition: string;
+		price_cents: number;
+		observed_at: string;
+	}>) {
+		const ageDays = (today.getTime() - new Date(row.observed_at).getTime()) / 86_400_000;
+		const arr = buckets.get(row.condition) ?? [];
+		arr.push({ price: row.price_cents, age_days: ageDays });
+		buckets.set(row.condition, arr);
+	}
+
+	const snapshotDate = today.toISOString().slice(0, 10);
+	const snapshots: SnapshotRow[] = [];
+	for (const [condition, rows] of buckets) {
+		const sorted = rows.slice().sort((a, b) => a.price - b.price);
+		const median = percentile(sorted.map((r) => r.price), 50);
+		const p25 = percentile(sorted.map((r) => r.price), 25);
+		const p75 = percentile(sorted.map((r) => r.price), 75);
+		// Linear freshness: events age 0 = 1.0, age 30 = 0.0
+		const freshness =
+			rows.reduce(
+				(sum, r) => sum + Math.max(0, 1 - r.age_days / SNAPSHOT_WINDOW_DAYS),
+				0
+			) / rows.length;
+		snapshots.push({
+			card_id: cardId,
+			condition,
+			snapshot_date: snapshotDate,
+			median_cents: Math.round(median),
+			p25_cents: Math.round(p25),
+			p75_cents: Math.round(p75),
+			sample_count: rows.length,
+			freshness_score: roundTo(freshness, 2)
+		});
+	}
+	return snapshots;
+}
+
+async function upsertSnapshots(snapshots: SnapshotRow[], dryRun: boolean): Promise<number> {
+	if (snapshots.length === 0 || dryRun) return snapshots.length;
+	const { error } = await supabase
+		.from('condition_price_snapshots')
+		.upsert(snapshots, { onConflict: 'card_id,condition,snapshot_date' });
+	if (error) {
+		console.error(`    snapshot upsert error: ${error.message}`);
+		return 0;
+	}
+	return snapshots.length;
+}
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+async function processCard(card: CardRow, opts: CliOptions): Promise<'ok' | 'skip' | 'noid' | 'empty' | 'err'> {
+	if (opts.resume && (await alreadyIngestedToday(card.card_id))) return 'skip';
+
+	const productId = await resolveProductId(card.card_id);
+	if (!productId) return 'noid';
+
+	const result = await withBackoff(() =>
+		fetchTCGPlayerListings({ productId, limit: PER_CARD_LIMIT })
+	);
+	if (!result || result.listings.length === 0) return 'empty';
+
+	const now = new Date().toISOString();
+	const events = listingsToEvents(card.card_id, result.listings, now);
+	const written = await insertEvents(events, opts.dryRun);
+	const snapshots = await computeSnapshots(card.card_id);
+	const snapWritten = await upsertSnapshots(snapshots, opts.dryRun);
+
+	const splits = summariseSnapshots(snapshots);
+	console.log(
+		`  [${card.card_id}] ${card.name}: ${written} events, ${snapWritten} snapshots — ${splits}`
+	);
+	return 'ok';
+}
+
+function summariseSnapshots(snapshots: SnapshotRow[]): string {
+	if (snapshots.length === 0) return 'no-confident-conditions';
+	return snapshots
+		.sort(conditionOrder)
+		.map(
+			(s) =>
+				`${s.condition} $${(s.median_cents / 100).toFixed(2)} n=${s.sample_count}` +
+				(s.sample_count < 10 ? '*' : '')
+		)
+		.join(' / ');
+}
+
+const CONDITION_ORDER: Record<string, number> = { NM: 0, LP: 1, MP: 2, HP: 3, DMG: 4 };
+function conditionOrder(a: { condition: string }, b: { condition: string }): number {
+	return (CONDITION_ORDER[a.condition] ?? 9) - (CONDITION_ORDER[b.condition] ?? 9);
+}
+
+async function main(): Promise<void> {
+	const opts = parseCli();
+	const cards = await loadCards(opts);
+	if (cards.length === 0) {
+		console.log('No cards matched. Use --card, --set, --all, or --limit.');
+		return;
+	}
+
+	console.log(
+		`Ingesting condition prices for ${cards.length} card(s)` +
+			(opts.dryRun ? ' [DRY RUN]' : '') +
+			(opts.resume ? ' [resume on]' : ' [resume off]')
+	);
+
+	const counts = { ok: 0, skip: 0, noid: 0, empty: 0, err: 0 };
+	const start = Date.now();
+
+	for (let i = 0; i < cards.length; i++) {
+		const card = cards[i];
+		try {
+			const outcome = await processCard(card, opts);
+			counts[outcome]++;
+		} catch (err) {
+			counts.err++;
+			console.error(`  [${card.card_id}] ${(err as Error).message}`);
+		}
+		if (i < cards.length - 1) await sleep(PER_CARD_DELAY_MS);
+
+		if ((i + 1) % 25 === 0) {
+			const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+			console.log(
+				`  progress: ${i + 1}/${cards.length}  (${elapsed}s)  ok=${counts.ok} ` +
+					`skip=${counts.skip} noid=${counts.noid} empty=${counts.empty} err=${counts.err}`
+			);
+		}
+	}
+
+	const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+	console.log(
+		`\nDone in ${elapsed}s — ok=${counts.ok} skip=${counts.skip} ` +
+			`noid=${counts.noid} empty=${counts.empty} err=${counts.err}`
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+function percentile(sortedAsc: number[], p: number): number {
+	if (sortedAsc.length === 0) return 0;
+	const idx = Math.min(
+		sortedAsc.length - 1,
+		Math.max(0, Math.floor((p / 100) * (sortedAsc.length - 1)))
+	);
+	return sortedAsc[idx];
+}
+
+function roundTo(n: number, places: number): number {
+	const m = 10 ** places;
+	return Math.round(n * m) / m;
+}
+
+main().catch((err) => {
+	console.error('fatal:', err);
+	process.exit(1);
+});

--- a/scripts/verify-listings-scraper.ts
+++ b/scripts/verify-listings-scraper.ts
@@ -1,0 +1,130 @@
+/**
+ * Phase 1 verification: TCGPlayer listings scraper dry-run
+ *
+ * Walks a small fixed set of Pokemon TCG API card_ids, resolves each to
+ * its TCGPlayer productId (via the pokemontcg.io /tcgplayer redirect),
+ * then runs fetchTCGPlayerListings({ dryRun: true }) against each.
+ *
+ * This is the gate before writing scripts/ingest-condition-prices.ts —
+ * if the scraper returns zero listings or the condition split looks
+ * nonsensical, fix the scraper first.
+ *
+ * Run with:
+ *   npx tsx scripts/verify-listings-scraper.ts
+ */
+
+import { fetchTCGPlayerListings } from '../src/lib/services/tcgplayer-listings-scraper';
+
+const TEST_CARDS = [
+	{ card_id: 'base1-4', name: 'Charizard (Base Set Holo)' },
+	{ card_id: 'base1-2', name: 'Blastoise (Base Set Holo)' },
+	{ card_id: 'base1-15', name: 'Venusaur (Base Set Holo)' },
+	{ card_id: 'sm4-54', name: 'Gardevoir GX (SM Crimson Invasion)' },
+	{ card_id: 'swsh45-18', name: 'Pikachu V (Shining Fates)' }
+];
+
+/**
+ * Resolve a Pokemon TCG API card_id → TCGPlayer productId.
+ * pokemontcg.io exposes a redirect: /tcgplayer/{card_id} → TCGPlayer URL.
+ * We follow the redirect manually and extract /product/{id}/ from the
+ * Location header so we don't pay the full HTML page fetch.
+ */
+async function resolveProductId(cardId: string): Promise<string | null> {
+	const redirectUrl = `https://prices.pokemontcg.io/tcgplayer/${cardId}`;
+	try {
+		const res = await fetch(redirectUrl, {
+			redirect: 'manual',
+			headers: {
+				'User-Agent':
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36'
+			}
+		});
+		const location = res.headers.get('location');
+		if (!location) return null;
+		const match = location.match(/\/product\/(\d+)(?:[\/?]|$)/);
+		return match?.[1] ?? null;
+	} catch (err) {
+		console.error(`  resolve failed: ${(err as Error).message}`);
+		return null;
+	}
+}
+
+async function main(): Promise<void> {
+	console.log('Phase 1 verification — TCGPlayer listings scraper dry-run\n');
+	console.log(`${'card_id'.padEnd(16)} ${'productId'.padEnd(10)} ${'source'.padEnd(7)} result`);
+	console.log('─'.repeat(80));
+
+	let apiHits = 0;
+	let htmlHits = 0;
+	let misses = 0;
+
+	for (const c of TEST_CARDS) {
+		const productId = await resolveProductId(c.card_id);
+		if (!productId) {
+			console.log(`${c.card_id.padEnd(16)} ${'—'.padEnd(10)} —       no product resolved (${c.name})`);
+			misses++;
+			continue;
+		}
+
+		// Real (non-dry-run) first so we can see the actual split, then
+		// explicitly call dry-run once to verify the dry-run branch prints
+		// but returns empty.
+		const real = await fetchTCGPlayerListings({ productId, limit: 50 });
+		const summary = summarise(real.listings);
+		console.log(
+			`${c.card_id.padEnd(16)} ${productId.padEnd(10)} ${real.source.padEnd(7)} ` +
+				`${real.listings.length} listings | ${summary}`
+		);
+
+		if (real.source === 'api') apiHits++;
+		else if (real.source === 'html') htmlHits++;
+		else misses++;
+
+		// Dry-run path sanity check (logs summary, returns empty)
+		const dry = await fetchTCGPlayerListings({ productId, limit: 5, dryRun: true });
+		if (dry.listings.length !== 0) {
+			console.error('  ⚠️  dryRun did not return empty — scraper contract violated');
+		}
+
+		// 300ms politeness between cards
+		await sleep(300);
+	}
+
+	console.log('\nSummary');
+	console.log(`  api=${apiHits}  html=${htmlHits}  miss=${misses}`);
+
+	if (apiHits + htmlHits === 0) {
+		console.log('\n❌ No listings returned from any source. Fix the scraper before proceeding.');
+		process.exit(1);
+	}
+	if (misses > 0) {
+		console.log(`\n⚠️  ${misses} card(s) returned nothing — investigate before full ingestion.`);
+	}
+	console.log('\n✅ Verification passed. Safe to write the ingestion script.');
+}
+
+function summarise(listings: Array<{ condition: string | null; price_cents: number }>): string {
+	if (listings.length === 0) return '(no listings)';
+	const buckets: Record<string, number[]> = {};
+	for (const l of listings) {
+		const k = l.condition ?? 'unknown';
+		(buckets[k] ||= []).push(l.price_cents);
+	}
+	return Object.entries(buckets)
+		.sort(([, a], [, b]) => b.length - a.length)
+		.map(([k, prices]) => {
+			const sorted = prices.slice().sort((a, b) => a - b);
+			const median = sorted[Math.floor(sorted.length / 2)];
+			return `${k} n=${prices.length} med=$${(median / 100).toFixed(2)}`;
+		})
+		.join(', ');
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+main().catch((err) => {
+	console.error('fatal:', err);
+	process.exit(1);
+});

--- a/src/lib/services/__tests__/condition-detector.test.ts
+++ b/src/lib/services/__tests__/condition-detector.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+import {
+	inferCondition,
+	MIN_SNAPSHOT_CONFIDENCE,
+	type Condition,
+	type ConditionInference
+} from '../condition-detector';
+
+// ─── Canonical TCGPlayer phrasing ──────────────────────────────────────────
+describe('canonical TCGPlayer phrases', () => {
+	const tcgCases: Array<[string, Condition]> = [
+		['Charizard Base Set — Near Mint', 'NM'],
+		['Pikachu Illustrator Lightly Played', 'LP'],
+		['Blastoise 1st Edition Moderately Played', 'MP'],
+		['Venusaur Shadowless Heavily Played', 'HP'],
+		['Gyarados 1999 Damaged', 'DMG']
+	];
+
+	for (const [title, expected] of tcgCases) {
+		it(`${expected} ← "${title}"`, () => {
+			const out = inferCondition(title);
+			expect(out.condition).toBe(expected);
+			expect(out.confidence).toBeGreaterThanOrEqual(0.9);
+		});
+	}
+});
+
+// ─── eBay free-text descriptions ───────────────────────────────────────────
+describe('eBay descriptive phrasing', () => {
+	const cases: Array<[string, Condition, number]> = [
+		['pack fresh charizard base set holo', 'NM', 0.9],
+		['excellent condition mewtwo base set', 'NM', 0.7],
+		['mint condition jolteon jungle set', 'NM', 0.85],
+		['pristine blastoise shadowless', 'NM', 0.85],
+		['minor whitening on edges', 'LP', 0.75],
+		['light wear on corners, still great', 'LP', 0.8],
+		['very good condition with some edge wear', 'LP', 0.7],
+		['moderate wear on edges', 'MP', 0.8],
+		['played condition, some scratches', 'MP', 0.75],
+		['heavy wear, still playable', 'HP', 0.8],
+		['card is damaged, crease on surface', 'DMG', 0.9]
+	];
+
+	for (const [title, expected, minConf] of cases) {
+		it(`${expected} ← "${title}"`, () => {
+			const out = inferCondition(title);
+			expect(out.condition).toBe(expected);
+			expect(out.confidence).toBeGreaterThanOrEqual(minConf);
+		});
+	}
+});
+
+// ─── Contextual abbreviations ──────────────────────────────────────────────
+describe('condition-context abbreviations', () => {
+	const cases: Array<[string, Condition]> = [
+		['Charizard Base Set Condition: NM', 'NM'],
+		['Pikachu Jungle cond: LP', 'LP'],
+		['Venusaur Base Grade: MP', 'MP'],
+		['Blastoise Condition - HP', 'HP'],
+		['Gyarados 1st Ed Condition: DMG', 'DMG'],
+		['Charizard (NM) Unlimited', 'NM'],
+		['Mewtwo Base (LP)', 'LP'],
+		['Raichu Jungle (MP)', 'MP']
+	];
+
+	for (const [title, expected] of cases) {
+		it(`${expected} ← "${title}"`, () => {
+			const out = inferCondition(title);
+			expect(out.condition).toBe(expected);
+			expect(out.confidence).toBeGreaterThanOrEqual(0.85);
+		});
+	}
+
+	it('NM/LP range → conservative LP', () => {
+		expect(inferCondition('Charizard Holo NM/LP').condition).toBe('LP');
+	});
+
+	it('MP/HP range → conservative HP', () => {
+		expect(inferCondition('Venusaur 1st Ed MP/HP').condition).toBe('HP');
+	});
+});
+
+// ─── False-positive traps ──────────────────────────────────────────────────
+describe('false positive filters', () => {
+	it('"Charizard 120 HP" (hit points) should NOT be HP condition', () => {
+		const out = inferCondition('Charizard Base Set Holo 120 HP #4 Unlimited');
+		expect(out.condition).not.toBe('HP');
+	});
+
+	it('"damaged box" → card condition is NOT DMG', () => {
+		const out = inferCondition('Charizard Box Set SEALED - damaged box, card is NM');
+		// It should match NM (card condition) rather than DMG (box)
+		expect(out.condition).toBe('NM');
+	});
+
+	it('"box is damaged" → card condition is NOT DMG', () => {
+		const out = inferCondition('Pikachu plush — box is damaged but card lightly played');
+		expect(out.condition).toBe('LP');
+	});
+
+	it('"damaged sleeve" → not DMG', () => {
+		const out = inferCondition('Blastoise — damaged sleeve, card near mint');
+		expect(out.condition).toBe('NM');
+	});
+
+	it('"heavy shipping" → not HP', () => {
+		const out = inferCondition('Rare card — heavy shipping fees');
+		// No actual condition signal, should return null
+		expect(out.condition).toBe(null);
+	});
+
+	it('card named "Mint" inside set name does not auto-trigger NM', () => {
+		// Only "mint condition" / "gem mint" / "near mint" / "pack fresh" /
+		// "pristine" should fire NM. Standalone "Mint" as a word in a
+		// set/product name shouldn't.
+		const out = inferCondition('Pokemon Jungle Mint Pack Opening Video');
+		// We don't match bare "mint" — so null here.
+		expect(out.condition).toBe(null);
+	});
+});
+
+// ─── Nulls / empties / garbage ─────────────────────────────────────────────
+describe('inconclusive inputs', () => {
+	const nullCases = [
+		'',
+		'   ',
+		'Charizard Base Set Holo 1999',
+		'Pokemon card for sale',
+		'Rare vintage holo'
+	];
+
+	for (const title of nullCases) {
+		it(`null ← "${title}"`, () => {
+			const out = inferCondition(title);
+			expect(out.condition).toBe(null);
+			expect(out.confidence).toBe(0);
+		});
+	}
+
+	it('non-string input returns null safely', () => {
+		// @ts-expect-error intentionally wrong type
+		expect(inferCondition(null).condition).toBe(null);
+		// @ts-expect-error intentionally wrong type
+		expect(inferCondition(undefined).condition).toBe(null);
+	});
+});
+
+// ─── Accuracy benchmark on hand-labeled corpus ─────────────────────────────
+// Target from the roadmap: >95% accuracy on 100 hand-labeled titles.
+// This mixed corpus mimics real TCGPlayer + eBay surface forms.
+describe('benchmark: hand-labeled 100-title corpus', () => {
+	const corpus: Array<[string, Condition | null]> = [
+		// ─── NM (25) ───
+		['Charizard Base Set Holo Near Mint', 'NM'],
+		['Pikachu Illustrator NEAR MINT', 'NM'],
+		['Blastoise Near-Mint 1st Edition', 'NM'],
+		['Mewtwo Base Unlimited - Near Mint', 'NM'],
+		['Venusaur Shadowless, Near Mint Condition', 'NM'],
+		['Gyarados Base Pack Fresh', 'NM'],
+		['Raichu Jungle pristine condition', 'NM'],
+		['Alakazam Base Gem Mint copy', 'NM'],
+		['Machamp 1st Ed Mint Condition', 'NM'],
+		['Zapdos Fossil - excellent condition', 'NM'],
+		['Articuno Fossil Near Mint Holo', 'NM'],
+		['Moltres Fossil NM', 'NM'],
+		['Dragonite Fossil Condition: NM', 'NM'],
+		['Clefairy Base (NM)', 'NM'],
+		['Nidoking Base NM/M', 'NM'],
+		['Poliwrath Base Near Mint 1999 WOTC', 'NM'],
+		['Chansey Base NEAR MINT holo PSA worthy', 'NM'],
+		['Hitmonchan Base - pack fresh, straight from booster', 'NM'],
+		['Magneton Fossil pristine', 'NM'],
+		['Electabuzz Base near mint condition', 'NM'],
+		['Scyther Jungle - excellent condition, centered', 'NM'],
+		['Flareon Jungle Holo NM', 'NM'],
+		['Vaporeon Jungle (NM)', 'NM'],
+		['Jolteon Jungle Near Mint straight out of pack', 'NM'],
+		['Snorlax Jungle Gem Mint Candidate', 'NM'],
+
+		// ─── LP (20) ───
+		['Charizard Base Lightly Played', 'LP'],
+		['Blastoise Shadowless LIGHTLY PLAYED', 'LP'],
+		['Venusaur Base Lightly-Played', 'LP'],
+		['Mewtwo Base light wear on corners', 'LP'],
+		['Pikachu Illustrator - minor wear', 'LP'],
+		['Gyarados 1st Ed minor whitening', 'LP'],
+		['Dragonite Fossil LP', 'LP'],
+		['Machamp 1st Ed (LP)', 'LP'],
+		['Alakazam Base cond: LP', 'LP'],
+		['Ninetales Base very good condition', 'LP'],
+		['Raichu Jungle NM/LP', 'LP'],
+		['Scyther Jungle - light play', 'LP'],
+		['Electabuzz Base Lightly Played', 'LP'],
+		['Hitmonchan Base Lightly Played holo', 'LP'],
+		['Zapdos Fossil Condition - LP', 'LP'],
+		['Articuno Fossil minor edge whitening', 'LP'],
+		['Moltres Fossil - light wear, centered', 'LP'],
+		['Snorlax Jungle Lightly Played 1st edition', 'LP'],
+		['Flareon Jungle very good condition overall', 'LP'],
+		['Vaporeon Jungle minor wear on back', 'LP'],
+
+		// ─── MP (20) ───
+		['Charizard Base Moderately Played', 'MP'],
+		['Blastoise Base MODERATELY PLAYED', 'MP'],
+		['Venusaur Shadowless - moderate wear', 'MP'],
+		['Mewtwo Base played condition', 'MP'],
+		['Pikachu Illustrator moderate wear on corners', 'MP'],
+		['Gyarados Base Moderately-Played', 'MP'],
+		['Dragonite Fossil MP', 'MP'],
+		['Machamp 1st Ed (MP)', 'MP'],
+		['Alakazam Base Cond: MP', 'MP'],
+		['Raichu Jungle LP/MP', 'MP'],
+		['Scyther Jungle moderate play', 'MP'],
+		['Electabuzz Base Moderately Played holo', 'MP'],
+		['Hitmonchan Base played condition 1st ed', 'MP'],
+		['Zapdos Fossil Grade: MP', 'MP'],
+		['Articuno Fossil moderate wear on edges', 'MP'],
+		['Moltres Fossil - played condition overall', 'MP'],
+		['Snorlax Jungle Moderately Played 1st ed', 'MP'],
+		['Flareon Jungle - moderate wear on back', 'MP'],
+		['Vaporeon Jungle played condition', 'MP'],
+		['Jolteon Jungle Moderately Played', 'MP'],
+
+		// ─── HP (15) ───
+		['Charizard Base Heavily Played', 'HP'],
+		['Blastoise Base HEAVILY PLAYED', 'HP'],
+		['Venusaur Base - heavy wear', 'HP'],
+		['Mewtwo Base Heavily-Played', 'HP'],
+		['Gyarados Base Heavy Play wear visible', 'HP'],
+		['Dragonite Fossil - heavy wear on edges', 'HP'],
+		['Machamp 1st Ed Condition: HP', 'HP'],
+		['Alakazam Base (HP)', 'HP'],
+		['Raichu Jungle MP/HP', 'HP'],
+		['Scyther Jungle Heavily Played', 'HP'],
+		['Electabuzz Base heavy wear holo', 'HP'],
+		['Zapdos Fossil Heavily Played', 'HP'],
+		['Snorlax Jungle HEAVY WEAR visible', 'HP'],
+		['Flareon Jungle Heavily Played', 'HP'],
+		['Vaporeon Jungle heavy play, creases', 'HP'],
+
+		// ─── DMG (10) ───
+		['Charizard Base Damaged', 'DMG'],
+		['Blastoise Base - poor condition, tear', 'DMG'],
+		['Venusaur Base DAMAGED crease', 'DMG'],
+		['Mewtwo Base Damaged with bent corner', 'DMG'],
+		['Gyarados Base - damaged, water spots', 'DMG'],
+		['Dragonite Fossil DMG', 'DMG'],
+		['Machamp 1st Ed (DMG)', 'DMG'],
+		['Alakazam Base Condition: DMG', 'DMG'],
+		['Raichu Jungle HP/DMG', 'DMG'],
+		['Scyther Jungle damaged surface crease', 'DMG'],
+
+		// ─── False-positive traps (10) → expect null ───
+		['Charizard 120 HP Base Set Unlimited', null],
+		['Pikachu 40 HP Jungle 1st Edition', null],
+		['Blastoise 100 HP Base Set Shadowless', null],
+		['Damaged box but unopened pack', null], // "damaged box" stripped, no other signal
+		['Mewtwo 60 HP Base Set', null],
+		['Pokemon Card Lot — buy now', null],
+		['Vintage Holo Rare 1999 WOTC', null],
+		['Pokemon Jungle Booster Pack sealed', null],
+		['Snorlax Jungle 90 HP 1st edition', null],
+		['Raichu Jungle 60 HP holo rare', null]
+	];
+
+	it('corpus is exactly 100 titles', () => {
+		expect(corpus.length).toBe(100);
+	});
+
+	it('achieves ≥95% accuracy', () => {
+		let correct = 0;
+		const failures: Array<{ title: string; expected: Condition | null; got: ConditionInference }> =
+			[];
+		for (const [title, expected] of corpus) {
+			const got = inferCondition(title);
+			if (got.condition === expected) {
+				correct++;
+			} else {
+				failures.push({ title, expected, got });
+			}
+		}
+		const accuracy = correct / corpus.length;
+		// Include failure diagnostics in the assertion message so CI output is useful
+		if (accuracy < 0.95) {
+			console.error('Failures:', failures);
+		}
+		expect(accuracy).toBeGreaterThanOrEqual(0.95);
+	});
+});
+
+// ─── Snapshot filter threshold is actually usable ──────────────────────────
+describe('MIN_SNAPSHOT_CONFIDENCE sanity', () => {
+	it('threshold accepts canonical matches', () => {
+		expect(inferCondition('Near Mint Charizard').confidence).toBeGreaterThanOrEqual(
+			MIN_SNAPSHOT_CONFIDENCE
+		);
+	});
+
+	it('threshold rejects silent nulls', () => {
+		expect(inferCondition('Charizard Base Set Holo').confidence).toBeLessThan(
+			MIN_SNAPSHOT_CONFIDENCE
+		);
+	});
+});

--- a/src/lib/services/condition-detector.ts
+++ b/src/lib/services/condition-detector.ts
@@ -1,0 +1,184 @@
+/**
+ * Condition detector — infer TCGPlayer-style condition from free-text listings
+ *
+ * Pure helper. Given a listing title or description, returns the most likely
+ * raw-card condition in the TCGPlayer 5-tier scale (NM/LP/MP/HP/DMG) along
+ * with a 0–1 confidence score. Callers downstream exclude events with
+ * confidence below `MIN_SNAPSHOT_CONFIDENCE` from aggregate math so
+ * low-quality signals don't pollute the median/p25/p75.
+ *
+ * Design doctrine (same as grading-roi.ts): when unsure, return null. Never
+ * guess and bury the uncertainty — the aggregator is explicit about what it
+ * couldn't classify.
+ *
+ * Three tiers of signal strength:
+ *   1. Canonical full phrases ("Near Mint", "Lightly Played", …) → 0.95
+ *   2. Abbreviations inside condition context ("Condition: NM", "NM/M") → 0.85
+ *   3. Descriptive eBay language ("minor edge wear", "pack fresh") → 0.65
+ *
+ * False-positive traps filtered explicitly:
+ *   - "HP" alone → Pokémon hit points, not Heavily Played
+ *   - "damaged box/case/sleeve/wrapper" → packaging, not the card
+ *   - "near mint pikachu" (card name) → still counts as NM in practice,
+ *     listings that mention "near mint" are overwhelmingly condition signals
+ *   - "mint" standalone inside a set name ("Jungle Mint" etc.) → ignored
+ *
+ * When the inferrer can't decide confidently it returns
+ *   { condition: null, confidence: 0 }
+ * which the ingestion script treats as "keep the event, exclude from stats".
+ */
+
+export type Condition = 'NM' | 'LP' | 'MP' | 'HP' | 'DMG';
+
+export interface ConditionInference {
+	condition: Condition | null;
+	confidence: number;
+	/** Phrase we matched on — useful for debugging false positives. */
+	matchedPhrase?: string;
+}
+
+/** Snapshots exclude events below this confidence. */
+export const MIN_SNAPSHOT_CONFIDENCE = 0.7;
+
+/** Order matters: longer / more-specific phrases win over shorter ones. */
+const CANONICAL_PHRASES: Array<{
+	pattern: RegExp;
+	condition: Condition;
+	confidence: number;
+}> = [
+	// DMG (most specific first — "damaged" phrase needs negative guard applied below)
+	{ pattern: /\bdamaged\b/i, condition: 'DMG', confidence: 0.95 },
+	{ pattern: /\bpoor condition\b/i, condition: 'DMG', confidence: 0.9 },
+
+	// HP — "Heavily Played" only. Bare "HP" is handled separately with
+	// strict context because Pokémon titles print HP as hit points.
+	{ pattern: /\bheavily[-\s]played\b/i, condition: 'HP', confidence: 0.95 },
+	{ pattern: /\bheavy wear\b/i, condition: 'HP', confidence: 0.8 },
+	{ pattern: /\bheavy play\b/i, condition: 'HP', confidence: 0.85 },
+
+	// MP
+	{ pattern: /\bmoderately[-\s]played\b/i, condition: 'MP', confidence: 0.95 },
+	{ pattern: /\bmoderate wear\b/i, condition: 'MP', confidence: 0.8 },
+	{ pattern: /\bmoderate play\b/i, condition: 'MP', confidence: 0.85 },
+	{ pattern: /\bplayed condition\b/i, condition: 'MP', confidence: 0.75 },
+
+	// LP
+	{ pattern: /\blightly[-\s]played\b/i, condition: 'LP', confidence: 0.95 },
+	{ pattern: /\blight wear\b/i, condition: 'LP', confidence: 0.8 },
+	{ pattern: /\blight play\b/i, condition: 'LP', confidence: 0.85 },
+	{ pattern: /\bminor wear\b/i, condition: 'LP', confidence: 0.8 },
+	{ pattern: /\bminor(?:\s+edge)?\s+whitening\b/i, condition: 'LP', confidence: 0.75 },
+	{ pattern: /\bvery good condition\b/i, condition: 'LP', confidence: 0.7 },
+
+	// NM
+	{ pattern: /\bnear[-\s]?mint\b/i, condition: 'NM', confidence: 0.95 },
+	{ pattern: /\bpack fresh\b/i, condition: 'NM', confidence: 0.9 },
+	{ pattern: /\bgem mint\b/i, condition: 'NM', confidence: 0.9 },
+	{ pattern: /\bpristine\b/i, condition: 'NM', confidence: 0.85 },
+	{ pattern: /\bmint condition\b/i, condition: 'NM', confidence: 0.85 },
+	{ pattern: /\bexcellent condition\b/i, condition: 'NM', confidence: 0.7 },
+
+	// Bare abbreviations (no context needed). HP is deliberately omitted —
+	// "120 HP" in any basic-Pokémon title would misclassify.
+	// DMG is safe (not a common acronym otherwise), LP/MP appear mostly as
+	// condition tags in card listings.
+	{ pattern: /\bDMG\b/i, condition: 'DMG', confidence: 0.85 },
+	{ pattern: /\bNM\b/i, condition: 'NM', confidence: 0.8 },
+	{ pattern: /\bLP\b/i, condition: 'LP', confidence: 0.75 },
+	{ pattern: /\bMP\b/i, condition: 'MP', confidence: 0.75 }
+];
+
+/**
+ * Negative guards — applied BEFORE canonical matching. If a title matches
+ * one of these patterns, we remove the matched phrase from the title before
+ * running condition detection. This eliminates "damaged box" → DMG, etc.
+ */
+const NEGATIVE_GUARDS: RegExp[] = [
+	/\bdamaged\s+(?:box|case|sleeve|wrapper|package|packaging|envelope)\b/gi,
+	/\b(?:box|case|sleeve|wrapper|package|packaging|envelope)\s+(?:is\s+)?damaged\b/gi,
+	// "light/heavy shipping" isn't about the card
+	/\b(?:light|heavy)\s+shipping\b/gi
+];
+
+/**
+ * Abbreviation patterns that need condition CONTEXT to fire. Otherwise bare
+ * "HP" in "Charizard 120 HP" would misclassify every basic Pokémon card.
+ */
+const CONTEXTUAL_ABBREVIATIONS: Array<{
+	pattern: RegExp;
+	condition: Condition;
+	confidence: number;
+}> = [
+	// "Condition: NM" / "Cond: LP" / "Grade: MP"
+	{ pattern: /\b(?:condition|cond|grade)\s*[:\-]\s*nm\b/i, condition: 'NM', confidence: 0.9 },
+	{ pattern: /\b(?:condition|cond|grade)\s*[:\-]\s*lp\b/i, condition: 'LP', confidence: 0.9 },
+	{ pattern: /\b(?:condition|cond|grade)\s*[:\-]\s*mp\b/i, condition: 'MP', confidence: 0.9 },
+	{ pattern: /\b(?:condition|cond|grade)\s*[:\-]\s*hp\b/i, condition: 'HP', confidence: 0.9 },
+	{ pattern: /\b(?:condition|cond|grade)\s*[:\-]\s*dmg\b/i, condition: 'DMG', confidence: 0.9 },
+
+	// Slash-separated condition ranges pick the WORSE side (conservative)
+	{ pattern: /\bnm\s*\/\s*m\b/i, condition: 'NM', confidence: 0.85 },
+	{ pattern: /\bnm\s*\/\s*lp\b/i, condition: 'LP', confidence: 0.8 },
+	{ pattern: /\blp\s*\/\s*mp\b/i, condition: 'MP', confidence: 0.8 },
+	{ pattern: /\bmp\s*\/\s*hp\b/i, condition: 'HP', confidence: 0.8 },
+	{ pattern: /\bhp\s*\/\s*dmg\b/i, condition: 'DMG', confidence: 0.8 },
+
+	// Parenthetical: "(NM)" / "(LP)"
+	{ pattern: /\(\s*nm\s*\)/i, condition: 'NM', confidence: 0.85 },
+	{ pattern: /\(\s*lp\s*\)/i, condition: 'LP', confidence: 0.85 },
+	{ pattern: /\(\s*mp\s*\)/i, condition: 'MP', confidence: 0.85 },
+	{ pattern: /\(\s*hp\s*\)/i, condition: 'HP', confidence: 0.85 },
+	{ pattern: /\(\s*dmg\s*\)/i, condition: 'DMG', confidence: 0.85 }
+];
+
+/**
+ * Infer card condition from a free-text listing title or description.
+ *
+ * Returns `{ condition: null, confidence: 0 }` when no signal is found or
+ * when the only signals hit false-positive filters.
+ */
+export function inferCondition(title: string): ConditionInference {
+	if (!title || typeof title !== 'string') {
+		return { condition: null, confidence: 0 };
+	}
+
+	// Step 1 — strip negative guards so packaging-damage doesn't leak into the
+	// canonical matcher.
+	let cleaned = title;
+	for (const guard of NEGATIVE_GUARDS) {
+		cleaned = cleaned.replace(guard, ' ');
+	}
+
+	// Step 2 — contextual abbreviations (highest precision).
+	const abbrevMatch = firstMatch(cleaned, CONTEXTUAL_ABBREVIATIONS);
+	if (abbrevMatch) return abbrevMatch;
+
+	// Step 3 — canonical phrases. We want the highest-confidence match; if
+	// multiple tiers hit (rare — e.g. "near mint excellent condition") the
+	// first (longest canonical) wins because the list is ordered.
+	const canonicalMatch = firstMatch(cleaned, CANONICAL_PHRASES);
+	if (canonicalMatch) return canonicalMatch;
+
+	return { condition: null, confidence: 0 };
+}
+
+function firstMatch(
+	text: string,
+	candidates: Array<{ pattern: RegExp; condition: Condition; confidence: number }>
+): ConditionInference | null {
+	// Collect all matches, then prefer the highest confidence. If two tie,
+	// the earlier one in the list (more specific) wins.
+	let best: ConditionInference | null = null;
+	for (const c of candidates) {
+		const m = text.match(c.pattern);
+		if (!m) continue;
+		if (!best || c.confidence > best.confidence) {
+			best = {
+				condition: c.condition,
+				confidence: c.confidence,
+				matchedPhrase: m[0]
+			};
+		}
+	}
+	return best;
+}

--- a/src/lib/services/tcgplayer-listings-scraper.ts
+++ b/src/lib/services/tcgplayer-listings-scraper.ts
@@ -1,0 +1,346 @@
+/**
+ * TCGPlayer Listings Scraper — per-condition marketplace pricing
+ *
+ * Fetches the active marketplace listings for a single TCGPlayer product.
+ * Unlike `tcgplayer-scraper.ts` (which scrapes the recent-sales table),
+ * this one targets the listings section and returns one row per active
+ * seller — with the condition TCGPlayer reports for that listing.
+ *
+ * This is the Phase 1 differentiator: PriceCharting reports a single
+ * "ungraded" number; TCGPlayer listings let us derive structured
+ * NM/LP/MP/HP/DMG ladders.
+ *
+ * Data flow:
+ *   productId → POST mp-search-api.tcgplayer.com/v1/product/{id}/listings
+ *             → results[].{ price, condition, printing, quantity, sellerName }
+ *             → map through inferCondition (safety net) + price→cents
+ *             → structured { price_cents, condition, confidence, … }
+ *
+ * Robustness:
+ *   - HTML fallback for when the JSON API 403's (parses __NEXT_DATA__)
+ *   - Optional `dryRun` flag — fetches and logs but never returns
+ *     shaped data to downstream persistence code. Phase 1 verification
+ *     step 3 uses this against smp-SM04 and base1-4.
+ *
+ * Non-goals (explicit):
+ *   - Writing to DB. That's the ingestion script's job. This module is
+ *     a pure fetcher with side-effects limited to network + console.
+ *   - Pagination across thousands of listings. Capped at 200 per call;
+ *     enough to compute medians without flooding the endpoint.
+ */
+
+import { inferCondition, type Condition } from './condition-detector';
+
+const LISTINGS_ENDPOINT_BASE = 'https://mp-search-api.tcgplayer.com/v1/product';
+const PRODUCT_PAGE_BASE = 'https://www.tcgplayer.com/product';
+
+const HEADERS: HeadersInit = {
+	'User-Agent':
+		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+	Accept: 'application/json, text/plain, */*',
+	'Accept-Language': 'en-US,en;q=0.9',
+	'Content-Type': 'application/json',
+	Origin: 'https://www.tcgplayer.com',
+	Referer: 'https://www.tcgplayer.com/'
+};
+
+const HTML_HEADERS: HeadersInit = {
+	'User-Agent':
+		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+	Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+	'Accept-Language': 'en-US,en;q=0.9'
+};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface TCGListing {
+	/** Always integer cents. Total asking price for a single copy (price only; shipping excluded). */
+	price_cents: number;
+	/** Normalised condition. Null when TCGPlayer's label didn't map to our 5-tier scale. */
+	condition: Condition | null;
+	/** 0–1. Canonical TCGPlayer labels resolve at ≥0.95. */
+	confidence: number;
+	/** Raw condition text TCGPlayer returned (for audit / debugging). */
+	rawCondition: string | null;
+	/** Printing variant — "Normal", "Holofoil", "Reverse Holofoil", "1st Edition Holofoil", etc. */
+	printing: string | null;
+	/** Number of copies in this listing. */
+	quantity: number;
+	/** Seller display name. Kept for future anti-spam heuristics. */
+	seller: string | null;
+	/** TCGPlayer's own listing id, used for dedup in sale_events. */
+	listingId: string | null;
+}
+
+export interface FetchListingsOptions {
+	productId: number | string;
+	/** Max listings to return. Clamped 1–200. Default 100. */
+	limit?: number;
+	/** Filter to specific printings ("Normal", "Holofoil"…). Default: all printings. */
+	printings?: string[];
+	/**
+	 * When true, the scraper runs the request and logs what it would
+	 * return, but returns an empty array to callers. Intended for
+	 * verification against known product ids before wiring into the
+	 * ingestion script.
+	 */
+	dryRun?: boolean;
+}
+
+export interface FetchListingsResult {
+	productId: string;
+	productUrl: string;
+	listings: TCGListing[];
+	/** Whether results came from the JSON API or the HTML fallback. */
+	source: 'api' | 'html' | 'none';
+	error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function fetchTCGPlayerListings(
+	opts: FetchListingsOptions
+): Promise<FetchListingsResult> {
+	const productId = String(opts.productId);
+	const limit = clamp(opts.limit ?? 100, 1, 200);
+	const productUrl = `${PRODUCT_PAGE_BASE}/${productId}/`;
+
+	// Try the JSON listings endpoint first.
+	let listings = await fetchViaApi(productId, limit, opts.printings);
+	let source: FetchListingsResult['source'] = listings.length > 0 ? 'api' : 'none';
+
+	// Fallback to HTML __NEXT_DATA__ scraping if the API didn't return anything.
+	if (listings.length === 0) {
+		const htmlListings = await fetchViaHtml(productId, limit, opts.printings);
+		if (htmlListings.length > 0) {
+			listings = htmlListings;
+			source = 'html';
+		}
+	}
+
+	if (opts.dryRun) {
+		const summary = summariseByCondition(listings);
+		console.log(
+			`[tcgplayer-listings dry-run] productId=${productId} source=${source} ` +
+				`count=${listings.length} ${summary}`
+		);
+		return { productId, productUrl, listings: [], source };
+	}
+
+	return { productId, productUrl, listings, source };
+}
+
+// ---------------------------------------------------------------------------
+// JSON API path
+// ---------------------------------------------------------------------------
+
+interface ApiListing {
+	listingId?: number | string;
+	productId?: number | string;
+	price?: number;
+	shippingPrice?: number;
+	quantity?: number;
+	sellerName?: string;
+	condition?: string;
+	printing?: string;
+	language?: string;
+}
+
+interface ApiResponse {
+	results?: Array<{
+		results?: ApiListing[];
+		totalResults?: number;
+	}>;
+}
+
+// TCGPlayer's listings API caps page size at 50 — larger sizes silently
+// return empty. We paginate with `from` offsets to reach the requested limit.
+const PAGE_SIZE = 50;
+
+async function fetchViaApi(
+	productId: string,
+	limit: number,
+	printings: string[] | undefined
+): Promise<TCGListing[]> {
+	const collected: TCGListing[] = [];
+	const seenListingIds = new Set<string>();
+
+	for (let from = 0; from < limit && collected.length < limit; from += PAGE_SIZE) {
+		const size = Math.min(PAGE_SIZE, limit - from);
+		const body = {
+			filters: {
+				term: {
+					sellerStatus: 'Live',
+					channelId: 0,
+					language: ['English'],
+					...(printings && printings.length > 0 ? { printing: printings } : {})
+				}
+			},
+			from,
+			size,
+			sort: { field: 'price+shipping', order: 'asc' },
+			context: { shippingCountry: 'US' }
+		};
+
+		let raw: ApiListing[] = [];
+		try {
+			const res = await fetch(`${LISTINGS_ENDPOINT_BASE}/${productId}/listings`, {
+				method: 'POST',
+				headers: HEADERS,
+				body: JSON.stringify(body)
+			});
+			if (!res.ok) break;
+			const data = (await res.json()) as ApiResponse;
+			raw = data.results?.[0]?.results ?? [];
+		} catch {
+			break;
+		}
+
+		if (raw.length === 0) break; // reached end of listings
+
+		for (const r of raw) {
+			const mapped = mapApiListing(r);
+			if (!mapped) continue;
+			const key = mapped.listingId ?? `${mapped.price_cents}:${mapped.seller}:${mapped.rawCondition}`;
+			if (seenListingIds.has(key)) continue;
+			seenListingIds.add(key);
+			collected.push(mapped);
+		}
+
+		if (raw.length < size) break; // partial page = end of results
+	}
+
+	return collected;
+}
+
+function mapApiListing(r: ApiListing): TCGListing | null {
+	if (typeof r.price !== 'number' || r.price <= 0) return null;
+	const rawCondition = typeof r.condition === 'string' ? r.condition : null;
+	const inferred = rawCondition ? inferCondition(rawCondition) : null;
+	return {
+		price_cents: Math.round(r.price * 100),
+		condition: inferred?.condition ?? null,
+		confidence: inferred?.confidence ?? 0,
+		rawCondition,
+		printing: typeof r.printing === 'string' ? r.printing : null,
+		quantity: typeof r.quantity === 'number' ? r.quantity : 0,
+		seller: typeof r.sellerName === 'string' ? r.sellerName : null,
+		listingId: r.listingId != null ? String(r.listingId) : null
+	};
+}
+
+// ---------------------------------------------------------------------------
+// HTML fallback — parse __NEXT_DATA__
+// ---------------------------------------------------------------------------
+
+async function fetchViaHtml(
+	productId: string,
+	limit: number,
+	printings: string[] | undefined
+): Promise<TCGListing[]> {
+	try {
+		const res = await fetch(`${PRODUCT_PAGE_BASE}/${productId}/`, {
+			headers: HTML_HEADERS,
+			redirect: 'follow'
+		});
+		if (!res.ok) return [];
+		const html = await res.text();
+		const nextData = extractNextData(html);
+		if (!nextData) return [];
+
+		// __NEXT_DATA__ structure varies across TCGPlayer releases. We walk
+		// the tree looking for arrays of objects that look like listings.
+		const candidates = findListingArrays(nextData);
+		for (const arr of candidates) {
+			const mapped = arr
+				.map((raw) => mapApiListing(raw as ApiListing))
+				.filter((l): l is TCGListing => l !== null);
+			if (mapped.length === 0) continue;
+			const filtered =
+				printings && printings.length > 0
+					? mapped.filter((l) => !l.printing || printings.includes(l.printing))
+					: mapped;
+			return filtered.slice(0, limit);
+		}
+		return [];
+	} catch {
+		return [];
+	}
+}
+
+function extractNextData(html: string): unknown {
+	const match = html.match(
+		/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/i
+	);
+	if (!match) return null;
+	try {
+		return JSON.parse(match[1]);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Walk an arbitrary JSON tree and collect arrays that look like listings
+ * (objects with price + condition keys). Keeps the scraper resilient to
+ * the exact nesting path changing.
+ */
+function findListingArrays(root: unknown): unknown[][] {
+	const out: unknown[][] = [];
+	const seen = new Set<object>();
+
+	function walk(node: unknown): void {
+		if (node === null || typeof node !== 'object') return;
+		if (seen.has(node as object)) return;
+		seen.add(node as object);
+
+		if (Array.isArray(node)) {
+			const looksLikeListings =
+				node.length > 0 &&
+				node.every(
+					(item) =>
+						item !== null &&
+						typeof item === 'object' &&
+						'price' in (item as object) &&
+						'condition' in (item as object)
+				);
+			if (looksLikeListings) {
+				out.push(node);
+				return; // don't descend further into this array
+			}
+			for (const item of node) walk(item);
+			return;
+		}
+
+		for (const v of Object.values(node as Record<string, unknown>)) walk(v);
+	}
+
+	walk(root);
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clamp(n: number, lo: number, hi: number): number {
+	return Math.min(hi, Math.max(lo, n));
+}
+
+function summariseByCondition(listings: TCGListing[]): string {
+	const buckets: Record<string, number[]> = {};
+	for (const l of listings) {
+		const key = l.condition ?? 'unknown';
+		(buckets[key] ||= []).push(l.price_cents);
+	}
+	return Object.entries(buckets)
+		.map(([c, prices]) => {
+			const median = prices.slice().sort((a, b) => a - b)[Math.floor(prices.length / 2)];
+			return `${c}=${prices.length}(med $${(median / 100).toFixed(2)})`;
+		})
+		.join(' ');
+}

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -41,12 +41,25 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 	// watchlist so the page can show "In Collection" / "Watching" state
 	// on initial render without needing JS. Errors are swallowed — if
 	// Supabase is unreachable the buttons just show their default state.
-	const [collectionRows, watchlistRows] = await Promise.all([
+	const [collectionRows, watchlistRows, conditionPriceRows] = await Promise.all([
 		supabase.from('collection').select('id').eq('card_id', params.id).limit(1),
-		supabase.from('watchlist').select('id').eq('card_id', params.id).limit(1)
+		supabase.from('watchlist').select('id').eq('card_id', params.id).limit(1),
+		// Latest snapshot per condition. Small (≤5 rows per card) so we can
+		// fetch and collapse in JS without a window function.
+		supabase
+			.from('condition_price_snapshots')
+			.select('condition, median_cents, p25_cents, p75_cents, sample_count, snapshot_date')
+			.eq('card_id', params.id)
+			.order('snapshot_date', { ascending: false })
+			.limit(50)
 	]);
 	const inCollection = !!collectionRows.data?.length;
 	const onWatchlist = !!watchlistRows.data?.length;
+
+	// Collapse to one row per condition, keeping the most recent. Missing
+	// table (404 after a fresh deploy before migration 005 applies) returns
+	// null data — we just show nothing, per honesty doctrine.
+	const conditionPrices = collapseLatestPerCondition(conditionPriceRows.data ?? []);
 
 	return {
 		card,
@@ -57,10 +70,32 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		priceHistory,
 		ebaySold: { query: '', listings: [], averagePrice: 0, medianPrice: 0, lowPrice: 0, highPrice: 0, totalSold: 0 },
 		psaPop: null,
+		conditionPrices,
 		inCollection,
 		onWatchlist
 	};
 };
+
+interface ConditionSnapshotRow {
+	condition: string;
+	median_cents: number;
+	p25_cents: number;
+	p75_cents: number;
+	sample_count: number;
+	snapshot_date: string;
+}
+
+function collapseLatestPerCondition(rows: ConditionSnapshotRow[]): ConditionSnapshotRow[] {
+	const latest = new Map<string, ConditionSnapshotRow>();
+	for (const r of rows) {
+		const existing = latest.get(r.condition);
+		if (!existing || r.snapshot_date > existing.snapshot_date) latest.set(r.condition, r);
+	}
+	const order = ['NM', 'LP', 'MP', 'HP', 'DMG'];
+	return order
+		.map((c) => latest.get(c))
+		.filter((r): r is ConditionSnapshotRow => r != null);
+}
 
 /**
  * Form actions for "Add to Collection" and "Add to Watchlist".

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -18,6 +18,26 @@
 	let priceHistory = $derived(data.priceHistory as PriceHistory | null);
 	let ebaySold = $derived(data.ebaySold as EbaySoldResult);
 	let psaPop = $derived(data.psaPop as PSAPopData | null);
+	let conditionPrices = $derived(
+		(data.conditionPrices ?? []) as Array<{
+			condition: string;
+			median_cents: number;
+			p25_cents: number;
+			p75_cents: number;
+			sample_count: number;
+			snapshot_date: string;
+		}>
+	);
+	let hasConditionPrices = $derived(conditionPrices.length > 0);
+	let conditionPricesAsOf = $derived(conditionPrices[0]?.snapshot_date ?? null);
+
+	const CONDITION_LABEL: Record<string, string> = {
+		NM: 'Near Mint',
+		LP: 'Lightly Played',
+		MP: 'Moderately Played',
+		HP: 'Heavily Played',
+		DMG: 'Damaged'
+	};
 
 	// "Added" state comes from either the server loader (reload-resistant,
 	// works without JS) or the most recent form submission result.
@@ -335,6 +355,34 @@
 						</svg>
 						<p class="text-sm font-medium">Pricing not yet available</p>
 						<p class="mt-1 text-xs">New cards may take a few days to get market pricing</p>
+					</div>
+				</div>
+			{/if}
+
+			<!-- Price by Condition (Phase 1: per-condition raw pricing from TCGPlayer listings) -->
+			{#if hasConditionPrices}
+				<div class="rounded-2xl border border-vault-border bg-vault-surface p-4 sm:p-6">
+					<div class="flex items-center justify-between">
+						<h2 class="text-lg font-semibold text-white">Price by Condition</h2>
+						{#if conditionPricesAsOf}
+							<span class="text-[10px] text-vault-text-muted">as of {conditionPricesAsOf}</span>
+						{/if}
+					</div>
+					<p class="mt-1 text-xs text-vault-text-muted">
+						Median active-listing price on TCGPlayer by condition. <span class="italic">low sample</span> when n &lt; 10.
+					</p>
+					<div class="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-5 sm:gap-3">
+						{#each conditionPrices as row}
+							{@const isLowSample = row.sample_count < 10}
+							<div class="rounded-xl border border-vault-border bg-vault-bg p-3 text-center">
+								<p class="text-[11px] font-medium text-vault-gold">{row.condition}</p>
+								<p class="text-[10px] text-vault-text-muted">{CONDITION_LABEL[row.condition] ?? row.condition}</p>
+								<p class="mt-1 text-base font-bold text-white">${(row.median_cents / 100).toFixed(2)}</p>
+								<p class="text-[10px] text-vault-text-muted">
+									n={row.sample_count}{#if isLowSample} <span class="italic text-amber-400">low</span>{/if}
+								</p>
+							</div>
+						{/each}
 					</div>
 				</div>
 			{/if}

--- a/supabase/migrations/005_sale_events.sql
+++ b/supabase/migrations/005_sale_events.sql
@@ -1,0 +1,111 @@
+-- Trove: Data Sovereignty Phase 1 — per-condition raw pricing
+--
+-- Two new tables:
+--
+--   sale_events
+--     Append-only log of every observed listing/sale across any
+--     marketplace. Raw events are kept forever so snapshots can be
+--     re-derived with different weighting without re-scraping.
+--     `condition` is inferred from free-text titles for eBay-style
+--     sources, or taken directly from structured listings (TCGPlayer).
+--     NULL means the inferrer couldn't tell — those rows are excluded
+--     from snapshot math but retained for later re-analysis.
+--
+--   condition_price_snapshots
+--     Nightly rollup per (card_id, condition, snapshot_date). Stores
+--     median / p25 / p75 in cents + sample_count so the UI can show
+--     low-sample caveats honestly (n<10). `freshness_score` decays as
+--     the underlying events age, letting downstream consumers weight
+--     recent-vs-stale without re-querying sale_events.
+--
+-- Powers the "Price by Condition" ladder on card detail pages
+-- (NM / LP / MP / HP / DMG). This per-condition structure is the
+-- Phase 1 differentiator — no other public aggregator indexes it.
+
+-- ============================================
+-- Raw event log — every observation we ingest
+-- ============================================
+
+create table if not exists sale_events (
+    id uuid primary key default gen_random_uuid(),
+
+    -- Card identity (card_id is text to match card_index.card_id)
+    card_id text not null,
+
+    -- Source & identity within that source (for dedup)
+    marketplace text not null,          -- 'tcgplayer' | 'ebay' | 'pwcc' | ...
+    external_id text,                   -- listing id, item id, cert id, etc.
+    title text,                         -- original listing title for audit
+
+    -- Money
+    price_cents integer not null check (price_cents >= 0),
+    currency text not null default 'USD',
+
+    -- Condition (raw) — nullable when inference was inconclusive
+    condition text check (condition in ('NM', 'LP', 'MP', 'HP', 'DMG')),
+    condition_confidence numeric(3, 2) check (
+        condition_confidence is null
+        or (condition_confidence >= 0 and condition_confidence <= 1)
+    ),
+
+    -- Grading (nullable — only populated for graded sales in later phases)
+    grade numeric(3, 1),
+    grader text check (grader in ('PSA', 'CGC', 'BGS', 'SGC', 'TAG') or grader is null),
+
+    -- Event type — did we see a listing price or a closed sale?
+    -- 'listing' = active asking price, 'sold' = realized sale.
+    event_type text not null default 'listing'
+        check (event_type in ('listing', 'sold')),
+
+    -- When the source says the event happened vs when we wrote the row
+    observed_at timestamptz not null,
+    inserted_at timestamptz not null default now()
+);
+
+-- (marketplace, external_id) dedup — same listing seen twice should not
+-- double-count. NULL external_id is allowed (rare) and will not dedup.
+create unique index if not exists uq_sale_events_marketplace_external
+    on sale_events (marketplace, external_id)
+    where external_id is not null;
+
+create index if not exists idx_sale_events_card_observed
+    on sale_events (card_id, observed_at desc);
+create index if not exists idx_sale_events_marketplace_observed
+    on sale_events (marketplace, observed_at desc);
+create index if not exists idx_sale_events_condition
+    on sale_events (card_id, condition, observed_at desc)
+    where condition is not null;
+
+alter table sale_events disable row level security;
+
+-- ============================================
+-- Nightly rollups — what the UI reads
+-- ============================================
+
+create table if not exists condition_price_snapshots (
+    card_id text not null,
+    condition text not null
+        check (condition in ('NM', 'LP', 'MP', 'HP', 'DMG')),
+    snapshot_date date not null,
+
+    -- Aggregates (integers for money = cents, exact)
+    median_cents integer not null,
+    p25_cents integer not null,
+    p75_cents integer not null,
+    sample_count integer not null check (sample_count >= 0),
+
+    -- 0..1 — higher means more recent events dominate the aggregate.
+    -- Computed at snapshot time from age distribution of contributing
+    -- sale_events.
+    freshness_score numeric(3, 2) not null
+        check (freshness_score >= 0 and freshness_score <= 1),
+
+    computed_at timestamptz not null default now(),
+
+    primary key (card_id, condition, snapshot_date)
+);
+
+create index if not exists idx_condition_snapshots_card_date
+    on condition_price_snapshots (card_id, snapshot_date desc);
+
+alter table condition_price_snapshots disable row level security;


### PR DESCRIPTION
## Summary

- **Per-condition raw pricing** is the Phase 1 differentiator of the data sovereignty plan — nobody else indexes structured NM/LP/MP/HP/DMG prices for Pokémon cards.
- Full pipeline end-to-end: scraper → ingestion → snapshot rollups → honest UI.
- Verified live: 20 Base Set cards ingested (~4000 events, ~100 snapshots), prices decrease monotonically NM→DMG, amber \"low sample\" flag fires when n<10.

## What's in it

- **`supabase/migrations/005_sale_events.sql`** — two new tables:
  - `sale_events` — append-only raw event log (keep forever, re-derive aggregates with different weighting later)
  - `condition_price_snapshots` — nightly rollups with median/p25/p75 cents + sample_count + freshness_score
- **`src/lib/services/condition-detector.ts`** — pure `inferCondition(title)` helper returning `{ condition, confidence }`. 42 vitest cases, ≥95% accuracy on a 100-title hand-labeled corpus. Handles TCGPlayer canonical phrases, eBay descriptive language, contextual abbreviations, and false-positive traps (e.g. \"Charizard 120 HP\" shouldn't parse as Heavily Played).
- **`src/lib/services/tcgplayer-listings-scraper.ts`** — JSON API primary path + `__NEXT_DATA__` HTML fallback. **Paginated in pages of 50** because the endpoint silently caps `size>50` (discovered live-verifying).
- **`scripts/ingest-condition-prices.ts`** — batch writes, 200ms polite delay, exponential backoff, same-day resume. CLI flags: `--card`, `--set`, `--limit`, `--all`, `--dry-run`, `--no-resume`.
- **`scripts/verify-listings-scraper.ts`** — one-shot smoke test, kept as a regression check for future TCGPlayer API changes.
- **Card detail \"Price by Condition\" block** — ladder rendering with the Trove honesty doctrine: no fabricated numbers, sample-count caveats, \"as of YYYY-MM-DD\" freshness stamp.
- **vitest + test scripts** — `npm test` / `npm run test:watch`.

## Out of scope (Phase 2+ per roadmap)

- eBay sold data (Phase 2)
- Pop velocity deltas (Phase 3)
- Auction house comps (Phase 5)
- Public API (Phase 6)

## Follow-up PR

Fly.io cron deploy (daily 2am PT) — intentionally separate, architecturally independent.

## Test plan

- [x] `npm test` — 42 tests pass, ≥95% corpus accuracy
- [x] `npm run check` — no new type errors
- [x] Live scraper verification (5 products, all API hits)
- [x] Live ingestion against `--set base1 --limit 20` — 20 ok / 0 errors
- [x] Card detail UI renders full ladder (Charizard Base Set)
- [x] Card detail UI renders amber \"low\" flag for n<10 (Ninetales NM n=6)
- [ ] Migration 005 applied to production Supabase (done manually via SQL Editor before merge — see commit description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)