### PR TITLE
Real multi-grader pop: fix CGC mislabel, harden GemRate, add TAG Track A

### DIFF
--- a/.github/workflows/engine-tag.yml
+++ b/.github/workflows/engine-tag.yml
@@ -1,0 +1,34 @@
+name: engine-tag
+
+# Track A — TAG Grading pop crawl. TAG publishes its own authoritative pop
+# report (api.taggrading.com); reverse-engineered client in
+# src/lib/services/tag-grading.ts. Not Cloudflare-walled, lightly paced.
+# No-ops cleanly until migration 019 is applied (tag-pop.ts isolates per set
+# and the write simply errors-per-set until tag_grades exists).
+
+on:
+  schedule:
+    - cron: '20 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: engine-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    env:
+      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: TAG population crawl
+        run: node_modules/.bin/tsx scripts/tag-pop.ts --all

--- a/scripts/cron-tag-pop.sh
+++ b/scripts/cron-tag-pop.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Trove — Track A: nightly TAG Grading population crawl.
+# Gap-prioritised (never-synced sets first, then staleest), per-set isolated.
+# TAG's api.taggrading.com is not Cloudflare-walled, so this is lightly paced
+# and finishes well before the coverage-ledger snapshot.
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+LOG_DIR="$HOME/Library/Logs/Trove"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/tag-pop-$(date +%Y-%m-%d).log"
+
+{
+  echo "=== Trove tag-pop start: $(date -u +%FT%TZ) ==="
+  node_modules/.bin/tsx scripts/tag-pop.ts --all
+  EXIT=$?
+  echo "=== Trove tag-pop end: $(date -u +%FT%TZ) exit=$EXIT ==="
+} >>"$LOG_FILE" 2>&1
+
+if [ "${EXIT:-1}" -ne 0 ]; then
+  /usr/bin/osascript -e "display notification \"tag-pop failed (exit ${EXIT:-1}). See $LOG_FILE\" with title \"Trove\" sound name \"Basso\"" || true
+fi
+
+exit "${EXIT:-1}"

--- a/scripts/gemrate-pop.ts
+++ b/scripts/gemrate-pop.ts
@@ -72,10 +72,18 @@ const num = (v: string | undefined, d: number) => {
 	return Number.isFinite(n) && n >= 0 ? n : d;
 };
 
-// PSA-only by default: GemRate's item-details-advanced serves rowdata for PSA
-// only — cgc/bgs/sgc return empty rowdata for every set, and each empty grader
-// still burns the exponential CF backoff, starving the whole crawl. Override
-// via TROVE_GEMRATE_GRADERS if a working CGC/BGS/SGC endpoint is found.
+// PSA-only by default: GemRate's item-details-advanced serves real rowdata
+// for PSA ONLY. Verified live 2026-05-18 against base1 "Pokemon Game" 1999:
+//   psa -> 878KB, real RowData (gem rates, totals)
+//   cgc -> 77KB,  RowData '[]'  (empty — validate() rejects)
+//   bgs -> 77KB,  RowData '[]'  (empty — validate() rejects)
+//   sgc -> Cloudflare "Just a moment" challenge (fetch returns null)
+//   tag -> 878KB, RowData BYTE-IDENTICAL to PSA (param ignored, PSA echoed)
+// The `tag` echo is the dangerous one: it passes the card-number overlap
+// gate (same set), so an unguarded TROVE_GEMRATE_GRADERS=psa,tag would
+// write PSA's population onto TAG columns — fabrication. assertNotPsaEcho()
+// below hard-blocks that. Override TROVE_GEMRATE_GRADERS only if a source
+// genuinely serving distinct CGC/BGS/SGC/TAG rowdata is found.
 const GRADERS = (process.env.TROVE_GEMRATE_GRADERS ?? 'psa')
 	.split(',')
 	.map((s) => s.trim().toLowerCase())
@@ -244,6 +252,20 @@ function pickCanonical(rows: GemrateCard[]): GemrateCard | null {
 	);
 }
 
+/**
+ * Structural fingerprint of a fetched grader payload (card_number + totals +
+ * gem rate). GemRate ignores an unrecognised `grader` and serves the PSA page
+ * verbatim, which passes the card-number overlap gate. Comparing this
+ * signature to the PSA fetch for the SAME set catches the echo before any
+ * write — the honesty gate against persisting PSA pop as TAG/other.
+ */
+function rowSignature(rows: GemrateCard[]): string {
+	return rows
+		.map((r) => `${normNum(r.card_number)}:${r.card_total_grades ?? ''}:${r.card_gem_rate ?? ''}`)
+		.sort()
+		.join('|');
+}
+
 // --------------------------------------------------------------------------
 // Map GemRate -> card_index columns for one grader
 // --------------------------------------------------------------------------
@@ -381,6 +403,7 @@ async function processSet(
 	const graders = opts.only ? [opts.only] : GRADERS;
 	let resolved: GemrateTarget | null = null;
 	let totalWrote = 0;
+	let psaSig: string | null = null;
 	const wroteGraders: string[] = [];
 
 	for (const grader of graders) {
@@ -433,6 +456,28 @@ async function processSet(
 		const v = validate(rows, idx);
 		if (!v.ok) {
 			log(`  [${set.set_id}] ${grader}: validation failed post-fetch — ${v.reason}, skip`);
+			continue;
+		}
+
+		// Honesty gate: GemRate echoes the PSA page for unrecognised graders
+		// (verified: grader=tag). That echo passes validate() (same set), so
+		// catch it structurally before any write.
+		const sig = rowSignature(rows);
+		if (grader === 'psa') {
+			psaSig = sig;
+		} else if (psaSig !== null && sig === psaSig) {
+			log(
+				`  [${set.set_id}] ${grader}: PSA-echo detected (GemRate ignored grader) — ` +
+					`refusing to write fabricated ${grader} pop`
+			);
+			continue;
+		} else if (grader === 'tag') {
+			// No PSA fetch this run to diff against. GemRate provably serves
+			// no distinct TAG rowdata, so refuse rather than risk an echo.
+			log(
+				`  [${set.set_id}] tag: GemRate serves no real TAG pop (echoes PSA) — ` +
+					`skipping (honesty gate)`
+			);
 			continue;
 		}
 

--- a/scripts/refresh-index.ts
+++ b/scripts/refresh-index.ts
@@ -51,6 +51,7 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 // endpoint when a dev server URL is available (it uses SvelteKit's fetch which
 // passes Cloudflare). Set DEV_SERVER_URL=http://localhost:5178 in .env.local.
 import { fetchPriceCharting as fetchPriceChartingDirect } from '../src/lib/services/pricecharting-scraper.js';
+import { getTagCardPop, tagPopScalars, TagGradingError } from '../src/lib/services/tag-grading.js';
 
 const DEV_SERVER_URL = process.env.DEV_SERVER_URL ?? '';
 
@@ -226,15 +227,21 @@ async function enrichOneCard(card: TcgCard): Promise<EnrichedCardOutput> {
 			psa10_source: pc?.psa10 != null ? 'pricecharting' : null,
 			tag10_price: pc?.tag10 ?? null,
 			tag10_source: pc?.tag10 != null ? 'pricecharting' : null,
+			cgc10_price: pc?.cgc10 ?? null,
+			cgc10_source: pc?.cgc10 != null ? 'pricecharting' : null,
 			graded_prices_fetched_at: pc ? now : null,
 			psa10_last_sold_at: pc?.psa10LastSold ?? null,
 			psa_pop_total: psaPop?.total ?? null,
 			psa_pop_10: psaPop?.grade10 ?? null,
 			psa_gem_rate: psaPop?.gemRate ?? null,
 			psa_fetched_at: psaPop ? now : null,
-			tag_pop_total: cgcPop?.total ?? null,  // Using tag_pop columns for CGC until TAG scraper exists
-			tag_pop_10: cgcPop?.grade10 ?? null,
-			tag_fetched_at: cgcPop ? now : null,
+			// Real CGC pop into its own columns (migration 007). tag_pop_*
+			// is left untouched — PriceCharting has no TAG pop; writing CGC
+			// there fabricated TAG. Omitted from the upsert = never clobbered.
+			cgc_pop_total: cgcPop?.total ?? null,
+			cgc_pop_10: cgcPop?.grade10 ?? null,
+			cgc_gem_rate: cgcPop?.gemRate ?? null,
+			cgc_fetched_at: cgcPop ? now : null,
 			last_enriched_at: now,
 			enrich_version: 2,
 			enrich_errors: errors
@@ -306,15 +313,21 @@ function stalePriceRow(
 		psa10_source: pc?.psa10 != null ? 'pricecharting' : null,
 		tag10_price: pc?.tag10 ?? null,
 		tag10_source: pc?.tag10 != null ? 'pricecharting' : null,
+		cgc10_price: pc?.cgc10 ?? null,
+		cgc10_source: pc?.cgc10 != null ? 'pricecharting' : null,
 		graded_prices_fetched_at: pc ? now : null,
 		psa10_last_sold_at: pc?.psa10LastSold ?? null,
 		psa_pop_total: psaPop?.total ?? null,
 		psa_pop_10: psaPop?.grade10 ?? null,
 		psa_gem_rate: psaPop?.gemRate ?? null,
 		psa_fetched_at: psaPop ? now : null,
-		tag_pop_total: cgcPop?.total ?? null,
-		tag_pop_10: cgcPop?.grade10 ?? null,
-		tag_fetched_at: cgcPop ? now : null,
+		// Real CGC pop into its own columns (migration 007). tag_pop_* is
+		// left untouched — PriceCharting has no TAG pop; writing CGC there
+		// fabricated TAG. Omitted from the upsert = never clobbered.
+		cgc_pop_total: cgcPop?.total ?? null,
+		cgc_pop_10: cgcPop?.grade10 ?? null,
+		cgc_gem_rate: cgcPop?.gemRate ?? null,
+		cgc_fetched_at: cgcPop ? now : null,
 		last_enriched_at: now,
 		enrich_version: 2,
 		enrich_errors: errors
@@ -693,6 +706,43 @@ async function main() {
 		if (!tcgRes.ok) { console.error(`TCG API ${tcgRes.status}`); return; }
 		const card = (await tcgRes.json()).data as TcgCard;
 		const { row, psa10Sales } = await enrichOneCard(card);
+
+		// On-query TAG re-verify (single card only — bounded, user-driven).
+		// First-time TAG discovery + the alias honesty gate live in the
+		// nightly tag-pop crawler; here we only refresh a card whose TAG set
+		// is already known. Failure leaves the stored value untouched.
+		try {
+			const { data: prov } = await supabase
+				.from('card_index')
+				.select('card_number, tag_set_name, tag_brand_name, tag_year')
+				.eq('card_id', cardId)
+				.maybeSingle();
+			if (prov?.tag_set_name && prov?.tag_brand_name && prov?.tag_year && prov?.card_number) {
+				const grades = await getTagCardPop({
+					category: process.env.TROVE_TAG_CATEGORY || 'Pokémon',
+					year: prov.tag_year as number,
+					brandName: prov.tag_brand_name as string,
+					setName: prov.tag_set_name as string,
+					cardNumber: prov.card_number as string
+				});
+				if (grades) {
+					const sc = tagPopScalars(grades);
+					const nowIso = new Date().toISOString();
+					Object.assign(row, {
+						tag_pop_total: sc.total,
+						tag_pop_10: sc.grade10,
+						tag_gem_rate: sc.gemRate,
+						tag_grades: grades,
+						tag_fetched_at: nowIso,
+						tag_synced_at: nowIso
+					});
+				}
+			}
+		} catch (e) {
+			const m = e instanceof TagGradingError ? e.message : (e as Error).message;
+			console.warn(`TAG re-verify skipped: ${m}`);
+		}
+
 		if (dryRun) {
 			console.log('DRY RUN result:');
 			console.log(JSON.stringify({ row, psa10Sales }, null, 2));

--- a/scripts/tag-aliases.ts
+++ b/scripts/tag-aliases.ts
@@ -1,0 +1,78 @@
+/**
+ * Trove — TAG set matcher (Track A)
+ *
+ * TAG identifies a set by (category, year, brandName, cardSetName). Unlike
+ * GemRate we don't have to guess a single string: TAG's /pops/set returns
+ * EVERY set for a year with its real brandName + cardSetName, so the crawler
+ * enumerates that list and matches our tracked set against it by name, then
+ * proves the pick by card_number overlap (the honesty gate). A wrong match
+ * is rejected at the gate, never written.
+ *
+ * This module only normalises names and scores candidates; OVERRIDES pins a
+ * verified (brandName, cardSetName) when fuzzy matching is ambiguous.
+ */
+
+export interface TagSetKey {
+	brandName: string;
+	cardSetName: string;
+}
+
+/** set_id -> verified TAG (brandName, cardSetName). Add entries the crawler
+ *  logs as "NEED ALIAS" once confirmed against a real fetch. */
+const OVERRIDES: Record<string, TagSetKey> = {};
+
+export function hasTagOverride(setId: string): boolean {
+	return setId in OVERRIDES;
+}
+export function tagOverride(setId: string): TagSetKey | undefined {
+	return OVERRIDES[setId];
+}
+
+export function yearOf(releaseDate: string): number {
+	const m = (releaseDate ?? '').match(/(\d{4})/);
+	return m ? parseInt(m[1], 10) : NaN;
+}
+
+/** Lowercase, strip diacritics, drop a leading "pokemon ", collapse
+ *  whitespace and punctuation — for fuzzy name comparison only. */
+export function normName(s: string): string {
+	return (s ?? '')
+		.normalize('NFD')
+		.replace(/[̀-ͯ]/g, '')
+		.toLowerCase()
+		.replace(/[\t\r\n]+/g, ' ')
+		.replace(/^p\.?\s*m\.?\s+/i, '')
+		.replace(/\bpok[e]?mon\b/gi, '')
+		.replace(/[^a-z0-9]+/g, ' ')
+		.trim();
+}
+
+/**
+ * Score a TAG set row against our tracked set name. Higher = better; 0 = no
+ * match worth trying. Exact normalised equality ranks first, then
+ * containment either direction, then token overlap.
+ */
+export function scoreTagCandidate(ourSetName: string, tagCardSetName: string): number {
+	const a = normName(ourSetName);
+	const b = normName(tagCardSetName);
+	if (!a || !b) return 0;
+	if (a === b) return 100;
+	if (b.includes(a) || a.includes(b)) return 70;
+	const ta = new Set(a.split(' ').filter(Boolean));
+	const tb = new Set(b.split(' ').filter(Boolean));
+	if (ta.size === 0 || tb.size === 0) return 0;
+	let inter = 0;
+	for (const t of ta) if (tb.has(t)) inter++;
+	const jaccard = inter / (ta.size + tb.size - inter);
+	return jaccard >= 0.5 ? Math.round(40 * jaccard) : 0;
+}
+
+/** Normalise a card number for cross-source overlap: "42/102" -> "42",
+ *  strip leading zeros, lowercase (handles "TG12", "SWSH001"). */
+export function normCardNumber(v: string | null | undefined): string {
+	const s = String(v ?? '')
+		.trim()
+		.toLowerCase();
+	const head = s.split('/')[0]?.trim() ?? '';
+	return head.replace(/^0+(?=\d)/, '');
+}

--- a/scripts/tag-pop.ts
+++ b/scripts/tag-pop.ts
@@ -1,0 +1,543 @@
+#!/usr/bin/env tsx
+/**
+ * Trove — Track A: TAG Grading population acquisition
+ *
+ * TAG publishes its own authoritative pop report. This crawler closes the
+ * TAG gap the same way gemrate-pop.ts closes PSA: per-year set lists from
+ * api.taggrading.com, matched to our tracked_sets and PROVEN by card_number
+ * overlap before any write (honesty gate — a wrong set match is rejected,
+ * never persisted). See src/lib/services/tag-grading.ts for the protocol and
+ * project_grading_data_sources / feedback_data_is_always_findable.
+ *
+ * Mirrors Track A conventions: env-driven, per-set failure isolation, alert
+ * only on SUSTAINED failure, heartbeat status JSON, clean SIGTERM, one-shot
+ * (nightly). Writes the FULL grade distribution into tag_grades plus the
+ * scalar tag_pop_total/tag_pop_10/tag_gem_rate and provenance.
+ *
+ * Usage:
+ *   tsx scripts/tag-pop.ts --all                  # gap-prioritised crawl
+ *   tsx scripts/tag-pop.ts --set base1            # one set
+ *   tsx scripts/tag-pop.ts --set base1 --dry-run  # fetch+match, no write
+ *   tsx scripts/tag-pop.ts --verify base1         # strict end-to-end check
+ *   tsx scripts/tag-pop.ts --all --year 1999      # restrict to a year
+ *
+ * Env knobs (.env.local or process env):
+ *   PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (or PUBLISHABLE key)
+ *   TROVE_TAG_CATEGORY          override category name (default auto/Pokémon)
+ *   TROVE_TAG_REQ_DELAY_MS      pacing between requests       (default 1200)
+ *   TROVE_TAG_SET_LIMIT         cap sets per run, 0 = all     (default 0)
+ *   TROVE_TAG_CARD_LIMIT        page size for /pops/card       (default 100)
+ *   TROVE_TAG_MAX_PAGES         max card pages per set         (default 60)
+ *   TROVE_TAG_FAIL_ALERT        consec set failures -> alert   (default 5)
+ *   TROVE_TAG_STATUS            heartbeat file path
+ */
+
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+import { execFile } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import {
+	resolvePokemonCategory,
+	getTagSets,
+	getAllTagCards,
+	tagPopScalars,
+	TagGradingError,
+	type TagSetRow,
+	type TagCardRow,
+	type TagGradeMap
+} from '../src/lib/services/tag-grading.js';
+import {
+	yearOf,
+	scoreTagCandidate,
+	normCardNumber,
+	tagOverride,
+	hasTagOverride
+} from './tag-aliases.js';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY =
+	process.env.SUPABASE_SERVICE_ROLE_KEY ??
+	process.env.PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ??
+	'';
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+	console.error('Missing SUPABASE_URL or SUPABASE_KEY. Check .env.local');
+	process.exit(1);
+}
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const num = (v: string | undefined, d: number) => {
+	const n = parseInt(v ?? '', 10);
+	return Number.isFinite(n) && n >= 0 ? n : d;
+};
+
+const REQ_DELAY_MS = num(process.env.TROVE_TAG_REQ_DELAY_MS, 1200);
+const SET_LIMIT = num(process.env.TROVE_TAG_SET_LIMIT, 0);
+const CARD_LIMIT = num(process.env.TROVE_TAG_CARD_LIMIT, 100);
+const MAX_PAGES = num(process.env.TROVE_TAG_MAX_PAGES, 60);
+const FAIL_ALERT = num(process.env.TROVE_TAG_FAIL_ALERT, 5);
+const STATUS_FILE =
+	process.env.TROVE_TAG_STATUS ??
+	join(homedir(), 'Library', 'Logs', 'Trove', 'tag-pop-status.json');
+
+const ts = () => new Date().toISOString();
+const log = (m: string) => console.log(`[${ts()}] ${m}`);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let stopping = false;
+
+// --------------------------------------------------------------------------
+// Validation gate — prove the matched TAG set is actually OUR set
+// --------------------------------------------------------------------------
+
+interface IndexCard {
+	card_id: string;
+	card_number: string | null;
+}
+
+async function loadIndexCards(setId: string): Promise<IndexCard[]> {
+	const { data, error } = await supabase
+		.from('card_index')
+		.select('card_id, card_number')
+		.eq('set_id', setId);
+	if (error) throw new Error(`card_index load failed: ${error.message}`);
+	return (data ?? []) as IndexCard[];
+}
+
+interface Matched {
+	card_id: string;
+	grades: TagGradeMap;
+}
+interface Validation {
+	ok: boolean;
+	reason: string;
+	matches: Matched[];
+}
+
+/** Among TAG rows sharing a card number (parallels/variations), pick the
+ *  largest-population print — deterministic and real; we hold one row per
+ *  number until the variant layer exists (north-star decision 5). */
+function pickCanonical(rows: TagCardRow[]): TagCardRow {
+	return rows.reduce((a, b) =>
+		tagPopScalars(b.grades).total > tagPopScalars(a.grades).total ? b : a
+	);
+}
+
+function validate(tagCards: TagCardRow[], idx: IndexCard[]): Validation {
+	if (tagCards.length === 0)
+		return { ok: false, reason: 'no TAG cards', matches: [] };
+	if (idx.length === 0)
+		return { ok: false, reason: 'no card_index rows for set', matches: [] };
+
+	const idxByNum = new Map<string, string>();
+	for (const c of idx) {
+		const k = normCardNumber(c.card_number);
+		if (k && !idxByNum.has(k)) idxByNum.set(k, c.card_id);
+	}
+
+	const tagByNum = new Map<string, TagCardRow[]>();
+	for (const r of tagCards) {
+		const k = normCardNumber(r.cardNumber);
+		if (!k) continue;
+		const arr = tagByNum.get(k);
+		if (arr) arr.push(r);
+		else tagByNum.set(k, [r]);
+	}
+
+	const matches: Matched[] = [];
+	let matchedNums = 0;
+	for (const [k, rows] of tagByNum) {
+		const cardId = idxByNum.get(k);
+		if (!cardId) continue;
+		matchedNums++;
+		matches.push({ card_id: cardId, grades: pickCanonical(rows).grades });
+	}
+
+	const denom = Math.min(tagByNum.size, idxByNum.size);
+	const overlapPct = denom > 0 ? (matchedNums / denom) * 100 : 0;
+	const ok = overlapPct >= 60 && matchedNums >= Math.min(5, idxByNum.size);
+	return {
+		ok,
+		reason: ok
+			? `overlap ${overlapPct.toFixed(0)}% (${matchedNums}/${denom})`
+			: `low overlap ${overlapPct.toFixed(0)}% (${matchedNums}/${denom}) — match likely wrong`,
+		matches
+	};
+}
+
+// --------------------------------------------------------------------------
+// Per-set processing
+// --------------------------------------------------------------------------
+
+interface TrackedSet {
+	set_id: string;
+	set_name: string;
+	release_date: string;
+}
+interface SetResult {
+	setId: string;
+	ok: boolean;
+	wrote: number;
+	note: string;
+}
+
+// year -> TAG set rows (fetched once per run, reused across our sets)
+const yearSetCache = new Map<number, TagSetRow[]>();
+
+async function tagSetsForYear(category: string, year: number): Promise<TagSetRow[]> {
+	const cached = yearSetCache.get(year);
+	if (cached) return cached;
+	const rows = await getTagSets({ categoryName: category, year });
+	yearSetCache.set(year, rows);
+	await sleep(REQ_DELAY_MS);
+	return rows;
+}
+
+async function processSet(
+	category: string,
+	set: TrackedSet,
+	idx: IndexCard[],
+	dryRun: boolean
+): Promise<SetResult> {
+	const year = yearOf(set.release_date);
+	if (!Number.isFinite(year))
+		return { setId: set.set_id, ok: false, wrote: 0, note: 'no release year' };
+
+	let tagSets: TagSetRow[];
+	try {
+		tagSets = await tagSetsForYear(category, year);
+	} catch (e) {
+		return {
+			setId: set.set_id,
+			ok: false,
+			wrote: 0,
+			note: `set-list fetch failed: ${(e as Error).message}`
+		};
+	}
+
+	// Candidate TAG (brand, set) keys: override first, else fuzzy-scored.
+	const ovr = tagOverride(set.set_id);
+	const scored = tagSets
+		.map((r) => ({ r, s: scoreTagCandidate(set.set_name, r.cardSetName) }))
+		.filter((x) => x.s > 0)
+		.sort((a, b) => b.s - a.s);
+	const candidates: TagSetRow[] = [];
+	if (ovr) {
+		const exact = tagSets.find(
+			(r) =>
+				r.brandName.trim() === ovr.brandName.trim() &&
+				r.cardSetName.trim() === ovr.cardSetName.trim()
+		);
+		if (exact) candidates.push(exact);
+	}
+	for (const x of scored) if (!candidates.includes(x.r)) candidates.push(x.r);
+
+	if (candidates.length === 0)
+		return {
+			setId: set.set_id,
+			ok: false,
+			wrote: 0,
+			note: 'NO ALIAS — no TAG set scored for this year (add to tag-aliases OVERRIDES)'
+		};
+
+	for (const cand of candidates) {
+		if (stopping) break;
+		let cards: TagCardRow[];
+		try {
+			cards = await getAllTagCards({
+				category,
+				year,
+				brandName: cand.brandName,
+				setName: cand.cardSetName,
+				limit: CARD_LIMIT,
+				maxPages: MAX_PAGES
+			});
+		} catch (e) {
+			log(
+				`  [${set.set_id}] fetch "${cand.cardSetName}"/"${cand.brandName.trim()}" failed: ${(e as Error).message}`
+			);
+			await sleep(REQ_DELAY_MS);
+			continue;
+		}
+		await sleep(REQ_DELAY_MS);
+
+		const v = validate(cards, idx);
+		if (!v.ok) {
+			log(
+				`  [${set.set_id}] reject "${cand.cardSetName}"/"${cand.brandName.trim()}" — ${v.reason}`
+			);
+			continue;
+		}
+		log(
+			`  [${set.set_id}] match "${cand.cardSetName}"/"${cand.brandName.trim()}" — ${v.reason}` +
+				(hasTagOverride(set.set_id) ? ' (override)' : ' (fuzzy)')
+		);
+
+		if (dryRun) {
+			const sample = v.matches[0];
+			log(
+				`  [${set.set_id}] DRY: ${v.matches.length} cards` +
+					(sample
+						? ` e.g. ${sample.card_id} -> ${JSON.stringify({
+								...tagPopScalars(sample.grades),
+								grades: sample.grades
+							})}`
+						: '')
+			);
+			return {
+				setId: set.set_id,
+				ok: true,
+				wrote: 0,
+				note: `DRY ${cand.cardSetName}/${cand.brandName.trim()}`
+			};
+		}
+
+		const now = new Date().toISOString();
+		let wrote = 0;
+		let errs = 0;
+		for (const m of v.matches) {
+			const sc = tagPopScalars(m.grades);
+			const { error } = await supabase
+				.from('card_index')
+				.update({
+					tag_pop_total: sc.total,
+					tag_pop_10: sc.grade10,
+					tag_gem_rate: sc.gemRate,
+					tag_grades: m.grades,
+					tag_fetched_at: now,
+					tag_synced_at: now,
+					tag_set_name: cand.cardSetName,
+					tag_brand_name: cand.brandName.trim(),
+					tag_year: year
+				})
+				.eq('card_id', m.card_id);
+			if (error) errs++;
+			else wrote++;
+		}
+		log(`  [${set.set_id}] wrote ${wrote}, errors ${errs} (${v.reason})`);
+		return {
+			setId: set.set_id,
+			ok: wrote > 0,
+			wrote,
+			note: `${cand.cardSetName}/${cand.brandName.trim()}`
+		};
+	}
+
+	return {
+		setId: set.set_id,
+		ok: false,
+		wrote: 0,
+		note: 'NO MATCH — all candidates failed the overlap gate'
+	};
+}
+
+// --------------------------------------------------------------------------
+// Gap prioritisation — never-synced sets first, then staleest
+// --------------------------------------------------------------------------
+
+async function prioritisedSets(): Promise<TrackedSet[]> {
+	const { data: tracked, error } = await supabase
+		.from('tracked_sets')
+		.select('set_id, set_name, release_date')
+		.eq('enabled', true);
+	if (error) throw new Error(`tracked_sets load failed: ${error.message}`);
+	const sets = (tracked ?? []) as TrackedSet[];
+
+	// Per-set TAG freshness from card_index (paged; only 2 small columns).
+	const minSynced = new Map<string, number | null>(); // null = has unsynced
+	let from = 0;
+	const page = 1000;
+	for (;;) {
+		const { data, error: e } = await supabase
+			.from('card_index')
+			.select('set_id, tag_synced_at')
+			.range(from, from + page - 1);
+		if (e) throw new Error(`card_index scan failed: ${e.message}`);
+		const rows = (data ?? []) as Array<{ set_id: string; tag_synced_at: string | null }>;
+		for (const r of rows) {
+			if (r.tag_synced_at == null) {
+				minSynced.set(r.set_id, null);
+				continue;
+			}
+			const cur = minSynced.get(r.set_id);
+			if (cur === null) continue; // an unsynced row already pins this set
+			const t = Date.parse(r.tag_synced_at);
+			if (cur === undefined || t < cur) minSynced.set(r.set_id, t);
+		}
+		if (rows.length < page) break;
+		from += page;
+	}
+
+	const rank = (id: string): number => {
+		const v = minSynced.get(id);
+		if (v === undefined || v === null) return -1; // never-synced first
+		return v;
+	};
+	return sets.sort((a, b) => {
+		const ra = rank(a.set_id);
+		const rb = rank(b.set_id);
+		if (ra !== rb) return ra - rb;
+		return yearOf(a.release_date) - yearOf(b.release_date);
+	});
+}
+
+// --------------------------------------------------------------------------
+// Status / alerting (mirrors gemrate-pop)
+// --------------------------------------------------------------------------
+
+function writeStatus(s: Record<string, unknown>) {
+	try {
+		mkdirSync(dirname(STATUS_FILE), { recursive: true });
+		writeFileSync(STATUS_FILE, JSON.stringify({ updated_at: ts(), ...s }, null, 2));
+	} catch (e) {
+		log(`status write failed: ${(e as Error).message}`);
+	}
+}
+
+function alertSustained(msg: string) {
+	log(`SUSTAINED FAILURE — ${msg}`);
+	if (process.platform === 'darwin') {
+		try {
+			execFile('/usr/bin/osascript', [
+				'-e',
+				`display notification "tag-pop: ${msg}" with title "Trove" sound name "Basso"`
+			]);
+		} catch {
+			/* best-effort */
+		}
+	}
+}
+
+for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+	process.on(sig, () => {
+		log(`${sig} received — finishing current set then exiting`);
+		stopping = true;
+	});
+}
+
+// --------------------------------------------------------------------------
+// CLI
+// --------------------------------------------------------------------------
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			set: { type: 'string' },
+			all: { type: 'boolean', default: false },
+			'dry-run': { type: 'boolean', default: false },
+			verify: { type: 'string' },
+			year: { type: 'string' },
+			limit: { type: 'string' }
+		},
+		strict: false
+	});
+
+	const dryRun = !!values['dry-run'] || !!values.verify;
+	const yearFilter = values.year ? parseInt(values.year as string, 10) : null;
+
+	let setIds: string[];
+	if (values.verify) setIds = [values.verify as string];
+	else if (values.set) setIds = (values.set as string).split(',').map((s) => s.trim());
+	else if (values.all) setIds = [];
+	else {
+		console.log('Usage: --all | --set <id,..> | --verify <id> [--dry-run] [--year YYYY]');
+		return;
+	}
+
+	let category: string;
+	try {
+		category = process.env.TROVE_TAG_CATEGORY || (await resolvePokemonCategory());
+	} catch (e) {
+		console.error(`Cannot resolve TAG category: ${(e as Error).message}`);
+		process.exit(1);
+	}
+
+	let sets: TrackedSet[];
+	if (setIds.length > 0) {
+		const { data, error } = await supabase
+			.from('tracked_sets')
+			.select('set_id, set_name, release_date')
+			.in('set_id', setIds);
+		if (error) throw new Error(error.message);
+		sets = (data ?? []) as TrackedSet[];
+	} else {
+		sets = await prioritisedSets();
+	}
+	if (yearFilter)
+		sets = sets.filter((s) => yearOf(s.release_date) === yearFilter);
+
+	const cap = num(values.limit as string, SET_LIMIT);
+	if (cap > 0) sets = sets.slice(0, cap);
+
+	log(
+		`tag-pop start — ${sets.length} set(s), category="${category}"` +
+			`${yearFilter ? ` year=${yearFilter}` : ''}${dryRun ? ' DRY-RUN' : ''}`
+	);
+
+	let consecBad = 0;
+	let totalWrote = 0;
+	const needAlias: string[] = [];
+	const results: SetResult[] = [];
+
+	for (let i = 0; i < sets.length; i++) {
+		if (stopping) {
+			log('stopping — clean exit');
+			break;
+		}
+		const set = sets[i];
+		try {
+			const idx = await loadIndexCards(set.set_id);
+			const r = await processSet(category, set, idx, dryRun);
+			results.push(r);
+			totalWrote += r.wrote;
+			if (r.ok) consecBad = 0;
+			else {
+				consecBad++;
+				if (r.note.startsWith('NO ALIAS') || r.note.startsWith('NO MATCH'))
+					needAlias.push(set.set_id);
+			}
+			log(
+				`(${i + 1}/${sets.length}) ${set.set_id} — ${r.ok ? 'OK' : 'MISS'} ` +
+					`wrote=${r.wrote} ${r.note}`
+			);
+		} catch (e) {
+			consecBad++;
+			const m = e instanceof TagGradingError ? `TAG: ${e.message}` : (e as Error).message;
+			log(`(${i + 1}/${sets.length}) ${set.set_id} — ERROR ${m}`);
+		}
+
+		writeStatus({
+			phase: stopping ? 'stopping' : 'running',
+			processed: i + 1,
+			total: sets.length,
+			total_wrote: totalWrote,
+			consecutive_bad: consecBad,
+			need_alias: needAlias
+		});
+
+		if (consecBad >= FAIL_ALERT) {
+			alertSustained(`${consecBad} consecutive sets failed`);
+			consecBad = 0;
+		}
+	}
+
+	const okCount = results.filter((r) => r.ok).length;
+	log(`tag-pop done — ${okCount}/${sets.length} sets ok, ${totalWrote} card-rows written`);
+	if (needAlias.length)
+		log(`NEED ALIAS (add to tag-aliases OVERRIDES): ${needAlias.join(', ')}`);
+	writeStatus({
+		phase: 'done',
+		processed: sets.length,
+		ok: okCount,
+		total_wrote: totalWrote,
+		need_alias: needAlias
+	});
+}
+
+main().catch((e) => {
+	console.error('Fatal:', e);
+	process.exit(1);
+});

--- a/src/lib/services/tag-grading.ts
+++ b/src/lib/services/tag-grading.ts
@@ -1,0 +1,280 @@
+/**
+ * TAG Grading — population report client
+ *
+ * TAG publishes its own authoritative pop report (my.taggrading.com), backed
+ * by https://api.taggrading.com. The API is not Cloudflare-walled and needs
+ * no login for pop data, but it protects responses with client-side crypto.
+ * Reverse-engineered from the SPA bundle 2026-05-18:
+ *
+ *   - Request must carry header `x-tag-key` =
+ *       sha256( "<HASH_SALT>:" + sortedParamValues.join(",") )  (hex)
+ *     where sortedParamValues = the request params with undefined/null/""
+ *     dropped, VALUES only (names don't matter), JS-default-sorted. A call
+ *     with no params hashes the literal "<HASH_SALT>:".
+ *   - Response body is `ivHex:ciphertextHex`, AES-256-CBC, key =
+ *       sha256(DEC_PASSPHRASE) (raw 32-byte digest), PKCS7. Decrypted text
+ *     is JSON; the real payload is its `.data`.
+ *   - Plaintext JSON like {"status":403,...} is an unencrypted error.
+ *
+ * Keys ship in the client by necessity but are undocumented and can rotate —
+ * callers must isolate failures (the nightly crawl fails per-set, never the
+ * whole run) and treat a parse/crypto failure as "no data", never fabricate.
+ *
+ * TAG's scale is 1–10 WITH half grades (1.5 … 8.5) plus "VA"; grade "10" is
+ * the gem tier. Distribution maps use those string keys.
+ */
+
+import { createHash, createDecipheriv } from 'node:crypto';
+
+const TAG_API = 'https://api.taggrading.com';
+const HASH_SALT = 'TZYOj76MKF1Aw0QK0gpAGySALCNgKG';
+const DEC_PASSPHRASE = 'K6ucGQIf7viQW9IT0XLUk5MjSIxssgisqj';
+const DEC_KEY = createHash('sha256').update(DEC_PASSPHRASE).digest(); // 32 bytes
+const UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+	'(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+
+export class TagGradingError extends Error {}
+
+type ParamVal = string | number | undefined | null;
+export type TagParams = Record<string, ParamVal>;
+
+/** Replicates the SPA's x-tag-key input: lodash omitBy(undefined|null|"")
+ *  -> Object.values -> Array.prototype.sort() (JS default, code-unit) -> join(","). */
+function signParams(params?: TagParams): string {
+	let joined = '';
+	if (params) {
+		const vals = Object.values(params)
+			.filter((v) => v !== undefined && v !== null && v !== '')
+			.map((v) => String(v));
+		vals.sort(); // JS default lexicographic — matches the bundle exactly
+		joined = vals.join(',');
+	}
+	return createHash('sha256').update(`${HASH_SALT}:${joined}`).digest('hex');
+}
+
+function decryptBody(raw: string): unknown {
+	const idx = raw.indexOf(':');
+	if (idx <= 0) throw new TagGradingError('unexpected response shape (no iv:ct)');
+	const iv = Buffer.from(raw.slice(0, idx), 'hex');
+	const ctHex = raw.slice(idx + 1);
+	const d = createDecipheriv('aes-256-cbc', DEC_KEY, iv);
+	let out = d.update(ctHex, 'hex', 'utf8');
+	out += d.final('utf8');
+	const parsed = JSON.parse(out) as { data?: unknown };
+	return parsed?.data;
+}
+
+async function tagRequest<T>(path: string, params?: TagParams, timeoutMs = 40000): Promise<T> {
+	const qs = params
+		? '?' +
+			Object.entries(params)
+				.filter(([, v]) => v !== undefined && v !== null && v !== '')
+				.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+				.join('&')
+		: '';
+	const ctrl = new AbortController();
+	const t = setTimeout(() => ctrl.abort(), timeoutMs);
+	let res: Response;
+	try {
+		res = await fetch(`${TAG_API}${path}${qs}`, {
+			headers: {
+				'User-Agent': UA,
+				'Content-Type': 'application/json',
+				Pragma: 'no-cache',
+				'x-tag-key': signParams(params),
+				authorization: 'undefined',
+				Origin: 'https://my.taggrading.com',
+				Referer: 'https://my.taggrading.com/'
+			},
+			signal: ctrl.signal
+		});
+	} catch (e) {
+		throw new TagGradingError(`network: ${(e as Error).message}`);
+	} finally {
+		clearTimeout(t);
+	}
+	const raw = await res.text();
+	// Unencrypted JSON == an error envelope (403/400/500/etc).
+	if (raw.startsWith('{') || raw.startsWith('[')) {
+		let msg = `HTTP ${res.status}`;
+		try {
+			const j = JSON.parse(raw) as { message?: string; status?: number };
+			if (j?.message) msg = `${j.status ?? res.status}: ${j.message}`;
+		} catch {
+			/* keep generic */
+		}
+		throw new TagGradingError(msg);
+	}
+	if (!res.ok) throw new TagGradingError(`HTTP ${res.status}`);
+	return decryptBody(raw) as T;
+}
+
+// --------------------------------------------------------------------------
+// Typed endpoints
+// --------------------------------------------------------------------------
+
+export interface TagCategory {
+	id: number;
+	name: string;
+	type: string;
+	disable: boolean;
+	group: string;
+}
+export interface TagYearRow {
+	cardYear: string;
+	numberOfSets: number;
+	totalItems: number;
+	totalGraded: number;
+}
+/** grade label ("1".."10","1.5".."8.5","VA") -> count */
+export type TagGradeMap = Record<string, number>;
+export interface TagSetRow {
+	cardSetName: string;
+	brandName: string;
+	grades: TagGradeMap;
+}
+export interface TagCardRow {
+	cardName: string;
+	cardNumber: string;
+	variation?: string;
+	grades: TagGradeMap;
+}
+interface TagPaged<T> {
+	items: T[];
+	total?: number;
+	limit?: number;
+}
+
+export async function getTagCategories(): Promise<TagCategory[]> {
+	// no params -> hashes "<salt>:" ; response .data is the array
+	const data = await tagRequest<TagCategory[]>('/references/category');
+	return Array.isArray(data) ? data : [];
+}
+
+/** Resolve the Pokémon category name as TAG spells it (defensive vs. rename). */
+export async function resolvePokemonCategory(): Promise<string> {
+	try {
+		const cats = await getTagCategories();
+		const hit = cats.find((c) => /pok[eé]?mon/i.test(c.name) && !c.disable);
+		if (hit) return hit.name;
+	} catch {
+		/* fall through to the known value */
+	}
+	return 'Pokémon';
+}
+
+export async function getTagYears(categoryName: string): Promise<TagYearRow[]> {
+	const d = await tagRequest<TagPaged<TagYearRow>>('/pops/year', { categoryName });
+	return d?.items ?? [];
+}
+
+export async function getTagSets(args: {
+	categoryName: string;
+	year: string | number;
+	page?: number;
+	limit?: number;
+}): Promise<TagSetRow[]> {
+	const d = await tagRequest<TagPaged<TagSetRow>>('/pops/set', {
+		page: args.page ?? 1,
+		limit: args.limit ?? 200,
+		categoryName: args.categoryName,
+		year: args.year
+	});
+	return d?.items ?? [];
+}
+
+export async function getTagCardsPage(args: {
+	category: string;
+	year: string | number;
+	brandName: string;
+	setName: string;
+	page?: number;
+	limit?: number;
+}): Promise<TagPaged<TagCardRow>> {
+	return tagRequest<TagPaged<TagCardRow>>('/pops/card', {
+		page: args.page ?? 1,
+		limit: args.limit ?? 100,
+		category: args.category,
+		year: args.year,
+		brandName: args.brandName,
+		setName: args.setName
+	});
+}
+
+/** Walk all pages for one TAG (brand, set, year). Bounded to avoid runaway. */
+export async function getAllTagCards(args: {
+	category: string;
+	year: string | number;
+	brandName: string;
+	setName: string;
+	limit?: number;
+	maxPages?: number;
+}): Promise<TagCardRow[]> {
+	const limit = args.limit ?? 100;
+	const maxPages = args.maxPages ?? 60;
+	const out: TagCardRow[] = [];
+	for (let page = 1; page <= maxPages; page++) {
+		const pg = await getTagCardsPage({ ...args, page, limit });
+		const items = pg?.items ?? [];
+		out.push(...items);
+		const total = pg?.total ?? out.length;
+		if (out.length >= total || items.length === 0) break;
+	}
+	return out;
+}
+
+/** Normalise a card number for matching: "42/102" -> "42", strip leading
+ *  zeros. Mirrors scripts/tag-aliases.normCardNumber so on-query re-verify
+ *  and the nightly crawl agree. */
+function normNum(v: string | null | undefined): string {
+	const s = String(v ?? '')
+		.trim()
+		.toLowerCase();
+	return (s.split('/')[0]?.trim() ?? '').replace(/^0+(?=\d)/, '');
+}
+
+/**
+ * On-query single-card TAG pop. Given a card's already-known TAG provenance
+ * (set/brand/year from a prior crawl) plus its number, return that card's
+ * current grade map — or null if not found. Pages the set once; the largest
+ * print wins when a number has parallels (matches the crawler's canonical
+ * pick). Never throws into the caller's hot path beyond TagGradingError.
+ */
+export async function getTagCardPop(args: {
+	category: string;
+	year: string | number;
+	brandName: string;
+	setName: string;
+	cardNumber: string;
+}): Promise<TagGradeMap | null> {
+	const want = normNum(args.cardNumber);
+	if (!want) return null;
+	const cards = await getAllTagCards(args);
+	const hits = cards.filter((c) => normNum(c.cardNumber) === want);
+	if (hits.length === 0) return null;
+	return hits.reduce((a, b) =>
+		tagPopScalars(b.grades).total > tagPopScalars(a.grades).total ? b : a
+	).grades;
+}
+
+// --------------------------------------------------------------------------
+// Distribution helpers (honest scalars derived from the full map)
+// --------------------------------------------------------------------------
+
+export interface TagPopScalars {
+	total: number;
+	grade10: number;
+	/** percent, 2dp, clamped to numeric(5,2) */
+	gemRate: number | null;
+}
+
+export function tagPopScalars(grades: TagGradeMap | null | undefined): TagPopScalars {
+	if (!grades) return { total: 0, grade10: 0, gemRate: null };
+	let total = 0;
+	for (const v of Object.values(grades)) total += Number(v) || 0;
+	const grade10 = Number(grades['10']) || 0;
+	const gemRate =
+		total > 0 ? Math.min(999.99, Math.round((grade10 / total) * 10000) / 100) : null;
+	return { total, grade10, gemRate };
+}

--- a/supabase/migrations/019_tag_pop.sql
+++ b/supabase/migrations/019_tag_pop.sql
@@ -1,0 +1,37 @@
+-- Trove: Track A — real TAG Grading population
+--
+-- TAG (taggrading.com) publishes its own authoritative pop report. It is now
+-- a real, reachable source (api.taggrading.com, reverse-engineered: sha256
+-- x-tag-key + AES-256-CBC responses). migrations 003/007 reserved
+-- tag_pop_total / tag_pop_10 / tag_fetched_at for exactly this and have kept
+-- them NULL (007 cleared the old CGC mislabel). This migration adds the
+-- pieces needed to store TAG's FULL grade distribution honestly — TAG uses a
+-- 1–10 scale WITH half grades (1.5 … 8.5) plus VA, which a single integer
+-- cannot represent.
+--
+-- ADD-ONLY and idempotent. tag_pop_total/tag_pop_10/tag_fetched_at are
+-- REUSED as-is (no redefinition). combined_pop_total stays PSA+CGC — folding
+-- TAG in would silently shift the /browse hunt filter; revisit separately.
+
+-- Full per-card grade distribution as written by the TAG crawl, e.g.
+-- {"1":2,"2.5":1,"9":244,"10":51,"VA":8}. Authoritative detail; the integer
+-- tag_pop_total/tag_pop_10 columns remain the fast scalar path.
+alter table card_index add column if not exists tag_grades jsonb;
+
+-- Gem rate = grade-10 / total, percent (numeric(5,2), 0–999.99 safe).
+alter table card_index add column if not exists tag_gem_rate numeric(5, 2);
+
+-- Provenance so the nightly crawl can skip unchanged sets and so a
+-- single-card on-query refresh knows which TAG set/brand to re-fetch.
+alter table card_index add column if not exists tag_set_name text;
+alter table card_index add column if not exists tag_brand_name text;
+alter table card_index add column if not exists tag_year integer;
+alter table card_index add column if not exists tag_synced_at timestamptz;
+
+-- "Hot TAG pop" / Gem-10 sort + cheap staleest-first crawl ordering.
+create index if not exists idx_card_index_tag_pop_10
+    on card_index (tag_pop_10 desc nulls last)
+    where tag_pop_10 is not null;
+
+create index if not exists idx_card_index_tag_synced
+    on card_index (tag_synced_at asc nulls first);


### PR DESCRIPTION
## Summary
- **Fix CGC fabrication bug**: `refresh-index.ts` was writing real CGC pop into the `tag_pop_*` columns (re-breaking migration 007 every enrich cycle) and dropping `cgc10` price entirely. Now writes the real `cgc_pop_*` columns + `cgc10_price`; `tag_pop_*` is no longer fabricated. Restores `combined_pop_total` (PSA+CGC) and the coverage-ledger CGC count.
- **Harden GemRate**: a live probe proved `item-details-advanced` is PSA-only — `cgc`/`bgs` return empty, `sgc` is Cloudflare-walled, and `grader=tag` echoes the PSA payload byte-for-byte. Added a row-signature honesty gate so a `TROVE_GEMRATE_GRADERS` override can never silently write PSA pop as TAG.
- **TAG Grading Track A (new)**: TAG publishes its own authoritative pop report. Reverse-engineered `api.taggrading.com` (sha256 `x-tag-key` + AES-256-CBC). Adds shared client `src/lib/services/tag-grading.ts`, nightly crawler `scripts/tag-pop.ts` + `tag-aliases.ts` (fuzzy set-match proven by a card_number overlap gate, mirrors the GemRate Track A pattern), on-query single-card re-verify in `refresh-index --card`, `cron-tag-pop.sh` + `engine-tag.yml`, and migration `019_tag_pop.sql` (full grade distribution JSONB incl. half-grades + VA, gem rate, provenance; reuses the reserved 003/007 `tag_pop_*` columns).

## Test plan
- [x] `vitest run` — 51/51 passed
- [x] `npm run check` — 18 errors / 2 warnings (pre-existing baseline), 0 new, none in changed files
- [x] TAG TS service live — resolves category, 20 years, real 1999 set lists
- [x] `tsx scripts/tag-pop.ts --set base1 --dry-run` — matched Base Set 102/102, full real grade distribution; honesty gate correctly rejected a junk 1-card candidate
- [x] CGC fix verified live — Charizard real CGC10 $7068.75, cgcPop total 9 / g10 4
- [ ] **Apply `supabase/migrations/019_tag_pop.sql` by hand in Supabase** (Trove project). Until applied, `tag-pop` no-ops cleanly per-set (errors per set, no writes) and the on-query path stays inert — safe to merge ahead of the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)