### PR TITLE
Full per-grade price ladder — real ladder + honest estimates

### DIFF
--- a/scripts/refresh-index.ts
+++ b/scripts/refresh-index.ts
@@ -229,6 +229,10 @@ async function enrichOneCard(card: TcgCard): Promise<EnrichedCardOutput> {
 			tag10_source: pc?.tag10 != null ? 'pricecharting' : null,
 			cgc10_price: pc?.cgc10 ?? null,
 			cgc10_source: pc?.cgc10 != null ? 'pricecharting' : null,
+			// Real per-grade ladder (migration 020). Real cells only —
+			// PriceCharting blank `-` rows are already dropped upstream.
+			grade_ladder: pc?.gradeLadder ?? null,
+			grade_ladder_fetched_at: pc ? now : null,
 			graded_prices_fetched_at: pc ? now : null,
 			psa10_last_sold_at: pc?.psa10LastSold ?? null,
 			psa_pop_total: psaPop?.total ?? null,
@@ -315,6 +319,10 @@ function stalePriceRow(
 		tag10_source: pc?.tag10 != null ? 'pricecharting' : null,
 		cgc10_price: pc?.cgc10 ?? null,
 		cgc10_source: pc?.cgc10 != null ? 'pricecharting' : null,
+		// Real per-grade ladder (migration 020). Real cells only —
+		// PriceCharting blank `-` rows are already dropped upstream.
+		grade_ladder: pc?.gradeLadder ?? null,
+		grade_ladder_fetched_at: pc ? now : null,
 		graded_prices_fetched_at: pc ? now : null,
 		psa10_last_sold_at: pc?.psa10LastSold ?? null,
 		psa_pop_total: psaPop?.total ?? null,

--- a/src/app.css
+++ b/src/app.css
@@ -28,6 +28,9 @@
 	--color-vault-green: #34d399;
 	--color-vault-red: #f87171;
 	--color-vault-cyan: #22d3ee;
+	/* Estimated (non-real) per-grade values render in this darker blue so
+	   they are unmistakable next to bold-white real market prices. */
+	--color-vault-estimate: #3b82f6;
 
 	/* Pokemon type colors — unchanged so type badges keep their identity. */
 	--color-type-fire: #f97316;

--- a/src/lib/services/__tests__/grade-estimate.test.ts
+++ b/src/lib/services/__tests__/grade-estimate.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { buildGradeLadders, type CohortRow, type EstimatorInput } from '../grade-estimate';
+
+// Vintage Rare Holo so cohort + input share one era×rarity bucket.
+const baseInput: EstimatorInput = {
+	rarity: 'Rare Holo',
+	setReleaseDate: '2000-01-01',
+	rawNm: null,
+	psa10: null,
+	cgc10: null,
+	tag10: null,
+	gradeLadder: null,
+	cohort: null
+};
+
+function cohort(n: number, opts: Partial<CohortRow>): CohortRow[] {
+	return Array.from({ length: n }, () => ({
+		rarity: 'Rare Holo',
+		set_release_date: '2000-01-01',
+		raw_nm_price: null,
+		psa10_price: null,
+		cgc10_price: null,
+		tag10_price: null,
+		...opts
+	}));
+}
+
+const grader = (out: ReturnType<typeof buildGradeLadders>, g: string) =>
+	out.find((l) => l.grader === g);
+const cell = (out: ReturnType<typeof buildGradeLadders>, g: string, grade: string) =>
+	grader(out, g)?.cells.find((c) => c.grade === grade);
+
+describe('real PSA ladder is passed through, never re-estimated', () => {
+	const out = buildGradeLadders({
+		...baseInput,
+		gradeLadder: { psa: { '8': 100, '9': 200, '10': 500 } }
+	});
+
+	it('shows real PSA cells as real, unchanged', () => {
+		for (const [g, v] of [
+			['8', 100],
+			['9', 200],
+			['10', 500]
+		] as const) {
+			const c = cell(out, 'PSA', g)!;
+			expect(c.real).toBe(true);
+			expect(c.value).toBe(v);
+			expect(c.confidence).toBeUndefined();
+			expect(c.basis).toBeUndefined();
+		}
+	});
+
+	it('does NOT fabricate PSA sub-10 cells with no real anchor', () => {
+		// grades 1–7 and 9.5 have no real PriceCharting price → absent.
+		for (const g of ['1', '5', '7', '9.5']) expect(cell(out, 'PSA', g)).toBeUndefined();
+	});
+});
+
+describe('cross-grader estimate anchored on this card (near-real)', () => {
+	// Real PSA ladder + real CGC 10 on the same card ⇒ R = 250/500 = 0.5.
+	const out = buildGradeLadders({
+		...baseInput,
+		gradeLadder: { psa: { '8': 100, '9': 200, '10': 500 }, cgc: { '10': 250 } }
+	});
+
+	it('CGC 10 stays real', () => {
+		const c = cell(out, 'CGC', '10')!;
+		expect(c.real).toBe(true);
+		expect(c.value).toBe(250);
+	});
+
+	it('CGC 8/9 estimated = real PSA@grade × own-card R, high confidence', () => {
+		const c8 = cell(out, 'CGC', '8')!;
+		expect(c8.real).toBe(false);
+		expect(c8.value).toBe(50); // 100 × 0.5
+		expect(c8.confidence).toBeGreaterThanOrEqual(0.8);
+		expect(c8.tier).toBe('high');
+		expect(c8.basis).toContain('Not a market price');
+		expect(cell(out, 'CGC', '9')!.value).toBe(100); // 200 × 0.5
+	});
+
+	it('CGC grades with no real PSA shape anchor are omitted', () => {
+		expect(cell(out, 'CGC', '7')).toBeUndefined();
+		expect(cell(out, 'CGC', '9.5')).toBeUndefined();
+	});
+});
+
+describe('cross-grader estimate calibrated from the cohort', () => {
+	it('uses calibrated CGC10/PSA10 when the card has no own pair', () => {
+		const out = buildGradeLadders({
+			...baseInput,
+			gradeLadder: { psa: { '9': 100, '10': 300 } },
+			cohort: cohort(20, { psa10_price: 100, cgc10_price: 60, raw_nm_price: 10 })
+		});
+		const c9 = cell(out, 'CGC', '9')!;
+		expect(c9.real).toBe(false);
+		expect(c9.value).toBe(60); // 100 × 0.6
+		expect(c9.tier).toBe('low'); // calibrated, mid cohort → dimmer
+		expect(c9.basis).toContain('calibrated');
+	});
+
+	it('omits the estimate entirely when the cohort is too thin (<8 pairs)', () => {
+		const out = buildGradeLadders({
+			...baseInput,
+			gradeLadder: { psa: { '9': 100, '10': 300 } },
+			cohort: cohort(5, { psa10_price: 100, cgc10_price: 60 })
+		});
+		expect(grader(out, 'CGC')).toBeUndefined();
+	});
+});
+
+describe('Path B — raw→PSA10 only when there is no real PSA at all', () => {
+	it('emits one gated, clearly-marked blue PSA 10 estimate', () => {
+		const out = buildGradeLadders({
+			...baseInput,
+			rawNm: 20,
+			cohort: cohort(130, { raw_nm_price: 10, psa10_price: 80 })
+		});
+		const c = cell(out, 'PSA', '10')!;
+		expect(c.real).toBe(false);
+		expect(c.value).toBe(160); // 20 × (80/10)
+		expect(c.confidence).toBeLessThanOrEqual(0.6); // never "high"
+		expect(c.basis).toContain('no real PSA sale');
+	});
+
+	it('does NOT anchor other graders on an estimated PSA10 (no estimate-of-estimate)', () => {
+		const out = buildGradeLadders({
+			...baseInput,
+			rawNm: 20,
+			cohort: cohort(130, { raw_nm_price: 10, psa10_price: 80 })
+		});
+		expect(grader(out, 'CGC')).toBeUndefined();
+		expect(grader(out, 'TAG')).toBeUndefined();
+	});
+
+	it('shows nothing when the multiple cohort is too thin', () => {
+		const out = buildGradeLadders({
+			...baseInput,
+			rawNm: 20,
+			cohort: cohort(5, { raw_nm_price: 10, psa10_price: 80 })
+		});
+		expect(out).toHaveLength(0);
+	});
+});
+
+describe('BGS has no cohort column — estimates only from this card', () => {
+	it('estimates BGS sub-10 from own real BGS10 + real PSA ladder', () => {
+		const out = buildGradeLadders({
+			...baseInput,
+			gradeLadder: { psa: { '8': 100, '10': 400 }, bgs: { '10': 600, '10BL': 1500 } }
+		});
+		expect(cell(out, 'BGS', '10')!.real).toBe(true);
+		expect(cell(out, 'BGS', '10BL')!.real).toBe(true);
+		const c8 = cell(out, 'BGS', '8')!;
+		expect(c8.real).toBe(false);
+		expect(c8.value).toBe(150); // 100 × (600/400)
+		expect(c8.tier).toBe('high');
+	});
+
+	it('cannot estimate BGS from the cohort (no bgs10 column) — real cells only', () => {
+		const out = buildGradeLadders({
+			...baseInput,
+			gradeLadder: { psa: { '8': 100, '10': 400 } },
+			cohort: cohort(200, { psa10_price: 100, cgc10_price: 50, tag10_price: 70 })
+		});
+		expect(grader(out, 'BGS')).toBeUndefined();
+	});
+});
+
+describe('honesty invariants', () => {
+	const out = buildGradeLadders({
+		...baseInput,
+		gradeLadder: { psa: { '7': 50, '8': 100, '10': 500 }, cgc: { '10': 300 }, tag: { '10': 450 } }
+	});
+
+	it('every real cell has no confidence/basis; every estimate has both + is blue (real:false)', () => {
+		for (const l of out)
+			for (const c of l.cells) {
+				if (c.real) {
+					expect(c.confidence).toBeUndefined();
+					expect(c.basis).toBeUndefined();
+				} else {
+					expect(typeof c.confidence).toBe('number');
+					expect(c.confidence!).toBeGreaterThanOrEqual(0.4);
+					expect(c.basis).toContain('Not a market price');
+				}
+			}
+	});
+});

--- a/src/lib/services/grade-estimate.ts
+++ b/src/lib/services/grade-estimate.ts
@@ -1,0 +1,322 @@
+/**
+ * Per-grade value estimator — honest, real-anchored.
+ *
+ * Doctrine (see feedback_multipliers_vs_real_data / north-star honesty):
+ * an estimate is NEVER a free `raw × constant`. Every estimated cell is
+ * pinned to a real price on THIS card and a ratio calibrated from real
+ * cross-sectional catalog data, gated on confidence, and rendered
+ * unmistakably as an estimate by the UI.
+ *
+ * Architecture (real-ladder-first):
+ *  - PSA ladder is REAL or ABSENT. PriceCharting's `#full-prices` table
+ *    gives a real PSA price ladder (its generic "Grade N" = PSA-graded
+ *    sales). We show those real cells; we NEVER fabricate a PSA sub-10
+ *    cell (no real shape anchor → render nothing). The single exception
+ *    is a card with no real PSA at all: a calibrated raw→PSA10 estimate
+ *    (Path B), hard-gated, clearly marked, and never used to anchor any
+ *    other grader (no estimate-of-estimate).
+ *  - CGC / BGS / TAG: real where PriceCharting names them (their 10 /
+ *    9.5 / pristine / black-label). Every other grade is estimated as
+ *    `realPSA@grade × R`, where R = that grader's 10 ÷ PSA 10 — taken
+ *    from THIS card's own real pair when present (near-real), else the
+ *    calibrated median over the era×rarity cohort. A grade with no real
+ *    PSA shape anchor is omitted (no fabrication).
+ */
+
+import type { GradeLadder } from './pricecharting-scraper';
+
+// Era bucketing for curve calibration. Mirrors insights.ts::eraForDate
+// intentionally — this module stays pure/DB-free (insights.ts transitively
+// imports the Supabase client), and the boundaries are a stable domain fact.
+type Era = 'vintage' | 'ex' | 'modern' | 'current' | 'unknown';
+function eraForDate(date: string | null | undefined): Era {
+	if (!date) return 'unknown';
+	const year = Number.parseInt(date.slice(0, 4), 10);
+	if (!Number.isFinite(year)) return 'unknown';
+	if (year < 2003) return 'vintage';
+	if (year < 2011) return 'ex';
+	if (year < 2020) return 'modern';
+	return 'current';
+}
+
+export interface CohortRow {
+	rarity: string | null;
+	set_release_date: string | null;
+	raw_nm_price: number | null;
+	psa10_price: number | null;
+	cgc10_price: number | null;
+	tag10_price: number | null;
+}
+
+export interface EstimatorInput {
+	rarity: string | null;
+	setReleaseDate: string | null;
+	rawNm: number | null;
+	/** Real PSA 10 / CGC 10 / TAG 10 columns (card_index). */
+	psa10: number | null;
+	cgc10: number | null;
+	tag10: number | null;
+	/** This card's REAL per-grade ladder (migration 020), real cells only. */
+	gradeLadder: GradeLadder | null;
+	/** Calibration cohort (catalog rows with real raw + real PSA 10). */
+	cohort: CohortRow[] | null;
+}
+
+export type Grader = 'PSA' | 'CGC' | 'BGS' | 'TAG';
+export type Tier = 'high' | 'medium' | 'low';
+
+export interface GradeCell {
+	grade: string;
+	value: number;
+	/** true = real market price (UI: bold white). false = estimate (UI: blue). */
+	real: boolean;
+	confidence?: number;
+	tier?: Tier;
+	/** Human, spelled-out derivation for the estimate tooltip. */
+	basis?: string;
+}
+
+export interface GraderLadder {
+	grader: Grader;
+	cells: GradeCell[];
+}
+
+// Standard low→high ladder shown for every grader. PriceCharting prices
+// the integer ladder + 9.5; grader-specific specials are appended only
+// when that grader has a real value for them.
+const BASE_GRADES = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '9.5', '10'] as const;
+const SPECIALS: Partial<Record<Grader, string[]>> = {
+	CGC: ['10P'],
+	BGS: ['10BL']
+};
+
+// Confidence gates (doctrine #3): below 0.4 → render NOTHING.
+const SHOW = 0.6; // ≥ medium/high
+const DIM = 0.4; // [0.4,0.6) low-confidence, still shown faintly
+
+function median(xs: number[]): number {
+	const s = [...xs].sort((a, b) => a - b);
+	const n = s.length;
+	if (n === 0) return NaN;
+	return n % 2 ? s[(n - 1) / 2] : (s[n / 2 - 1] + s[n / 2]) / 2;
+}
+
+function iqr(xs: number[]): number {
+	if (xs.length < 4) return 0;
+	const s = [...xs].sort((a, b) => a - b);
+	const q = (p: number) => s[Math.min(s.length - 1, Math.max(0, Math.round(p * (s.length - 1))))];
+	return q(0.75) - q(0.25);
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+	return Math.max(lo, Math.min(hi, n));
+}
+
+// Cohort-size → calibration factor. < 8 pairs anywhere ⇒ no estimate.
+function calibrationFactor(n: number): number {
+	if (n >= 120) return 1;
+	if (n >= 40) return 0.85;
+	if (n >= 15) return 0.65;
+	if (n >= 8) return 0.5;
+	return 0;
+}
+
+interface RatioStat {
+	ratio: number;
+	n: number;
+	dispFactor: number;
+	scope: 'era×rarity' | 'era' | 'catalog';
+}
+
+/**
+ * Calibrate grader10 ÷ PSA10 from real cohort pairs, bucketed by
+ * era×rarity; broaden to era-only then whole-catalog if a bucket is
+ * thin. Returns null when even the catalog has < 8 real pairs.
+ */
+function calibrateRatio(
+	cohort: CohortRow[],
+	field: 'cgc10_price' | 'tag10_price',
+	era: Era,
+	rarity: string | null
+): RatioStat | null {
+	const ratiosFor = (rows: CohortRow[]): number[] =>
+		rows
+			.filter((r) => (r.psa10_price ?? 0) > 0 && (r[field] ?? 0) > 0)
+			.map((r) => (r[field] as number) / (r.psa10_price as number))
+			.filter((x) => Number.isFinite(x) && x > 0);
+
+	const sameEra = cohort.filter((r) => eraForDate(r.set_release_date) === era);
+	const buckets: Array<{ rows: CohortRow[]; scope: RatioStat['scope'] }> = [
+		{ rows: sameEra.filter((r) => (r.rarity ?? '') === (rarity ?? '')), scope: 'era×rarity' },
+		{ rows: sameEra, scope: 'era' },
+		{ rows: cohort, scope: 'catalog' }
+	];
+
+	for (const b of buckets) {
+		const rs = ratiosFor(b.rows);
+		if (rs.length >= 8) {
+			const m = median(rs);
+			const disp = m > 0 ? clamp(iqr(rs) / m, 0, 1) : 1;
+			return {
+				ratio: m,
+				n: rs.length,
+				dispFactor: clamp(1 - 0.6 * disp, 0.4, 1),
+				scope: b.scope
+			};
+		}
+	}
+	return null;
+}
+
+/** Calibrate the PSA10 ÷ raw multiple (Path B) the same way. */
+function calibrateMultiple(cohort: CohortRow[], era: Era, rarity: string | null): RatioStat | null {
+	const multFor = (rows: CohortRow[]): number[] =>
+		rows
+			.filter((r) => (r.raw_nm_price ?? 0) > 0 && (r.psa10_price ?? 0) > 0)
+			.map((r) => (r.psa10_price as number) / (r.raw_nm_price as number))
+			.filter((x) => Number.isFinite(x) && x > 0);
+
+	const sameEra = cohort.filter((r) => eraForDate(r.set_release_date) === era);
+	const buckets: Array<{ rows: CohortRow[]; scope: RatioStat['scope'] }> = [
+		{ rows: sameEra.filter((r) => (r.rarity ?? '') === (rarity ?? '')), scope: 'era×rarity' },
+		{ rows: sameEra, scope: 'era' },
+		{ rows: cohort, scope: 'catalog' }
+	];
+	for (const b of buckets) {
+		const ms = multFor(b.rows);
+		if (ms.length >= 8) {
+			const m = median(ms);
+			const disp = m > 0 ? clamp(iqr(ms) / m, 0, 1) : 1;
+			return { ratio: m, n: ms.length, dispFactor: clamp(1 - 0.6 * disp, 0.4, 1), scope: b.scope };
+		}
+	}
+	return null;
+}
+
+function round2(n: number): number {
+	return Math.round(n * 100) / 100;
+}
+
+function tierFor(conf: number): Tier {
+	return conf >= 0.8 ? 'high' : conf >= SHOW ? 'medium' : 'low';
+}
+
+/**
+ * Build the per-grade ladders for PSA / CGC / BGS / TAG.
+ * Real cells (real:true) are bold-white market prices; estimates
+ * (real:false) are the darker-blue, tooltip-disclosed cells.
+ */
+export function buildGradeLadders(input: EstimatorInput): GraderLadder[] {
+	const gl = input.gradeLadder ?? {};
+	const era = eraForDate(input.setReleaseDate);
+	const cohort = input.cohort ?? [];
+
+	// This card's unified REAL PSA ladder = scraped Grade-N ladder, with
+	// the real PSA 10 column filling "10" if the ladder lacks it.
+	const psaReal: Record<string, number> = { ...(gl.psa ?? {}) };
+	if (psaReal['10'] == null && (input.psa10 ?? 0) > 0) psaReal['10'] = input.psa10 as number;
+
+	// This card's real grader-10 (for the near-real own-card ratio path).
+	const ownTen: Record<Grader, number | null> = {
+		PSA: psaReal['10'] ?? null,
+		CGC: gl.cgc?.['10'] ?? input.cgc10 ?? null,
+		BGS: gl.bgs?.['10'] ?? null,
+		TAG: gl.tag?.['10'] ?? input.tag10 ?? null
+	};
+	const realPsa10 = psaReal['10'] ?? null;
+
+	const ladders: GraderLadder[] = [];
+
+	for (const grader of ['PSA', 'CGC', 'BGS', 'TAG'] as const) {
+		const realMap: Record<string, number> = {
+			...((gl[grader.toLowerCase() as keyof GradeLadder] as Record<string, number>) ?? {})
+		};
+		// Legacy real 10-columns merge in for their grader.
+		if (grader === 'PSA' && psaReal['10'] != null) realMap['10'] = psaReal['10'];
+		if (grader === 'CGC' && (input.cgc10 ?? 0) > 0 && realMap['10'] == null)
+			realMap['10'] = input.cgc10 as number;
+		if (grader === 'TAG' && (input.tag10 ?? 0) > 0 && realMap['10'] == null)
+			realMap['10'] = input.tag10 as number;
+
+		const grades = [...BASE_GRADES, ...(SPECIALS[grader] ?? [])];
+		const cells: GradeCell[] = [];
+
+		// Pre-compute this grader's cross-grader ratio R once.
+		// 1) own card: real grader-10 & real PSA-10 → near-real.
+		// 2) else calibrated median over the cohort (CGC/TAG only — no
+		//    bgs10 column exists to calibrate from).
+		let ratio: number | null = null;
+		let ratioConf = 0;
+		let ratioBasis = '';
+		if (grader !== 'PSA') {
+			if (ownTen[grader] != null && realPsa10 != null && realPsa10 > 0) {
+				ratio = (ownTen[grader] as number) / realPsa10;
+				ratioConf = 0.9;
+				ratioBasis = `real ${grader} 10 $${round2(ownTen[grader] as number)} ÷ real PSA 10 $${round2(realPsa10)} on this card (${round2(ratio)}×)`;
+			} else if (grader === 'CGC' || grader === 'TAG') {
+				const stat = calibrateRatio(
+					cohort,
+					grader === 'CGC' ? 'cgc10_price' : 'tag10_price',
+					era,
+					input.rarity
+				);
+				if (stat) {
+					ratio = stat.ratio;
+					ratioConf = 0.62 * calibrationFactor(stat.n) * stat.dispFactor;
+					ratioBasis = `calibrated ${grader} 10 ÷ PSA 10 = ${round2(stat.ratio)}× (${stat.scope} cohort, n=${stat.n})`;
+				}
+			}
+		}
+
+		for (const g of grades) {
+			const real = realMap[g];
+			if (real != null && real > 0) {
+				cells.push({ grade: g, value: round2(real), real: true });
+				continue;
+			}
+
+			if (grader === 'PSA') {
+				// PSA is real-or-absent. The ONLY estimate allowed is a
+				// PSA 10 from raw when the card has NO real PSA at all
+				// (Path B) — hard-gated, never anchors other graders.
+				if (g === '10' && realPsa10 == null && (input.rawNm ?? 0) > 0) {
+					const stat = calibrateMultiple(cohort, era, input.rarity);
+					if (stat) {
+						const conf = clamp(0.55 * calibrationFactor(stat.n) * stat.dispFactor, 0, 0.6);
+						if (conf >= DIM) {
+							cells.push({
+								grade: g,
+								value: round2((input.rawNm as number) * stat.ratio),
+								real: false,
+								confidence: conf,
+								tier: tierFor(conf),
+								basis: `Estimate — no real PSA sale for this card. Raw $${round2(input.rawNm as number)} × calibrated PSA10/raw ${round2(stat.ratio)}× (${stat.scope} cohort, n=${stat.n}). Not a market price.`
+							});
+						}
+					}
+				}
+				continue;
+			}
+
+			// CGC / BGS / TAG estimate: real PSA price at THIS grade ×
+			// the cross-grader ratio. No real PSA anchor at g ⇒ omit.
+			const psaAnchor = psaReal[g];
+			if (psaAnchor == null || psaAnchor <= 0 || ratio == null) continue;
+
+			const conf = ratioConf; // shape anchor is real PSA@g (1.0)
+			if (conf < DIM) continue;
+			cells.push({
+				grade: g,
+				value: round2(psaAnchor * ratio),
+				real: false,
+				confidence: conf,
+				tier: tierFor(conf),
+				basis: `Estimate — no real ${grader} ${g} sale for this card. Real PSA ${g} $${round2(psaAnchor)} × ${ratioBasis}. Not a market price.`
+			});
+		}
+
+		if (cells.length > 0) ladders.push({ grader, cells });
+	}
+
+	return ladders;
+}

--- a/src/lib/services/pricecharting-scraper.ts
+++ b/src/lib/services/pricecharting-scraper.ts
@@ -35,6 +35,31 @@ export interface PopDistribution {
 	gemRate: number;
 }
 
+/**
+ * Real per-grade price ladder, normalized by grader, exactly as
+ * PriceCharting publishes it on the `#full-prices` table. Only cells
+ * PriceCharting actually lists a price for are present — a blank `-`
+ * cell is absent here, never zero-filled (honesty doctrine: no
+ * fabricated numbers, an absent grade renders nothing downstream).
+ *
+ * `psa` carries PriceCharting's generic "Grade N" columns: by
+ * PriceCharting's own methodology these reflect PSA-graded sales (PSA
+ * is their default grader), plus the explicitly-named "PSA 10". The
+ * other graders only ever get their separately-named 10 (and 9.5 /
+ * pristine / black-label where listed) — PriceCharting publishes no
+ * sub-10 CGC/BGS/TAG/SGC price columns.
+ *
+ * Keys: integer/half grade as a string ("1".."9", "9.5", "10"); plus
+ * "10P" = CGC 10 Pristine, "10BL" = BGS 10 Black Label.
+ */
+export interface GradeLadder {
+	psa?: Record<string, number>;
+	cgc?: Record<string, number>;
+	bgs?: Record<string, number>;
+	tag?: Record<string, number>;
+	sgc?: Record<string, number>;
+}
+
 export interface PriceChartingData {
 	/** PriceCharting "Ungraded" tier — the canonical raw price */
 	ungraded: number | null;
@@ -48,6 +73,9 @@ export interface PriceChartingData {
 	tag10: number | null;
 	/** All parsed tiers as key→price map for future use */
 	allTiers: Record<string, number>;
+	/** Real per-grade ladder normalized by grader (see GradeLadder).
+	 *  This is the long-discarded sub-10 data — kept now, real only. */
+	gradeLadder: GradeLadder;
 	/** PSA population distribution (from pop_data JS variable) */
 	psaPop: PopDistribution | null;
 	/** CGC population distribution */
@@ -418,6 +446,50 @@ function mapTiers(tiers: Record<string, number>): Pick<PriceChartingData, 'ungra
 	};
 }
 
+/**
+ * Normalize the raw tier map into a per-grader real price ladder.
+ *
+ * PriceCharting's `#full-prices` table is already fully parsed by
+ * parsePriceTiers (every <td>Label</td><td>$Price</td> row); mapTiers
+ * only kept the five 10-slots and dropped the rest. This keeps the
+ * real sub-10 ladder.
+ *
+ * Mapping (PriceCharting's own labeling):
+ *  - "Grade N" / "PSA N"      → psa[N]   (their generic Grade = PSA sales)
+ *  - "CGC 10 Pristine"        → cgc["10P"]
+ *  - "CGC N"                  → cgc[N]
+ *  - "BGS 10 Black Label"     → bgs["10BL"]
+ *  - "BGS N"                  → bgs[N]
+ *  - "TAG N"                  → tag[N]
+ *  - "SGC N"                  → sgc[N]
+ * Anything else (Ungraded, Box only, New, Complete, generic Graded) is
+ * intentionally ignored — it is not a per-grade graded comp.
+ */
+function normalizeGradeLadder(tiers: Record<string, number>): GradeLadder {
+	const ladder: GradeLadder = {};
+	const put = (g: keyof GradeLadder, key: string, val: number) => {
+		if (!Number.isFinite(val) || val <= 0) return;
+		(ladder[g] ??= {})[key] = val;
+	};
+
+	for (const [rawKey, val] of Object.entries(tiers)) {
+		const k = rawKey.toLowerCase().replace(/\s+/g, ' ').trim();
+
+		// CGC / BGS specials first (before the generic "<grader> N" rule).
+		if (k === 'cgc 10 pristine') { put('cgc', '10P', val); continue; }
+		if (k === 'bgs 10 black label' || k === 'bgs 10 black') { put('bgs', '10BL', val); continue; }
+
+		// PriceCharting's generic graded column = PSA-equivalent sales.
+		let m = k.match(/^grade (\d+(?:\.\d)?)$/);
+		if (m) { put('psa', m[1], val); continue; }
+
+		m = k.match(/^(psa|cgc|bgs|tag|sgc) (\d+(?:\.\d)?)$/);
+		if (m) { put(m[1] as keyof GradeLadder, m[2], val); continue; }
+	}
+
+	return ladder;
+}
+
 // ---------------------------------------------------------------------------
 // Main public function
 // ---------------------------------------------------------------------------
@@ -441,6 +513,7 @@ async function parseProductPage(url: string, matchedName: string): Promise<Price
 	return {
 		...mapped,
 		allTiers: tiers,
+		gradeLadder: normalizeGradeLadder(tiers),
 		psaPop: popData.psa,
 		cgcPop: popData.cgc,
 		psa10LastSold,

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -6,6 +6,7 @@ import { cacheTcgPlayerPrices, getPriceHistoryFromCache } from '$services/price-
 import { supabase } from '$services/supabase';
 import { getCardSignal, getSimilarCards } from '$services/insights';
 import { computeGradingROI, DEFAULT_TIER_BY_SERVICE } from '$services/grading-roi';
+import { buildGradeLadders, type CohortRow } from '$services/grade-estimate';
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import type { GradingService } from '$types';
@@ -185,10 +186,78 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		// migration 019 not applied yet — TAG ladder hidden, page is fine
 	}
 
+	// Real per-grade ladder (migration 020). Isolated + best-effort like
+	// tagExtra above so the page renders normally before 020 is applied
+	// (the per-grade ladder simply stays absent until the column +
+	// re-scrape exist). Honesty doctrine: real cells only.
+	let gradeLadder: Record<string, Record<string, number>> | null = null;
+	let gradeLadderFetchedAt: string | null = null;
+	try {
+		const { data, error } = await supabase
+			.from('card_index')
+			.select('grade_ladder, grade_ladder_fetched_at')
+			.eq('card_id', params.id)
+			.maybeSingle();
+		if (!error && data) {
+			const d = data as { grade_ladder?: unknown; grade_ladder_fetched_at?: string | null };
+			gradeLadder =
+				(d.grade_ladder as Record<string, Record<string, number>> | null) ?? null;
+			gradeLadderFetchedAt = d.grade_ladder_fetched_at ?? null;
+		}
+	} catch {
+		// migration 020 not applied yet — per-grade ladder hidden, page fine
+	}
+
+	// Calibration cohort for the grade estimator: catalog rows that carry
+	// a real PSA 10 + real raw, so the cross-grader 10 ratio (CGC10/PSA10,
+	// TAG10/PSA10) and the raw→PSA10 multiple are learned from real pairs,
+	// never a free constant. Only stable columns (pre-020 safe), tiny
+	// projection, capped, fault-isolated — failure just means no estimates
+	// (page unaffected). rarity/era bucket the curve shape.
+	let estimatorCohort: CohortRow[] | null = null;
+	try {
+		const { data, error: cohortErr } = await supabase
+			.from('card_index')
+			.select('rarity, set_release_date, raw_nm_price, psa10_price, cgc10_price, tag10_price')
+			.not('psa10_price', 'is', null)
+			.not('raw_nm_price', 'is', null)
+			.limit(6000);
+		if (!cohortErr && data) estimatorCohort = data as unknown as CohortRow[];
+	} catch {
+		// best-effort — without the cohort the estimator only emits cells
+		// it can anchor on this card's own real prices; page unaffected.
+	}
+
 	// Collapse to one row per condition, keeping the most recent. Missing
 	// table (404 after a fresh deploy before migration 005 applies) returns
 	// null data — we just show nothing, per honesty doctrine.
 	const conditionPrices = collapseLatestPerCondition(conditionPriceRows.data ?? []);
+
+	// Per-grade ladders (real cells + honest, real-anchored estimates).
+	// Pure + fault-isolated — any failure just omits the section.
+	const ir = indexRow as unknown as {
+		rarity: string | null;
+		set_release_date: string | null;
+		raw_nm_price: number | null;
+		psa10_price: number | null;
+		cgc10_price: number | null;
+		tag10_price: number | null;
+	} | null;
+	let gradeLadders: ReturnType<typeof buildGradeLadders> = [];
+	try {
+		gradeLadders = buildGradeLadders({
+			rarity: ir?.rarity ?? null,
+			setReleaseDate: ir?.set_release_date ?? null,
+			rawNm: ir?.raw_nm_price ?? null,
+			psa10: ir?.psa10_price ?? null,
+			cgc10: ir?.cgc10_price ?? null,
+			tag10: ir?.tag10_price ?? null,
+			gradeLadder,
+			cohort: estimatorCohort
+		});
+	} catch {
+		gradeLadders = [];
+	}
 
 	return {
 		card,
@@ -202,6 +271,8 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		conditionPrices,
 		indexRow,
 		tagExtra,
+		gradeLadders,
+		gradeLadderFetchedAt,
 		cardSignal,
 		gradingROI,
 		similarCards,
@@ -342,6 +413,7 @@ export const actions: Actions = {
 			cgcPop: { total: number; grade10: number; gemRate: number } | null;
 			psa10LastSold: string | null;
 			psa10Sales: Array<{ sold_at: string; price: number; marketplace: string | null }>;
+			gradeLadder?: Record<string, Record<string, number>> | null;
 		} | null = null;
 		try {
 			const res = await fetch(`/api/pricecharting?${qs}`);
@@ -393,6 +465,13 @@ export const actions: Actions = {
 			upd.cgc_pop_10 = pc.cgcPop.grade10;
 			upd.cgc_gem_rate = pc.cgcPop.gemRate;
 			upd.cgc_fetched_at = now;
+		}
+		// Real per-grade ladder (migration 020). Only written when the
+		// scrape actually returned graded cells — a transient miss never
+		// clobbers a previously-good ladder with null/empty.
+		if (pc.gradeLadder && Object.keys(pc.gradeLadder).length > 0) {
+			upd.grade_ladder = pc.gradeLadder;
+			upd.grade_ladder_fetched_at = now;
 		}
 		if (pc.psa10LastSold != null) upd.psa10_last_sold_at = pc.psa10LastSold;
 

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -201,6 +201,39 @@
 		})()
 	);
 
+	// Per-grade ladders: real cells (bold white) + honest, real-anchored
+	// estimates (darker blue + est. chip + tooltip). Built server-side by
+	// grade-estimate.ts; empty array = nothing to show (page unaffected).
+	interface GradeCell {
+		grade: string;
+		value: number;
+		real: boolean;
+		confidence?: number;
+		tier?: 'high' | 'medium' | 'low';
+		basis?: string;
+	}
+	interface GraderLadder {
+		grader: 'PSA' | 'CGC' | 'BGS' | 'TAG';
+		cells: GradeCell[];
+	}
+	let gradeLadders = $derived(
+		((data as Record<string, unknown>).gradeLadders ?? []) as GraderLadder[]
+	);
+	let gradeLadderFetchedAt = $derived(
+		((data as Record<string, unknown>).gradeLadderFetchedAt ?? null) as string | null
+	);
+	const GRADER_COLOR: Record<string, string> = {
+		PSA: 'text-vault-gold',
+		CGC: 'text-blue-400',
+		BGS: 'text-amber-400',
+		TAG: 'text-purple-300'
+	};
+	function gradeLabel(g: string): string {
+		if (g === '10P') return '10 Pristine';
+		if (g === '10BL') return '10 Black';
+		return g;
+	}
+
 	function rawSourceLabel(src: string | null | undefined): string | null {
 		if (!src) return null;
 		if (src === 'pricecharting') return 'PriceCharting Ungraded';
@@ -661,6 +694,72 @@
 								{/each}
 							</div>
 							<p class="mt-2 text-[10px] text-vault-text-muted">VA = Verified Authentic (ungraded). Real counts from TAG; grades with no copies are omitted.</p>
+						</div>
+					{/if}
+
+					<!-- Full per-grade ladder: real (white) + estimates (blue) -->
+					{#if gradeLadders.length > 0}
+						<div class="mt-4 rounded-xl border border-vault-border bg-vault-bg p-3 sm:p-4">
+							<div class="flex items-baseline justify-between gap-3">
+								<p class="text-sm font-semibold text-vault-text">Per-grade ladder</p>
+								{#if gradeLadderFetchedAt && relTime(gradeLadderFetchedAt)}
+									<p class="text-[10px] text-vault-text-muted">
+										real prices · {relTime(gradeLadderFetchedAt)}
+									</p>
+								{/if}
+							</div>
+							<p class="mt-1 text-[11px] text-vault-text-muted">
+								<span class="font-bold text-white">White</span> = real market price.
+								<span class="font-medium text-vault-estimate">Blue</span> = estimate
+								(no real sale for that grade) — hover for how it was derived.
+							</p>
+
+							{#each gradeLadders as ladder (ladder.grader)}
+								<div class="mt-3">
+									<p class="text-[11px] font-medium {GRADER_COLOR[ladder.grader] ?? 'text-vault-text'}">
+										{ladder.grader}
+										{#if ladder.grader === 'TAG'}
+											<span class="text-[10px] font-normal text-vault-text-muted"
+												>· prices estimated; real TAG counts are in the distribution above</span
+											>
+										{/if}
+									</p>
+									<div class="mt-1.5 grid grid-cols-3 gap-1.5 sm:grid-cols-6">
+										{#each ladder.cells as c (c.grade)}
+											{#if c.real}
+												<div class="rounded-lg border border-vault-border/60 px-2 py-1 text-center">
+													<p class="text-[10px] text-vault-text-muted">{ladder.grader} {gradeLabel(c.grade)}</p>
+													<p class="text-sm font-bold text-white">{fmtMoney(c.value)}</p>
+												</div>
+											{:else}
+												<div
+													class="rounded-lg border border-dashed border-vault-estimate/40 bg-vault-estimate/[0.04] px-2 py-1 text-center {c.tier === 'low' ? 'opacity-70' : ''}"
+													title={c.basis}
+												>
+													<p class="text-[10px] text-vault-text-muted">{ladder.grader} {gradeLabel(c.grade)}</p>
+													<p class="text-sm font-medium italic text-vault-estimate">
+														{fmtMoney(c.value)}
+													</p>
+													<p class="text-[9px] font-medium text-vault-estimate/80">
+														{c.tier === 'low' ? 'est.?' : 'est.'}
+													</p>
+												</div>
+											{/if}
+										{/each}
+									</div>
+								</div>
+							{/each}
+
+							<p class="mt-3 text-[10px] leading-relaxed text-vault-text-muted">
+								Real prices from PriceCharting's per-grade table — its generic
+								“Grade N” reflects PSA-graded sales. CGC / BGS / TAG sub-10
+								grades are estimated from this card's real PSA price at that
+								grade × that grader's 10-to-PSA-10 ratio (this card's own real
+								pair when available, else a ratio calibrated from real
+								catalog cards in the same era and rarity). Grades with no
+								real anchor and low-confidence estimates are omitted — a blank
+								beats a bad number.
+							</p>
 						</div>
 					{/if}
 

--- a/supabase/migrations/020_grade_ladder.sql
+++ b/supabase/migrations/020_grade_ladder.sql
@@ -1,0 +1,31 @@
+-- Trove: real per-grade price ladder from PriceCharting
+--
+-- PriceCharting's `#full-prices` table publishes a full per-grade price
+-- ladder. The scraper (pricecharting-scraper.ts::parsePriceTiers) has
+-- always parsed every row of it, but mapTiers() kept only the five
+-- 10-slots (ungraded/psa10/cgc10/bgs10/tag10) and discarded the entire
+-- real sub-10 ladder — the same "data was reachable, we threw it away"
+-- pattern as the long-dropped bgs10. This migration persists the real
+-- ladder so the card page can show real per-grade numbers (and the
+-- estimator can anchor on them instead of fabricating).
+--
+-- Honesty doctrine: only cells PriceCharting actually lists a price for
+-- are stored. A blank `-` cell is absent from the JSON, never zero. The
+-- generic "Grade N" columns reflect PSA-graded sales (PriceCharting's
+-- own methodology), so they land under the `psa` key; CGC/BGS/TAG/SGC
+-- only ever get their separately-named 10 (+ 9.5 / pristine / black
+-- label where listed).
+--
+-- ADD-ONLY and idempotent. No existing column is redefined; nothing
+-- else (combined_pop_total, the 10-price columns) is touched.
+
+-- Normalized per-grader ladder, e.g.
+-- {"psa":{"7":40,"8":75,"9":140,"9.5":210,"10":520},
+--  "cgc":{"10":480},"bgs":{"9.5":260,"10":540,"10BL":1900},"tag":{"10":510}}
+-- Keys are the grade as a string ("1".."9","9.5","10"); "10P" = CGC 10
+-- Pristine, "10BL" = BGS 10 Black Label.
+alter table card_index add column if not exists grade_ladder jsonb;
+
+-- Provenance: when the real ladder was last scraped (separate from
+-- graded_prices_fetched_at so a pre-020 row reads NULL, not "fresh").
+alter table card_index add column if not exists grade_ladder_fetched_at timestamptz;


### PR DESCRIPTION
## Summary

Adds a full per-grade price ladder (1–10+) for PSA / CGC / BGS / TAG to the card page. Real numbers stay bold white; estimates render in a distinct **darker blue** with an `est.` chip + tooltip spelling out exactly how each was derived.

The architecture is **real-ladder-first**, not "estimate everything":

- **PriceCharting's `#full-prices` table was already fully scraped** — `mapTiers()` just threw away everything except the five 10-slots. We now persist the real per-grade ladder (migration `020`). PriceCharting's generic "Grade N" reflects PSA-graded sales, so we get a **real PSA price ladder**; CGC/BGS/TAG keep their real named 10/9.5/specials. (Also recovers the long-dropped real `bgs10`.)
- **PSA is real-or-absent** — never a fabricated sub-10 cell. The only PSA estimate is a hard-gated raw→PSA10 fallback when a card has no real PSA at all.
- **CGC/BGS/TAG sub-10 = real PSA price at that grade × that grader's 10/PSA-10 ratio** — the ratio from this card's own real pair when present (near-real), else a median calibrated from real catalog cards in the same era×rarity. Pinned to real anchors + real cross-sectional calibration; never a free constant.
- **Confidence-gated:** ≥0.6 shown, 0.4–0.6 shown faint (`est.?`), **<0.4 renders nothing**. A blank beats a bad number (honesty doctrine).

Estimates are display-only — they never feed sort, ROI, ranking, `cardSignal`, or `psa10_multiple`.

## Test plan

- [x] `svelte-check`: 18 errors / 2 warnings — exactly baseline, **0 new**
- [x] `vitest`: 64/64 (51 baseline + 13 new for `grade-estimate.ts`)
- [x] Model run against **live `card_index`**: real PSA10 passes through untouched; calibrated **TAG10 estimate** emitted from 362 real TAG/PSA pairs; CGC correctly omitted (0 calibration pairs → honest blank); Path B correctly refused a sub-threshold number; no invariant violations
- [ ] **Migration `020_grade_ladder.sql` needs hand-apply** in Supabase (add-only/idempotent, like 019). Until then the page renders fine (per-grade ladder simply hidden) and the estimator degrades to cross-grader-10 + Path B only — never breaks
- [ ] **Do not merge until the model is confirmed** (per request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)