### PR TITLE
Real CGC + Beckett (BGS) full population — like TAG/PSA

### DIFF
--- a/.github/workflows/engine-bgs.yml
+++ b/.github/workflows/engine-bgs.yml
@@ -1,0 +1,34 @@
+name: engine-bgs
+
+# Beckett (BGS) pop crawl. Beckett publishes its own pop report
+# (beckett.com/api/grading/pop-report); reverse-engineered client in
+# src/lib/services/bgs-grading.ts. Plain JSON, no auth, no Cloudflare.
+# No-ops cleanly until migration 021 is applied (bgs-pop.ts isolates per
+# set; the write simply errors-per-set until bgs_grades exists).
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: engine-bgs
+  cancel-in-progress: false
+
+jobs:
+  bgs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    env:
+      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: BGS population crawl
+        run: node_modules/.bin/tsx scripts/bgs-pop.ts --all

--- a/.github/workflows/engine-cgc.yml
+++ b/.github/workflows/engine-cgc.yml
@@ -1,0 +1,34 @@
+name: engine-cgc
+
+# CGC Cards pop crawl. CGC publishes its own authoritative pop report
+# (production.api.aws.ccg-ops.com); reverse-engineered client in
+# src/lib/services/cgc-grading.ts. Plain JSON, no auth, no Cloudflare.
+# No-ops cleanly until migration 021 is applied (cgc-pop.ts isolates per
+# set; the write simply errors-per-set until cgc_grades exists).
+
+on:
+  schedule:
+    - cron: '40 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: engine-cgc
+  cancel-in-progress: false
+
+jobs:
+  cgc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    env:
+      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: ${{ secrets.PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: CGC population crawl
+        run: node_modules/.bin/tsx scripts/cgc-pop.ts --all

--- a/scripts/bgs-pop.ts
+++ b/scripts/bgs-pop.ts
@@ -1,0 +1,433 @@
+#!/usr/bin/env tsx
+/**
+ * Trove — Beckett (BGS) population acquisition (like Track A / tag-pop.ts)
+ *
+ * Beckett publishes its own pop report. This crawler closes the BGS gap the
+ * same way tag-pop.ts closes TAG: for each tracked set, ask Beckett for sets
+ * whose name contains our set name, fuzzy-rank the candidates, and PROVE the
+ * pick by card_number overlap before any write (honesty gate — a wrong
+ * match is rejected, never persisted). Writes the FULL grade distribution
+ * into bgs_grades + the scalar bgs_pop_total/bgs_pop_10/bgs_gem_rate(+_full)
+ * and provenance. See src/lib/services/bgs-grading.ts and
+ * project_grading_data_sources / feedback_data_is_always_findable.
+ *
+ * Usage:
+ *   tsx scripts/bgs-pop.ts --all                  # gap-prioritised crawl
+ *   tsx scripts/bgs-pop.ts --set base1            # one set
+ *   tsx scripts/bgs-pop.ts --set base1 --dry-run  # fetch+match, no write
+ *
+ * Env: PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (or PUBLISHABLE);
+ *   TROVE_BGS_REQ_DELAY_MS (1000) TROVE_BGS_SET_LIMIT (0)
+ *   TROVE_BGS_CARD_LIMIT (100) TROVE_BGS_MAX_PAGES (60)
+ *   TROVE_BGS_FAIL_ALERT (5) TROVE_BGS_STATUS
+ */
+
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import {
+	searchBgsSets,
+	getBgsCardsForSet,
+	bgsDrillKeyword,
+	bgsPopScalars,
+	BgsGradingError,
+	type BgsCardRow,
+	type BgsGradeMap
+} from '../src/lib/services/bgs-grading.js';
+import { yearOf, scoreTagCandidate, normCardNumber } from './tag-aliases.js';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY =
+	process.env.SUPABASE_SERVICE_ROLE_KEY ??
+	process.env.PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ??
+	'';
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+	console.error('Missing SUPABASE_URL or SUPABASE_KEY. Check .env.local');
+	process.exit(1);
+}
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const num = (v: string | undefined, d: number) => {
+	const n = parseInt(v ?? '', 10);
+	return Number.isFinite(n) && n >= 0 ? n : d;
+};
+const REQ_DELAY_MS = num(process.env.TROVE_BGS_REQ_DELAY_MS, 1000);
+const SET_LIMIT = num(process.env.TROVE_BGS_SET_LIMIT, 0);
+const CARD_LIMIT = num(process.env.TROVE_BGS_CARD_LIMIT, 100);
+const MAX_PAGES = num(process.env.TROVE_BGS_MAX_PAGES, 60);
+const FAIL_ALERT = num(process.env.TROVE_BGS_FAIL_ALERT, 5);
+const STATUS_FILE =
+	process.env.TROVE_BGS_STATUS ??
+	join(homedir(), 'Library', 'Logs', 'Trove', 'bgs-pop-status.json');
+
+const ts = () => new Date().toISOString();
+const log = (m: string) => console.log(`[${ts()}] ${m}`);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let stopping = false;
+
+interface IndexCard {
+	card_id: string;
+	card_number: string | null;
+}
+async function loadIndexCards(setId: string): Promise<IndexCard[]> {
+	const { data, error } = await supabase
+		.from('card_index')
+		.select('card_id, card_number')
+		.eq('set_id', setId);
+	if (error) throw new Error(`card_index load failed: ${error.message}`);
+	return (data ?? []) as IndexCard[];
+}
+
+interface Matched {
+	card_id: string;
+	grades: BgsGradeMap;
+}
+interface Validation {
+	ok: boolean;
+	reason: string;
+	matches: Matched[];
+}
+function pickCanonical(rows: BgsCardRow[]): BgsCardRow {
+	return rows.reduce((a, b) =>
+		bgsPopScalars(b.grades).total > bgsPopScalars(a.grades).total ? b : a
+	);
+}
+function validate(bgsCards: BgsCardRow[], idx: IndexCard[]): Validation {
+	if (bgsCards.length === 0) return { ok: false, reason: 'no BGS cards', matches: [] };
+	if (idx.length === 0) return { ok: false, reason: 'no card_index rows', matches: [] };
+	const idxByNum = new Map<string, string>();
+	for (const c of idx) {
+		const k = normCardNumber(c.card_number);
+		if (k && !idxByNum.has(k)) idxByNum.set(k, c.card_id);
+	}
+	const bgsByNum = new Map<string, BgsCardRow[]>();
+	for (const r of bgsCards) {
+		const k = normCardNumber(r.cardNumber);
+		if (!k) continue;
+		const arr = bgsByNum.get(k);
+		if (arr) arr.push(r);
+		else bgsByNum.set(k, [r]);
+	}
+	const matches: Matched[] = [];
+	let matchedNums = 0;
+	for (const [k, rows] of bgsByNum) {
+		const cardId = idxByNum.get(k);
+		if (!cardId) continue;
+		matchedNums++;
+		matches.push({ card_id: cardId, grades: pickCanonical(rows).grades });
+	}
+	const denom = Math.min(bgsByNum.size, idxByNum.size);
+	const overlapPct = denom > 0 ? (matchedNums / denom) * 100 : 0;
+	const ok = overlapPct >= 60 && matchedNums >= Math.min(5, idxByNum.size);
+	return {
+		ok,
+		reason: ok
+			? `overlap ${overlapPct.toFixed(0)}% (${matchedNums}/${denom})`
+			: `low overlap ${overlapPct.toFixed(0)}% (${matchedNums}/${denom}) — match likely wrong`,
+		matches
+	};
+}
+
+interface TrackedSet {
+	set_id: string;
+	set_name: string;
+	release_date: string;
+}
+interface SetResult {
+	setId: string;
+	ok: boolean;
+	wrote: number;
+	note: string;
+}
+
+async function processSet(
+	set: TrackedSet,
+	idx: IndexCard[],
+	dryRun: boolean
+): Promise<SetResult> {
+	// Beckett's `set_name` is a constrained substring filter over its bare
+	// set-name field (not the displayed "<year> Pokemon <name>"), so one
+	// keyword often misses. Probe a few variants, union the candidates,
+	// fuzzy-rank, and let the card-number overlap gate prove correctness.
+	// Beckett names sets "<year> Pokemon[ TCG] <core> <edition/lang>"
+	// (e.g. "1999 Pokemon Base Unlimited"); `set_name` is a substring
+	// filter over that. Probe several keywords, union candidates, then a
+	// lenient BGS-specific score — the card-number overlap gate is the
+	// real correctness guarantee, so we keep many candidates and let it
+	// reject the wrong ones rather than over-filter here.
+	const base = set.set_name.replace(/^pok[eé]mon\s+/i, '').trim() || set.set_name;
+	const baseToks = base.split(/\s+/).filter((t) => t.length >= 3);
+	const keywords = Array.from(
+		new Set(
+			[base, baseToks.slice(-2).join(' '), ...baseToks]
+				.map((s) => (s ?? '').trim())
+				.filter((s) => s.length >= 3)
+		)
+	).slice(0, 5);
+	const byLpg = new Map<string, import('../src/lib/services/bgs-grading.js').BgsSetCandidate>();
+	for (const kw of keywords) {
+		if (stopping) break;
+		try {
+			for (const c of await searchBgsSets(kw)) if (!byLpg.has(c.lpgSetId)) byLpg.set(c.lpgSetId, c);
+		} catch (e) {
+			log(`  [${set.set_id}] search "${kw}" failed: ${(e as Error).message}`);
+		}
+		await sleep(REQ_DELAY_MS);
+	}
+	const kw = keywords[0] ?? base;
+
+	// Strip Beckett's decoration (year / Pokemon / TCG / "card game") and
+	// edition+language noise so the CORE set tokens can be compared.
+	const NOISE =
+		/\b(1st|first|edition|unlimited|english|japanese|korean|chinese|traditional|simplified|french|german|italian|spanish|dutch|portuguese|thai|indonesian|reverse|foil|holo|theme|deck|promo|promos|gift|box|set|tcg|game|card)\b/g;
+	const core = (s: string) =>
+		s
+			.normalize('NFD')
+			.replace(/[̀-ͯ]/g, '')
+			.toLowerCase()
+			.replace(/^\s*\d{4}\s+/, '')
+			.replace(/\bpok[eé]?mon\b/g, ' ')
+			.replace(NOISE, ' ')
+			.replace(/[^a-z0-9]+/g, ' ')
+			.trim();
+	const ourCore = new Set(core(set.set_name).split(/\s+/).filter(Boolean));
+	const scoreBgs = (name: string): number => {
+		const cset = new Set(core(name).split(/\s+/).filter(Boolean));
+		if (ourCore.size === 0 || cset.size === 0) {
+			// Both reduced to pure decoration (e.g. our "Base Set" → ""):
+			// fall back to the standard fuzzy on the raw names.
+			return scoreTagCandidate(set.set_name, name);
+		}
+		let inter = 0;
+		for (const t of ourCore) if (cset.has(t)) inter++;
+		const jacc = inter / (ourCore.size + cset.size - inter);
+		let s = Math.round(100 * jacc);
+		const low = name.toLowerCase();
+		if (/\b(english|unlimited|1st edition|first edition)\b/.test(low)) s += 8;
+		if (/\b(japanese|korean|chinese|french|german|italian|spanish|dutch|portuguese|thai|indonesian)\b/.test(low))
+			s -= 20;
+		return s;
+	};
+	const scored = [...byLpg.values()]
+		.map((c) => ({ c, s: scoreBgs(c.name) }))
+		.filter((x) => x.s > 0)
+		.sort((a, b) => b.s - a.s)
+		.slice(0, 8);
+	if (scored.length === 0)
+		return {
+			setId: set.set_id,
+			ok: false,
+			wrote: 0,
+			note: `NO MATCH — no Beckett set scored (tried: ${keywords.join(' | ')})`
+		};
+
+	for (const { c } of scored) {
+		if (stopping) break;
+		const drillKw = bgsDrillKeyword(c.name);
+		let cards: BgsCardRow[];
+		try {
+			cards = await getBgsCardsForSet({
+				setNameKeyword: drillKw,
+				displaySetId: c.setId,
+				lpgSetId: c.lpgSetId,
+				limit: CARD_LIMIT,
+				maxPages: MAX_PAGES,
+				onPage: () => sleep(REQ_DELAY_MS)
+			});
+		} catch (e) {
+			log(`  [${set.set_id}] fetch "${c.name}" failed: ${(e as Error).message}`);
+			await sleep(REQ_DELAY_MS);
+			continue;
+		}
+		await sleep(REQ_DELAY_MS);
+		const v = validate(cards, idx);
+		if (!v.ok) {
+			log(`  [${set.set_id}] reject "${c.name}" (#${c.setId}) — ${v.reason}`);
+			continue;
+		}
+		log(`  [${set.set_id}] match "${c.name}" (#${c.setId}) — ${v.reason}`);
+		if (dryRun) {
+			const sample = v.matches[0];
+			log(
+				`  [${set.set_id}] DRY: ${v.matches.length} cards` +
+					(sample
+						? ` e.g. ${sample.card_id} -> ${JSON.stringify({
+								...bgsPopScalars(sample.grades),
+								grades: sample.grades
+							})}`
+						: '')
+			);
+			return { setId: set.set_id, ok: true, wrote: 0, note: `DRY ${c.name}` };
+		}
+		const now = new Date().toISOString();
+		let wrote = 0;
+		let errs = 0;
+		for (const m of v.matches) {
+			const sc = bgsPopScalars(m.grades);
+			const { error } = await supabase
+				.from('card_index')
+				.update({
+					bgs_pop_total: sc.total,
+					bgs_pop_10: sc.grade10,
+					bgs_gem_rate: sc.gemRate,
+					bgs_gem_rate_full: sc.gemRate,
+					bgs_grades: m.grades,
+					bgs_fetched_at: now,
+					bgs_synced_at: now,
+					bgs_set_name: c.name,
+					bgs_set_id: c.setId,
+					bgs_lpg_set_id: c.lpgSetId
+				})
+				.eq('card_id', m.card_id);
+			if (error) errs++;
+			else wrote++;
+		}
+		log(`  [${set.set_id}] wrote ${wrote}, errors ${errs} (${v.reason})`);
+		return { setId: set.set_id, ok: wrote > 0, wrote, note: c.name };
+	}
+	return { setId: set.set_id, ok: false, wrote: 0, note: 'NO MATCH — all candidates failed the gate' };
+}
+
+async function prioritisedSets(): Promise<TrackedSet[]> {
+	const { data: tracked, error } = await supabase
+		.from('tracked_sets')
+		.select('set_id, set_name, release_date')
+		.eq('enabled', true);
+	if (error) throw new Error(`tracked_sets load failed: ${error.message}`);
+	const sets = (tracked ?? []) as TrackedSet[];
+	const minSynced = new Map<string, number | null>();
+	let from = 0;
+	const page = 1000;
+	for (;;) {
+		const { data, error: e } = await supabase
+			.from('card_index')
+			.select('set_id, bgs_synced_at')
+			.range(from, from + page - 1);
+		if (e) throw new Error(`card_index scan failed: ${e.message}`);
+		const rows = (data ?? []) as Array<{ set_id: string; bgs_synced_at: string | null }>;
+		for (const r of rows) {
+			if (r.bgs_synced_at == null) {
+				minSynced.set(r.set_id, null);
+				continue;
+			}
+			const cur = minSynced.get(r.set_id);
+			if (cur === null) continue;
+			const t = Date.parse(r.bgs_synced_at);
+			if (cur === undefined || t < cur) minSynced.set(r.set_id, t);
+		}
+		if (rows.length < page) break;
+		from += page;
+	}
+	const rank = (id: string): number => {
+		const v = minSynced.get(id);
+		if (v === undefined || v === null) return -1;
+		return v;
+	};
+	return sets.sort((a, b) => {
+		const ra = rank(a.set_id);
+		const rb = rank(b.set_id);
+		if (ra !== rb) return ra - rb;
+		return yearOf(a.release_date) - yearOf(b.release_date);
+	});
+}
+
+function writeStatus(s: Record<string, unknown>) {
+	try {
+		mkdirSync(dirname(STATUS_FILE), { recursive: true });
+		writeFileSync(STATUS_FILE, JSON.stringify({ updated_at: ts(), ...s }, null, 2));
+	} catch (e) {
+		log(`status write failed: ${(e as Error).message}`);
+	}
+}
+
+for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+	process.on(sig, () => {
+		log(`${sig} received — finishing current set then exiting`);
+		stopping = true;
+	});
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			set: { type: 'string' },
+			all: { type: 'boolean', default: false },
+			'dry-run': { type: 'boolean', default: false },
+			limit: { type: 'string' }
+		},
+		strict: false
+	});
+	const dryRun = !!values['dry-run'];
+
+	let setIds: string[];
+	if (values.set) setIds = (values.set as string).split(',').map((s) => s.trim());
+	else if (values.all) setIds = [];
+	else {
+		console.log('Usage: --all | --set <id,..> [--dry-run]');
+		return;
+	}
+
+	let sets: TrackedSet[];
+	if (setIds.length > 0) {
+		const { data, error } = await supabase
+			.from('tracked_sets')
+			.select('set_id, set_name, release_date')
+			.in('set_id', setIds);
+		if (error) throw new Error(error.message);
+		sets = (data ?? []) as TrackedSet[];
+	} else {
+		sets = await prioritisedSets();
+	}
+	const cap = num(values.limit as string, SET_LIMIT);
+	if (cap > 0) sets = sets.slice(0, cap);
+
+	log(`bgs-pop start — ${sets.length} set(s)${dryRun ? ' DRY-RUN' : ''}`);
+
+	let consecBad = 0;
+	let totalWrote = 0;
+	const results: SetResult[] = [];
+	for (let i = 0; i < sets.length; i++) {
+		if (stopping) {
+			log('stopping — clean exit');
+			break;
+		}
+		const set = sets[i];
+		try {
+			const idx = await loadIndexCards(set.set_id);
+			const r = await processSet(set, idx, dryRun);
+			results.push(r);
+			totalWrote += r.wrote;
+			if (r.ok) consecBad = 0;
+			else consecBad++;
+			log(`(${i + 1}/${sets.length}) ${set.set_id} — ${r.ok ? 'OK' : 'MISS'} wrote=${r.wrote} ${r.note}`);
+		} catch (e) {
+			consecBad++;
+			const m = e instanceof BgsGradingError ? `BGS: ${e.message}` : (e as Error).message;
+			log(`(${i + 1}/${sets.length}) ${set.set_id} — ERROR ${m}`);
+		}
+		writeStatus({
+			phase: stopping ? 'stopping' : 'running',
+			processed: i + 1,
+			total: sets.length,
+			total_wrote: totalWrote,
+			consecutive_bad: consecBad
+		});
+		if (consecBad >= FAIL_ALERT) {
+			log(`SUSTAINED FAILURE — ${consecBad} consecutive sets failed`);
+			consecBad = 0;
+		}
+	}
+	const okCount = results.filter((r) => r.ok).length;
+	log(`bgs-pop done — ${okCount}/${sets.length} sets ok, ${totalWrote} card-rows written`);
+	writeStatus({ phase: 'done', processed: sets.length, ok: okCount, total_wrote: totalWrote });
+}
+
+main().catch((e) => {
+	console.error('Fatal:', e);
+	process.exit(1);
+});

--- a/scripts/cgc-pop.ts
+++ b/scripts/cgc-pop.ts
@@ -1,0 +1,403 @@
+#!/usr/bin/env tsx
+/**
+ * Trove — CGC Cards population acquisition (like Track A / tag-pop.ts)
+ *
+ * CGC publishes its own authoritative pop report. This crawler closes the
+ * CGC gap exactly the way tag-pop.ts closes TAG: enumerate CGC's real set
+ * (group) list, fuzzy-match our tracked_sets against it, and PROVE the pick
+ * by card_number overlap before any write (honesty gate — a wrong match is
+ * rejected, never persisted). Writes the FULL grade distribution into
+ * cgc_grades + the scalar cgc_pop_total/cgc_pop_10/cgc_gem_rate(+_full) and
+ * provenance. See src/lib/services/cgc-grading.ts and
+ * project_grading_data_sources / feedback_data_is_always_findable.
+ *
+ * Usage:
+ *   tsx scripts/cgc-pop.ts --all                  # gap-prioritised crawl
+ *   tsx scripts/cgc-pop.ts --set base1            # one set
+ *   tsx scripts/cgc-pop.ts --set base1 --dry-run  # fetch+match, no write
+ *
+ * Env: PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (or PUBLISHABLE);
+ *   TROVE_CGC_REQ_DELAY_MS (800) TROVE_CGC_SET_LIMIT (0)
+ *   TROVE_CGC_MAX_PAGES (200) TROVE_CGC_FAIL_ALERT (5) TROVE_CGC_STATUS
+ */
+
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import {
+	resolveCgcPokemonCategoryId,
+	getCgcSubcategories,
+	getCgcGroups,
+	getCgcCardsForGroup,
+	cgcPopScalars,
+	CgcGradingError,
+	type CgcGroup,
+	type CgcCardRow,
+	type CgcGradeMap
+} from '../src/lib/services/cgc-grading.js';
+import { yearOf, scoreTagCandidate, normCardNumber } from './tag-aliases.js';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY =
+	process.env.SUPABASE_SERVICE_ROLE_KEY ??
+	process.env.PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ??
+	'';
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+	console.error('Missing SUPABASE_URL or SUPABASE_KEY. Check .env.local');
+	process.exit(1);
+}
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const num = (v: string | undefined, d: number) => {
+	const n = parseInt(v ?? '', 10);
+	return Number.isFinite(n) && n >= 0 ? n : d;
+};
+const REQ_DELAY_MS = num(process.env.TROVE_CGC_REQ_DELAY_MS, 800);
+const SET_LIMIT = num(process.env.TROVE_CGC_SET_LIMIT, 0);
+const MAX_PAGES = num(process.env.TROVE_CGC_MAX_PAGES, 200);
+const FAIL_ALERT = num(process.env.TROVE_CGC_FAIL_ALERT, 5);
+const STATUS_FILE =
+	process.env.TROVE_CGC_STATUS ??
+	join(homedir(), 'Library', 'Logs', 'Trove', 'cgc-pop-status.json');
+
+const ts = () => new Date().toISOString();
+const log = (m: string) => console.log(`[${ts()}] ${m}`);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let stopping = false;
+
+interface IndexCard {
+	card_id: string;
+	card_number: string | null;
+}
+async function loadIndexCards(setId: string): Promise<IndexCard[]> {
+	const { data, error } = await supabase
+		.from('card_index')
+		.select('card_id, card_number')
+		.eq('set_id', setId);
+	if (error) throw new Error(`card_index load failed: ${error.message}`);
+	return (data ?? []) as IndexCard[];
+}
+
+interface Matched {
+	card_id: string;
+	grades: CgcGradeMap;
+}
+interface Validation {
+	ok: boolean;
+	reason: string;
+	matches: Matched[];
+}
+
+function pickCanonical(rows: CgcCardRow[]): CgcCardRow {
+	return rows.reduce((a, b) =>
+		cgcPopScalars(b.grades).total > cgcPopScalars(a.grades).total ? b : a
+	);
+}
+
+/** Same honesty gate as tag-pop: prove the matched CGC group is OUR set by
+ *  card-number overlap before writing anything. */
+function validate(cgcCards: CgcCardRow[], idx: IndexCard[]): Validation {
+	if (cgcCards.length === 0) return { ok: false, reason: 'no CGC cards', matches: [] };
+	if (idx.length === 0) return { ok: false, reason: 'no card_index rows', matches: [] };
+
+	const idxByNum = new Map<string, string>();
+	for (const c of idx) {
+		const k = normCardNumber(c.card_number);
+		if (k && !idxByNum.has(k)) idxByNum.set(k, c.card_id);
+	}
+	const cgcByNum = new Map<string, CgcCardRow[]>();
+	for (const r of cgcCards) {
+		const k = normCardNumber(r.cardNumber);
+		if (!k) continue;
+		const arr = cgcByNum.get(k);
+		if (arr) arr.push(r);
+		else cgcByNum.set(k, [r]);
+	}
+	const matches: Matched[] = [];
+	let matchedNums = 0;
+	for (const [k, rows] of cgcByNum) {
+		const cardId = idxByNum.get(k);
+		if (!cardId) continue;
+		matchedNums++;
+		matches.push({ card_id: cardId, grades: pickCanonical(rows).grades });
+	}
+	const denom = Math.min(cgcByNum.size, idxByNum.size);
+	const overlapPct = denom > 0 ? (matchedNums / denom) * 100 : 0;
+	const ok = overlapPct >= 60 && matchedNums >= Math.min(5, idxByNum.size);
+	return {
+		ok,
+		reason: ok
+			? `overlap ${overlapPct.toFixed(0)}% (${matchedNums}/${denom})`
+			: `low overlap ${overlapPct.toFixed(0)}% (${matchedNums}/${denom}) — match likely wrong`,
+		matches
+	};
+}
+
+interface TrackedSet {
+	set_id: string;
+	set_name: string;
+	release_date: string;
+}
+interface SetResult {
+	setId: string;
+	ok: boolean;
+	wrote: number;
+	note: string;
+}
+
+// All Pokémon CGC groups (fetched once per run).
+let allGroups: CgcGroup[] | null = null;
+async function cgcGroups(categoryId: number): Promise<CgcGroup[]> {
+	if (allGroups) return allGroups;
+	const subs = await getCgcSubcategories(categoryId);
+	await sleep(REQ_DELAY_MS);
+	const groups: CgcGroup[] = [];
+	for (const s of subs) {
+		if (stopping) break;
+		try {
+			groups.push(...(await getCgcGroups(s.researchSubcategoryID)));
+		} catch (e) {
+			log(`  subcategory ${s.researchSubcategoryID} groups failed: ${(e as Error).message}`);
+		}
+		await sleep(REQ_DELAY_MS);
+	}
+	allGroups = groups;
+	log(`CGC group catalogue: ${groups.length} Pokémon groups`);
+	return groups;
+}
+
+async function processSet(
+	categoryId: number,
+	set: TrackedSet,
+	idx: IndexCard[],
+	dryRun: boolean
+): Promise<SetResult> {
+	let groups: CgcGroup[];
+	try {
+		groups = await cgcGroups(categoryId);
+	} catch (e) {
+		return { setId: set.set_id, ok: false, wrote: 0, note: `group-list failed: ${(e as Error).message}` };
+	}
+	const scored = groups
+		.map((g) => ({ g, s: scoreTagCandidate(set.set_name, g.name) }))
+		.filter((x) => x.s > 0)
+		.sort((a, b) => b.s - a.s);
+	if (scored.length === 0)
+		return { setId: set.set_id, ok: false, wrote: 0, note: 'NO MATCH — no CGC group scored' };
+
+	for (const { g } of scored) {
+		if (stopping) break;
+		let cards: CgcCardRow[];
+		try {
+			cards = await getCgcCardsForGroup(g.researchGroupID, {
+				maxPages: MAX_PAGES,
+				onPage: () => sleep(REQ_DELAY_MS)
+			});
+		} catch (e) {
+			log(`  [${set.set_id}] fetch "${g.name}" failed: ${(e as Error).message}`);
+			await sleep(REQ_DELAY_MS);
+			continue;
+		}
+		await sleep(REQ_DELAY_MS);
+
+		const v = validate(cards, idx);
+		if (!v.ok) {
+			log(`  [${set.set_id}] reject "${g.name}" — ${v.reason}`);
+			continue;
+		}
+		log(`  [${set.set_id}] match "${g.name}" (#${g.researchGroupID}) — ${v.reason}`);
+
+		if (dryRun) {
+			const sample = v.matches[0];
+			log(
+				`  [${set.set_id}] DRY: ${v.matches.length} cards` +
+					(sample
+						? ` e.g. ${sample.card_id} -> ${JSON.stringify({
+								...cgcPopScalars(sample.grades),
+								grades: sample.grades
+							})}`
+						: '')
+			);
+			return { setId: set.set_id, ok: true, wrote: 0, note: `DRY ${g.name}` };
+		}
+
+		const now = new Date().toISOString();
+		let wrote = 0;
+		let errs = 0;
+		for (const m of v.matches) {
+			const sc = cgcPopScalars(m.grades);
+			const { error } = await supabase
+				.from('card_index')
+				.update({
+					cgc_pop_total: sc.total,
+					cgc_pop_10: sc.grade10,
+					cgc_gem_rate: sc.gemRate,
+					cgc_gem_rate_full: sc.gemRate,
+					cgc_grades: m.grades,
+					cgc_fetched_at: now,
+					cgc_synced_at: now,
+					cgc_set_name: g.name,
+					cgc_group_id: g.researchGroupID
+				})
+				.eq('card_id', m.card_id);
+			if (error) errs++;
+			else wrote++;
+		}
+		log(`  [${set.set_id}] wrote ${wrote}, errors ${errs} (${v.reason})`);
+		return { setId: set.set_id, ok: wrote > 0, wrote, note: g.name };
+	}
+	return { setId: set.set_id, ok: false, wrote: 0, note: 'NO MATCH — all candidates failed the gate' };
+}
+
+async function prioritisedSets(): Promise<TrackedSet[]> {
+	const { data: tracked, error } = await supabase
+		.from('tracked_sets')
+		.select('set_id, set_name, release_date')
+		.eq('enabled', true);
+	if (error) throw new Error(`tracked_sets load failed: ${error.message}`);
+	const sets = (tracked ?? []) as TrackedSet[];
+
+	const minSynced = new Map<string, number | null>();
+	let from = 0;
+	const page = 1000;
+	for (;;) {
+		const { data, error: e } = await supabase
+			.from('card_index')
+			.select('set_id, cgc_synced_at')
+			.range(from, from + page - 1);
+		if (e) throw new Error(`card_index scan failed: ${e.message}`);
+		const rows = (data ?? []) as Array<{ set_id: string; cgc_synced_at: string | null }>;
+		for (const r of rows) {
+			if (r.cgc_synced_at == null) {
+				minSynced.set(r.set_id, null);
+				continue;
+			}
+			const cur = minSynced.get(r.set_id);
+			if (cur === null) continue;
+			const t = Date.parse(r.cgc_synced_at);
+			if (cur === undefined || t < cur) minSynced.set(r.set_id, t);
+		}
+		if (rows.length < page) break;
+		from += page;
+	}
+	const rank = (id: string): number => {
+		const v = minSynced.get(id);
+		if (v === undefined || v === null) return -1;
+		return v;
+	};
+	return sets.sort((a, b) => {
+		const ra = rank(a.set_id);
+		const rb = rank(b.set_id);
+		if (ra !== rb) return ra - rb;
+		return yearOf(a.release_date) - yearOf(b.release_date);
+	});
+}
+
+function writeStatus(s: Record<string, unknown>) {
+	try {
+		mkdirSync(dirname(STATUS_FILE), { recursive: true });
+		writeFileSync(STATUS_FILE, JSON.stringify({ updated_at: ts(), ...s }, null, 2));
+	} catch (e) {
+		log(`status write failed: ${(e as Error).message}`);
+	}
+}
+
+for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+	process.on(sig, () => {
+		log(`${sig} received — finishing current set then exiting`);
+		stopping = true;
+	});
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			set: { type: 'string' },
+			all: { type: 'boolean', default: false },
+			'dry-run': { type: 'boolean', default: false },
+			limit: { type: 'string' }
+		},
+		strict: false
+	});
+	const dryRun = !!values['dry-run'];
+
+	let setIds: string[];
+	if (values.set) setIds = (values.set as string).split(',').map((s) => s.trim());
+	else if (values.all) setIds = [];
+	else {
+		console.log('Usage: --all | --set <id,..> [--dry-run]');
+		return;
+	}
+
+	let categoryId: number;
+	try {
+		categoryId = await resolveCgcPokemonCategoryId();
+	} catch (e) {
+		console.error(`Cannot resolve CGC category: ${(e as Error).message}`);
+		process.exit(1);
+	}
+
+	let sets: TrackedSet[];
+	if (setIds.length > 0) {
+		const { data, error } = await supabase
+			.from('tracked_sets')
+			.select('set_id, set_name, release_date')
+			.in('set_id', setIds);
+		if (error) throw new Error(error.message);
+		sets = (data ?? []) as TrackedSet[];
+	} else {
+		sets = await prioritisedSets();
+	}
+	const cap = num(values.limit as string, SET_LIMIT);
+	if (cap > 0) sets = sets.slice(0, cap);
+
+	log(`cgc-pop start — ${sets.length} set(s), categoryId=${categoryId}${dryRun ? ' DRY-RUN' : ''}`);
+
+	let consecBad = 0;
+	let totalWrote = 0;
+	const results: SetResult[] = [];
+	for (let i = 0; i < sets.length; i++) {
+		if (stopping) {
+			log('stopping — clean exit');
+			break;
+		}
+		const set = sets[i];
+		try {
+			const idx = await loadIndexCards(set.set_id);
+			const r = await processSet(categoryId, set, idx, dryRun);
+			results.push(r);
+			totalWrote += r.wrote;
+			if (r.ok) consecBad = 0;
+			else consecBad++;
+			log(`(${i + 1}/${sets.length}) ${set.set_id} — ${r.ok ? 'OK' : 'MISS'} wrote=${r.wrote} ${r.note}`);
+		} catch (e) {
+			consecBad++;
+			const m = e instanceof CgcGradingError ? `CGC: ${e.message}` : (e as Error).message;
+			log(`(${i + 1}/${sets.length}) ${set.set_id} — ERROR ${m}`);
+		}
+		writeStatus({
+			phase: stopping ? 'stopping' : 'running',
+			processed: i + 1,
+			total: sets.length,
+			total_wrote: totalWrote,
+			consecutive_bad: consecBad
+		});
+		if (consecBad >= FAIL_ALERT) {
+			log(`SUSTAINED FAILURE — ${consecBad} consecutive sets failed`);
+			consecBad = 0;
+		}
+	}
+	const okCount = results.filter((r) => r.ok).length;
+	log(`cgc-pop done — ${okCount}/${sets.length} sets ok, ${totalWrote} card-rows written`);
+	writeStatus({ phase: 'done', processed: sets.length, ok: okCount, total_wrote: totalWrote });
+}
+
+main().catch((e) => {
+	console.error('Fatal:', e);
+	process.exit(1);
+});

--- a/scripts/refresh-index.ts
+++ b/scripts/refresh-index.ts
@@ -52,6 +52,8 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 // passes Cloudflare). Set DEV_SERVER_URL=http://localhost:5178 in .env.local.
 import { fetchPriceCharting as fetchPriceChartingDirect } from '../src/lib/services/pricecharting-scraper.js';
 import { getTagCardPop, tagPopScalars, TagGradingError } from '../src/lib/services/tag-grading.js';
+import { getCgcCardPop, cgcPopScalars, CgcGradingError } from '../src/lib/services/cgc-grading.js';
+import { getBgsCardPop, bgsDrillKeyword, bgsPopScalars, BgsGradingError } from '../src/lib/services/bgs-grading.js';
 
 const DEV_SERVER_URL = process.env.DEV_SERVER_URL ?? '';
 
@@ -749,6 +751,77 @@ async function main() {
 		} catch (e) {
 			const m = e instanceof TagGradingError ? e.message : (e as Error).message;
 			console.warn(`TAG re-verify skipped: ${m}`);
+		}
+
+		// On-query CGC re-verify (single card; provenance from a prior nightly
+		// cgc-pop crawl). Failure leaves stored values untouched.
+		try {
+			const { data: prov } = await supabase
+				.from('card_index')
+				.select('card_number, cgc_group_id')
+				.eq('card_id', cardId)
+				.maybeSingle();
+			if (prov?.cgc_group_id && prov?.card_number) {
+				const grades = await getCgcCardPop({
+					groupId: prov.cgc_group_id as number,
+					cardNumber: prov.card_number as string
+				});
+				if (grades) {
+					const sc = cgcPopScalars(grades);
+					const nowIso = new Date().toISOString();
+					Object.assign(row, {
+						cgc_pop_total: sc.total,
+						cgc_pop_10: sc.grade10,
+						cgc_gem_rate: sc.gemRate,
+						cgc_gem_rate_full: sc.gemRate,
+						cgc_grades: grades,
+						cgc_fetched_at: nowIso,
+						cgc_synced_at: nowIso
+					});
+				}
+			}
+		} catch (e) {
+			const m = e instanceof CgcGradingError ? e.message : (e as Error).message;
+			console.warn(`CGC re-verify skipped: ${m}`);
+		}
+
+		// On-query BGS re-verify (single card; provenance from a prior nightly
+		// bgs-pop crawl). Failure leaves stored values untouched.
+		try {
+			const { data: prov } = await supabase
+				.from('card_index')
+				.select('card_number, bgs_set_id, bgs_lpg_set_id, bgs_set_name')
+				.eq('card_id', cardId)
+				.maybeSingle();
+			if (
+				prov?.bgs_set_id &&
+				prov?.bgs_lpg_set_id &&
+				prov?.bgs_set_name &&
+				prov?.card_number
+			) {
+				const grades = await getBgsCardPop({
+					setNameKeyword: bgsDrillKeyword(prov.bgs_set_name as string),
+					displaySetId: prov.bgs_set_id as string,
+					lpgSetId: prov.bgs_lpg_set_id as string,
+					cardNumber: prov.card_number as string
+				});
+				if (grades) {
+					const sc = bgsPopScalars(grades);
+					const nowIso = new Date().toISOString();
+					Object.assign(row, {
+						bgs_pop_total: sc.total,
+						bgs_pop_10: sc.grade10,
+						bgs_gem_rate: sc.gemRate,
+						bgs_gem_rate_full: sc.gemRate,
+						bgs_grades: grades,
+						bgs_fetched_at: nowIso,
+						bgs_synced_at: nowIso
+					});
+				}
+			}
+		} catch (e) {
+			const m = e instanceof BgsGradingError ? e.message : (e as Error).message;
+			console.warn(`BGS re-verify skipped: ${m}`);
 		}
 
 		if (dryRun) {

--- a/src/lib/services/bgs-grading.ts
+++ b/src/lib/services/bgs-grading.ts
@@ -1,0 +1,267 @@
+/**
+ * Beckett (BGS) — population report client
+ *
+ * Beckett publishes its own pop report (beckett.com/grading/pop-report, a
+ * Next.js app proxied at /gradingpopreport). Reverse-engineered 2026-05-18
+ * from the Next bundle: the SPA calls a plain JSON API. NO auth, NO
+ * Cloudflare, works from a bare datacenter IP. Recipe (see
+ * project_grading_data_sources):
+ *
+ *   GET https://www.beckett.com/api/grading/pop-report
+ *       ?sport_id=477173            (Pokémon, Beckett's sport id)
+ *       &set_name=<keyword>         (substring match across Beckett set names)
+ *       &set_id=<id>                (drill into one set → per-card rows)
+ *       &page=N&limit=M&show_totals=1
+ *
+ * Response: { total_records, page, size,
+ *   sets:{<setId>:<name>}, sets_summary_data:{<setId>:<count>},
+ *   grade_summary_data:[{ set_id,set_name,card_num,player_name,title,
+ *     fg10..fg100,fgB100,non_bccg_card_total, ... }] }
+ *
+ * BGS scale: half-point 1–10. fgNN = grade NN/10 (fg10=1.0 … fg95=9.5,
+ * fg100=10 / Pristine), fgB100 = Black Label 10. Distribution map keys:
+ * "1","1.5",…,"9.5","10","10BL". Honest-or-null: a zero/absent grade is
+ * absent from the map, never fabricated.
+ */
+
+const BGS_API = 'https://www.beckett.com/api/grading/pop-report';
+/** Beckett's Pokémon sport id (verified live from the legacy selector). */
+export const BGS_POKEMON_SPORT_ID = '477173';
+const UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+	'(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+
+export class BgsGradingError extends Error {}
+
+async function bgsRequest<T>(params: Record<string, string>, timeoutMs = 40000): Promise<T> {
+	const qs = Object.entries(params)
+		.filter(([, v]) => v !== '' && v != null)
+		.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+		.join('&');
+	const ctrl = new AbortController();
+	const t = setTimeout(() => ctrl.abort(), timeoutMs);
+	let res: Response;
+	try {
+		res = await fetch(`${BGS_API}?${qs}`, {
+			headers: {
+				'User-Agent': UA,
+				Accept: 'application/json',
+				Referer: 'https://www.beckett.com/gradingpopreport'
+			},
+			signal: ctrl.signal
+		});
+	} catch (e) {
+		throw new BgsGradingError(`network: ${(e as Error).message}`);
+	} finally {
+		clearTimeout(t);
+	}
+	const text = await res.text();
+	// The Next app HTML shell (proxy catch-all) starts with "<" — treat as
+	// "endpoint moved", never as data.
+	if (text.startsWith('<')) throw new BgsGradingError('non-JSON (HTML shell)');
+	let j: unknown;
+	try {
+		j = JSON.parse(text);
+	} catch {
+		throw new BgsGradingError('non-JSON body');
+	}
+	if (j && typeof j === 'object' && 'status' in j && (j as { status: number }).status >= 400) {
+		const e = j as { status: number; message?: string };
+		throw new BgsGradingError(`${e.status}: ${e.message ?? 'error'}`);
+	}
+	if (!res.ok) throw new BgsGradingError(`HTTP ${res.status}`);
+	return j as T;
+}
+
+// fgNN → grade label. fg10=1.0 … fg95=9.5, fg100=10, fgB100=Black Label 10.
+function fgKeyToLabel(key: string): string | null {
+	if (/^fgB100$/i.test(key)) return '10BL';
+	const m = key.match(/^fg(\d{2,3})$/i);
+	if (!m) return null;
+	const n = parseInt(m[1], 10); // 10..100 → grade×10
+	if (n < 10 || n > 100) return null;
+	return `${n / 10}`; // 1, 1.5, … 9.5, 10
+
+}
+
+export type BgsGradeMap = Record<string, number>;
+
+interface BgsRawRow {
+	set_id?: string;
+	set_name?: string;
+	card_num?: string;
+	player_name?: string;
+	title?: string;
+	non_bccg_card_total?: string | number;
+	[k: string]: unknown;
+}
+
+export interface BgsCardRow {
+	cardNumber: string;
+	playerName: string;
+	title: string;
+	setId: string;
+	setName: string;
+	grades: BgsGradeMap;
+}
+
+interface BgsResponse {
+	total_records?: number;
+	page?: string | number;
+	size?: string | number;
+	sets?: Record<string, string>;
+	sets_summary_data?: Record<string, string | number>;
+	/** Beckett returns TWO id spaces: `sets` keys are display ids; the
+	 *  per-card drill-down wants the matching `lpg_set_ids` value, which is
+	 *  also the `set_id` carried on each grade_summary_data row. */
+	lpg_set_ids?: Record<string, string | number>;
+	grade_summary_data?: BgsRawRow[];
+}
+
+function rowToGrades(row: BgsRawRow): BgsGradeMap {
+	const out: BgsGradeMap = {};
+	for (const [k, v] of Object.entries(row)) {
+		if (!/^fg/i.test(k)) continue;
+		const label = fgKeyToLabel(k);
+		if (!label) continue;
+		const n = Number(v);
+		if (!Number.isFinite(n) || n <= 0) continue;
+		out[label] = (out[label] ?? 0) + n;
+	}
+	return out;
+}
+
+export interface BgsSetCandidate {
+	/** Beckett display set id (the `sets` map key). */
+	setId: string;
+	/** lpg id — what the per-card drill-down + row.set_id actually use. */
+	lpgSetId: string;
+	name: string;
+	count: number;
+}
+
+/** Set candidates for a keyword. Beckett's `set_name` is a constrained
+ *  substring filter over its bare set-name field (NOT the displayed
+ *  "<year> Pokemon <name>"), so a tracked set may surface under an
+ *  unexpected keyword — the caller fuzzy-ranks and the card-number
+ *  overlap gate (in the crawler) is the real correctness guarantee. */
+export async function searchBgsSets(setNameKeyword: string): Promise<BgsSetCandidate[]> {
+	const d = await bgsRequest<BgsResponse>({
+		sport_id: BGS_POKEMON_SPORT_ID,
+		set_name: setNameKeyword,
+		show_totals: '1',
+		page: '1',
+		limit: '100'
+	});
+	const sets = d.sets ?? {};
+	const counts = d.sets_summary_data ?? {};
+	const lpg = d.lpg_set_ids ?? {};
+	return Object.entries(sets).map(([setId, name]) => ({
+		setId,
+		lpgSetId: String(lpg[setId] ?? setId),
+		name: String(name),
+		count: Number(counts[setId] ?? 0)
+	}));
+}
+
+/** Walk all pages of one Beckett set's per-card grade rows.
+ *  The drill-down REQUEST takes the DISPLAY set id (the `sets` map key)
+ *  plus a `set_name` keyword that surfaced it; each returned row's
+ *  `set_id` is the lpg id, which we filter on. */
+export async function getBgsCardsForSet(args: {
+	setNameKeyword: string;
+	displaySetId: string;
+	lpgSetId: string;
+	limit?: number;
+	maxPages?: number;
+	onPage?: () => Promise<void>;
+}): Promise<BgsCardRow[]> {
+	const limit = args.limit ?? 100;
+	const maxPages = args.maxPages ?? 60;
+	const out: BgsCardRow[] = [];
+	for (let page = 1; page <= maxPages; page++) {
+		const d = await bgsRequest<BgsResponse>({
+			sport_id: BGS_POKEMON_SPORT_ID,
+			set_name: args.setNameKeyword,
+			set_id: args.displaySetId,
+			show_totals: '1',
+			page: String(page),
+			limit: String(limit)
+		});
+		const rows = (d.grade_summary_data ?? []).filter(
+			(r) => String(r.set_id) === args.lpgSetId
+		);
+		for (const r of rows)
+			out.push({
+				cardNumber: String(r.card_num ?? ''),
+				playerName: String(r.player_name ?? ''),
+				title: String(r.title ?? ''),
+				setId: String(r.set_id ?? args.lpgSetId),
+				setName: String(r.set_name ?? ''),
+				grades: rowToGrades(r)
+			});
+		const total = Number(d.total_records ?? out.length);
+		if ((d.grade_summary_data ?? []).length === 0 || out.length >= total) break;
+		if (args.onPage) await args.onPage();
+	}
+	return out;
+}
+
+// --------------------------------------------------------------------------
+// Distribution scalars
+// --------------------------------------------------------------------------
+
+export interface BgsPopScalars {
+	total: number;
+	/** BGS 10 + Black Label 10 — the "at 10" scalar. */
+	grade10: number;
+	gemRate: number | null;
+}
+
+export function bgsPopScalars(grades: BgsGradeMap | null | undefined): BgsPopScalars {
+	if (!grades) return { total: 0, grade10: 0, gemRate: null };
+	let total = 0;
+	for (const v of Object.values(grades)) total += Number(v) || 0;
+	const grade10 = (Number(grades['10']) || 0) + (Number(grades['10BL']) || 0);
+	const gemRate =
+		total > 0 ? Math.min(999.99, Math.round((grade10 / total) * 10000) / 100) : null;
+	return { total, grade10, gemRate };
+}
+
+function normNum(v: string | null | undefined): string {
+	const s = String(v ?? '')
+		.trim()
+		.toLowerCase();
+	return (s.split('/')[0]?.trim() ?? '').replace(/^0+(?=\d)/, '');
+}
+
+/** A safe `set_name` drill keyword from a Beckett set name: the first
+ *  core word (≥3 chars) after stripping the leading year and "Pokemon"
+ *  decoration — guaranteed to be a substring of that set's name, which
+ *  is what the Beckett filter requires. */
+export function bgsDrillKeyword(beckettSetName: string): string {
+	const core = beckettSetName
+		.replace(/^\s*\d{4}\s+/, '')
+		.replace(/\bpok[eé]?mon\b/gi, ' ')
+		.replace(/\b(tcg|card game)\b/gi, ' ')
+		.trim();
+	const w = core.split(/\s+/).find((t) => t.replace(/[^a-z0-9]/gi, '').length >= 3);
+	return (w ?? core.split(/\s+/)[0] ?? beckettSetName).trim();
+}
+
+/** On-query single-card BGS pop given a known Beckett set. Largest print wins. */
+export async function getBgsCardPop(args: {
+	setNameKeyword: string;
+	displaySetId: string;
+	lpgSetId: string;
+	cardNumber: string;
+}): Promise<BgsGradeMap | null> {
+	const want = normNum(args.cardNumber);
+	if (!want) return null;
+	const cards = await getBgsCardsForSet(args);
+	const hits = cards.filter((c) => normNum(c.cardNumber) === want);
+	if (hits.length === 0) return null;
+	return hits.reduce((a, b) =>
+		bgsPopScalars(b.grades).total > bgsPopScalars(a.grades).total ? b : a
+	).grades;
+}

--- a/src/lib/services/cgc-grading.ts
+++ b/src/lib/services/cgc-grading.ts
@@ -1,0 +1,243 @@
+/**
+ * CGC Cards — population report client
+ *
+ * CGC publishes its own authoritative pop report (cgccards.com/population-
+ * report). Reverse-engineered 2026-05-18 from the AngularJS bundle: the SPA
+ * calls a plain JSON API at https://production.api.aws.ccg-ops.com/api with
+ * the trading-cards research path. NO auth, NO Cloudflare, works from a bare
+ * datacenter IP. Recipe (see project_grading_data_sources):
+ *
+ *   base = https://production.api.aws.ccg-ops.com/api/cards/research/trading-cards
+ *   GET {base}/categories/                          -> Pokémon = researchCategoryID 2
+ *   GET {base}/subcategories/?researchCategoryID=2   -> eras (researchSubcategoryID)
+ *   GET {base}/groups?researchSubcategoryID=<sub>    -> sets   (researchGroupID, name)
+ *   GET {base}/population?researchGroupID=<group>    -> per-card full grade ladder
+ *   GET {base}/population/update-time/               -> nightly skip-unchanged
+ *
+ * CGC's scale: integer + half grades 1–10, plus three distinct top tiers —
+ * GemMint 10, Pristine 10, Perfect 10 — kept as separate keys. Distribution
+ * map keys: "1".."9","1.5".."9.5","10","10P" (Pristine), "10PF" (Perfect).
+ * "10" is GemMint 10 (the standard CGC 10). Honest-or-null: a missing field
+ * is absent from the map, never fabricated.
+ */
+
+const CGC_API = 'https://production.api.aws.ccg-ops.com/api/cards/research/trading-cards';
+const UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+	'(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+
+export class CgcGradingError extends Error {}
+
+async function cgcRequest<T>(path: string, timeoutMs = 40000): Promise<T> {
+	const ctrl = new AbortController();
+	const t = setTimeout(() => ctrl.abort(), timeoutMs);
+	let res: Response;
+	try {
+		res = await fetch(`${CGC_API}${path}`, {
+			headers: {
+				'User-Agent': UA,
+				Accept: 'application/json',
+				'Accept-Language': 'en-US',
+				Referer: 'https://www.cgccards.com/'
+			},
+			signal: ctrl.signal
+		});
+	} catch (e) {
+		throw new CgcGradingError(`network: ${(e as Error).message}`);
+	} finally {
+		clearTimeout(t);
+	}
+	if (!res.ok) throw new CgcGradingError(`HTTP ${res.status}`);
+	const text = await res.text();
+	if (!text) throw new CgcGradingError('empty body');
+	try {
+		return JSON.parse(text) as T;
+	} catch {
+		throw new CgcGradingError('non-JSON body');
+	}
+}
+
+// --------------------------------------------------------------------------
+// Typed endpoints
+// --------------------------------------------------------------------------
+
+export interface CgcCategory {
+	researchCategoryID: number;
+	name: string;
+	importCode?: string;
+}
+export interface CgcSubcategory {
+	researchSubcategoryID: number;
+	researchCategoryID: number;
+	name: string;
+}
+export interface CgcGroup {
+	researchGroupID: number;
+	researchSubcategoryID: number;
+	name: string;
+	seoName?: string;
+	populationCount?: number;
+	isEnabled?: boolean;
+}
+/** Raw population row as the API returns it (population_* fields). */
+interface CgcPopRow {
+	populationID: number;
+	cardNumber: string;
+	cardYear?: string;
+	[k: string]: unknown;
+}
+/** grade label -> count, e.g. {"9":27,"9.5":8,"10":12,"10P":2,"10PF":0} */
+export type CgcGradeMap = Record<string, number>;
+export interface CgcCardRow {
+	cardNumber: string;
+	cardYear?: string;
+	grades: CgcGradeMap;
+}
+
+export async function getCgcUpdateTime(): Promise<string | null> {
+	try {
+		const d = await cgcRequest<{ updateTime?: string }>('/population/update-time/');
+		return d?.updateTime ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export async function getCgcCategories(): Promise<CgcCategory[]> {
+	const d = await cgcRequest<CgcCategory[]>('/categories/');
+	return Array.isArray(d) ? d : [];
+}
+
+/** Resolve the Pokémon research category id (defensive vs. rename/reorder). */
+export async function resolveCgcPokemonCategoryId(): Promise<number> {
+	try {
+		const cats = await getCgcCategories();
+		const hit = cats.find((c) => /pok[eé]?mon/i.test(c.name));
+		if (hit) return hit.researchCategoryID;
+	} catch {
+		/* fall through */
+	}
+	return 2; // verified 2026-05-18
+}
+
+export async function getCgcSubcategories(categoryId: number): Promise<CgcSubcategory[]> {
+	const d = await cgcRequest<CgcSubcategory[]>(
+		`/subcategories/?researchCategoryID=${categoryId}`
+	);
+	return Array.isArray(d) ? d : [];
+}
+
+export async function getCgcGroups(subcategoryId: number): Promise<CgcGroup[]> {
+	const d = await cgcRequest<{ Items?: CgcGroup[] } | CgcGroup[]>(
+		`/groups?researchSubcategoryID=${subcategoryId}`
+	);
+	if (Array.isArray(d)) return d;
+	return d?.Items ?? [];
+}
+
+// Map raw population_* fields → our compact grade label.
+// CGC keys seen: population_<G>_<H> (e.g. 9_0, 9_5, 1_0), plus the three
+// distinct 10 tiers GemMint10 / Pristine10 / Perfect10.
+// Map raw population_* fields → compact grade labels. Real CGC fields
+// (verified live): population_1_0 … 9_5, population_AA (Authentic Altered),
+// population_AU (Authentic), GemMint10 / Pristine10 / Perfect10, and
+// population_Total. Total is the API's own sum — NEVER fold it into the
+// distribution (it would double the count); skip it explicitly.
+function rowToGrades(row: CgcPopRow): CgcGradeMap {
+	const out: CgcGradeMap = {};
+	for (const [k, v] of Object.entries(row)) {
+		if (!k.startsWith('population_')) continue;
+		const tag = k.slice('population_'.length);
+		if (/^Total$/i.test(tag)) continue;
+		const n = Number(v);
+		if (!Number.isFinite(n) || n <= 0) continue;
+		let label: string | null = null;
+		if (/^GemMint10$/i.test(tag)) label = '10';
+		else if (/^Pristine10$/i.test(tag)) label = '10P';
+		else if (/^Perfect10$/i.test(tag)) label = '10PF';
+		else if (/^AU$/i.test(tag)) label = 'AU';
+		else if (/^AA$/i.test(tag)) label = 'AA';
+		else {
+			const m = tag.match(/^(\d{1,2})_(\d)$/);
+			if (m) {
+				const whole = parseInt(m[1], 10);
+				label = m[2] === '5' ? `${whole}.5` : `${whole}`;
+			}
+		}
+		if (label) out[label] = (out[label] ?? 0) + n;
+	}
+	return out;
+}
+
+/** Walk all pages for a group. Server page size is fixed (50); paginate by
+ *  `page` until TotalCount is reached. Bounded to avoid runaway. */
+export async function getCgcCardsForGroup(
+	groupId: number,
+	opts: { maxPages?: number; onPage?: () => Promise<void> } = {}
+): Promise<CgcCardRow[]> {
+	const maxPages = opts.maxPages ?? 200;
+	const out: CgcCardRow[] = [];
+	for (let page = 1; page <= maxPages; page++) {
+		const d = await cgcRequest<{ Items?: CgcPopRow[]; TotalCount?: number } | CgcPopRow[]>(
+			`/population?researchGroupID=${groupId}&page=${page}`
+		);
+		const items: CgcPopRow[] = Array.isArray(d) ? d : (d?.Items ?? []);
+		const totalCount = Array.isArray(d) ? items.length : (d?.TotalCount ?? 0);
+		if (items.length === 0) break;
+		for (const r of items)
+			out.push({
+				cardNumber: String(r.cardNumber ?? ''),
+				cardYear: r.cardYear ? String(r.cardYear) : undefined,
+				grades: rowToGrades(r)
+			});
+		if (out.length >= totalCount) break;
+		if (opts.onPage) await opts.onPage();
+	}
+	return out;
+}
+
+// --------------------------------------------------------------------------
+// Distribution scalars (honest, derived from the full map)
+// --------------------------------------------------------------------------
+
+export interface CgcPopScalars {
+	total: number;
+	/** All three CGC 10 tiers summed — the "at 10" scalar. */
+	grade10: number;
+	gemRate: number | null;
+}
+
+export function cgcPopScalars(grades: CgcGradeMap | null | undefined): CgcPopScalars {
+	if (!grades) return { total: 0, grade10: 0, gemRate: null };
+	let total = 0;
+	for (const v of Object.values(grades)) total += Number(v) || 0;
+	const grade10 =
+		(Number(grades['10']) || 0) +
+		(Number(grades['10P']) || 0) +
+		(Number(grades['10PF']) || 0);
+	const gemRate =
+		total > 0 ? Math.min(999.99, Math.round((grade10 / total) * 10000) / 100) : null;
+	return { total, grade10, gemRate };
+}
+
+function normNum(v: string | null | undefined): string {
+	const s = String(v ?? '')
+		.trim()
+		.toLowerCase();
+	return (s.split('/')[0]?.trim() ?? '').replace(/^0+(?=\d)/, '');
+}
+
+/** On-query single-card CGC pop given a known group. Largest print wins. */
+export async function getCgcCardPop(args: {
+	groupId: number;
+	cardNumber: string;
+}): Promise<CgcGradeMap | null> {
+	const want = normNum(args.cardNumber);
+	if (!want) return null;
+	const cards = await getCgcCardsForGroup(args.groupId);
+	const hits = cards.filter((c) => normNum(c.cardNumber) === want);
+	if (hits.length === 0) return null;
+	return hits.reduce((a, b) =>
+		cgcPopScalars(b.grades).total > cgcPopScalars(a.grades).total ? b : a
+	).grades;
+}

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -186,6 +186,26 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		// migration 019 not applied yet — TAG ladder hidden, page is fine
 	}
 
+	// CGC + Beckett full-distribution columns land in migration 021. Same
+	// isolated/best-effort pattern as tagExtra so the page renders before
+	// it's applied (those ladders simply stay hidden until column + crawl).
+	let cgcBgsExtra: {
+		cgc_grades: Record<string, number> | null;
+		cgc_synced_at: string | null;
+		bgs_grades: Record<string, number> | null;
+		bgs_synced_at: string | null;
+	} | null = null;
+	try {
+		const { data, error } = await supabase
+			.from('card_index')
+			.select('cgc_grades, cgc_synced_at, bgs_grades, bgs_synced_at')
+			.eq('card_id', params.id)
+			.maybeSingle();
+		if (!error) cgcBgsExtra = (data as typeof cgcBgsExtra) ?? null;
+	} catch {
+		// migration 021 not applied yet — CGC/BGS ladders hidden, page fine
+	}
+
 	// Real per-grade ladder (migration 020). Isolated + best-effort like
 	// tagExtra above so the page renders normally before 020 is applied
 	// (the per-grade ladder simply stays absent until the column +
@@ -271,6 +291,7 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		conditionPrices,
 		indexRow,
 		tagExtra,
+		cgcBgsExtra,
 		gradeLadders,
 		gradeLadderFetchedAt,
 		cardSignal,

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -201,6 +201,48 @@
 		})()
 	);
 
+	// CGC + Beckett full distributions (migration 021), same isolated prop
+	// pattern as tagExtra. Real counts only; hidden until 021 + crawl.
+	let cgcBgsExtra = $derived(
+		((data as Record<string, unknown>).cgcBgsExtra ?? null) as {
+			cgc_grades: Record<string, number> | null;
+			cgc_synced_at: string | null;
+			bgs_grades: Record<string, number> | null;
+			bgs_synced_at: string | null;
+		} | null
+	);
+	// Sort numeric grades ascending; grader-special tiers (Pristine/Perfect/
+	// Black Label) right after 10, then Authentic tiers last.
+	const SPECIAL_ORDER: Record<string, number> = {
+		'10': 100,
+		'10P': 101,
+		'10PF': 102,
+		'10BL': 101,
+		AU: 200,
+		AA: 201,
+		VA: 200
+	};
+	function gradeRowsOf(g: Record<string, number> | null | undefined) {
+		if (!g) return [] as Array<{ label: string; count: number }>;
+		return Object.entries(g)
+			.map(([label, count]) => ({ label, count: Number(count) || 0 }))
+			.sort((a, b) => {
+				const av = SPECIAL_ORDER[a.label] ?? parseFloat(a.label);
+				const bv = SPECIAL_ORDER[b.label] ?? parseFloat(b.label);
+				return av - bv;
+			});
+	}
+	let cgcGradeRows = $derived(gradeRowsOf(cgcBgsExtra?.cgc_grades));
+	let bgsGradeRows = $derived(gradeRowsOf(cgcBgsExtra?.bgs_grades));
+	function gradeTierLabel(l: string): string {
+		if (l === '10P') return '10 Pristine';
+		if (l === '10PF') return '10 Perfect';
+		if (l === '10BL') return '10 Black';
+		if (l === 'AU') return 'Auth';
+		if (l === 'AA') return 'Auth Alt';
+		return l;
+	}
+
 	// Per-grade ladders: real cells (bold white) + honest, real-anchored
 	// estimates (darker blue + est. chip + tooltip). Built server-side by
 	// grade-estimate.ts; empty array = nothing to show (page unaffected).
@@ -694,6 +736,52 @@
 								{/each}
 							</div>
 							<p class="mt-2 text-[10px] text-vault-text-muted">VA = Verified Authentic (ungraded). Real counts from TAG; grades with no copies are omitted.</p>
+						</div>
+					{/if}
+
+					<!-- CGC full grade distribution (1–10 + halves + Pristine/Perfect 10 + Auth) -->
+					{#if cgcGradeRows.length > 0}
+						<div class="mt-3 rounded-xl border border-vault-border bg-vault-bg p-3">
+							<div class="flex items-baseline justify-between">
+								<p class="text-[11px] font-medium text-blue-400">CGC full grade distribution</p>
+								{#if cgcBgsExtra?.cgc_synced_at}
+									<p class="text-[10px] text-vault-text-muted" title="Direct from CGC's population report (cgccards.com).">
+										CGC · {daysSince(cgcBgsExtra?.cgc_synced_at) ?? 0}d
+									</p>
+								{/if}
+							</div>
+							<div class="mt-2 grid grid-cols-4 gap-1.5 sm:grid-cols-6">
+								{#each cgcGradeRows as r (r.label)}
+									<div class="rounded-lg border border-vault-border/60 px-2 py-1 text-center">
+										<p class="text-[10px] text-vault-text-muted">CGC {gradeTierLabel(r.label)}</p>
+										<p class="text-sm font-bold text-white">{fmtInt(r.count)}</p>
+									</div>
+								{/each}
+							</div>
+							<p class="mt-2 text-[10px] text-vault-text-muted">10 = Gem Mint 10. Real counts from CGC; grades with no copies are omitted.</p>
+						</div>
+					{/if}
+
+					<!-- Beckett (BGS) full grade distribution (1–10 incl. halves + Black Label) -->
+					{#if bgsGradeRows.length > 0}
+						<div class="mt-3 rounded-xl border border-vault-border bg-vault-bg p-3">
+							<div class="flex items-baseline justify-between">
+								<p class="text-[11px] font-medium text-amber-400">Beckett (BGS) full grade distribution</p>
+								{#if cgcBgsExtra?.bgs_synced_at}
+									<p class="text-[10px] text-vault-text-muted" title="Direct from Beckett's population report (beckett.com).">
+										BGS · {daysSince(cgcBgsExtra?.bgs_synced_at) ?? 0}d
+									</p>
+								{/if}
+							</div>
+							<div class="mt-2 grid grid-cols-4 gap-1.5 sm:grid-cols-6">
+								{#each bgsGradeRows as r (r.label)}
+									<div class="rounded-lg border border-vault-border/60 px-2 py-1 text-center">
+										<p class="text-[10px] text-vault-text-muted">BGS {gradeTierLabel(r.label)}</p>
+										<p class="text-sm font-bold text-white">{fmtInt(r.count)}</p>
+									</div>
+								{/each}
+							</div>
+							<p class="mt-2 text-[10px] text-vault-text-muted">10 = BGS 10, 10 Black = Black Label. Real counts from Beckett; grades with no copies are omitted.</p>
 						</div>
 					{/if}
 

--- a/supabase/migrations/021_cgc_bgs_pop.sql
+++ b/supabase/migrations/021_cgc_bgs_pop.sql
@@ -1,0 +1,54 @@
+-- Trove: real CGC + Beckett (BGS) full population, like TAG (migration 019)
+--
+-- CGC and Beckett each publish their own authoritative pop report with a
+-- full per-grade distribution. Reverse-engineered 2026-05-18 (plain JSON,
+-- no auth, no Cloudflare — see project_grading_data_sources):
+--   CGC: production.api.aws.ccg-ops.com … /population?researchGroupID=<id>
+--   BGS: www.beckett.com/api/grading/pop-report?sport_id=477173&set_id=<id>
+--
+-- migrations 007 / 016 already gave the scalar cgc_pop_* / bgs_pop_*
+-- columns. This adds the FULL grade distribution (CGC uses half grades +
+-- GemMint/Pristine/Perfect 10; BGS uses half grades + Black Label 10 — a
+-- single integer can't represent either) plus provenance so the nightly
+-- crawl can skip unchanged sets and an on-query single-card refresh knows
+-- which CGC group / Beckett set to re-fetch.
+--
+-- ADD-ONLY and idempotent. No existing column is redefined; combined_pop
+-- (psa+cgc) is intentionally left as-is.
+
+-- CGC full distribution + provenance.
+-- grade map e.g. {"7":40,"8.5":12,"9":27,"9.5":8,"10":12,"10P":2,"10PF":0,"AU":1}
+-- "10" = GemMint 10, "10P" = Pristine 10, "10PF" = Perfect 10,
+-- "AU" = Authentic, "AA" = Authentic Altered.
+alter table card_index add column if not exists cgc_grades jsonb;
+alter table card_index add column if not exists cgc_gem_rate_full numeric(5, 2);
+alter table card_index add column if not exists cgc_set_name text;
+alter table card_index add column if not exists cgc_group_id integer;
+alter table card_index add column if not exists cgc_synced_at timestamptz;
+
+-- Beckett (BGS) full distribution + provenance.
+-- grade map e.g. {"7":5,"8":9,"8.5":14,"9":120,"9.5":300,"10":51,"10BL":8}
+-- "10" = BGS 10 (Pristine), "10BL" = Black Label 10.
+alter table card_index add column if not exists bgs_grades jsonb;
+alter table card_index add column if not exists bgs_gem_rate_full numeric(5, 2);
+alter table card_index add column if not exists bgs_set_name text;
+-- Beckett has two id spaces: bgs_set_id = the display id used to REQUEST a
+-- set; bgs_lpg_set_id = the id carried on each per-card row (filter key).
+-- Both are needed to re-drill one card on-query.
+alter table card_index add column if not exists bgs_set_id text;
+alter table card_index add column if not exists bgs_lpg_set_id text;
+alter table card_index add column if not exists bgs_synced_at timestamptz;
+
+-- "Hot pop" / gem-10 sorts + cheap stalest-first crawl ordering, mirroring
+-- the migration-019 TAG indexes.
+create index if not exists idx_card_index_cgc_pop_10_d
+    on card_index (cgc_pop_10 desc nulls last)
+    where cgc_pop_10 is not null;
+create index if not exists idx_card_index_cgc_synced
+    on card_index (cgc_synced_at asc nulls first);
+
+create index if not exists idx_card_index_bgs_pop_10_d
+    on card_index (bgs_pop_10 desc nulls last)
+    where bgs_pop_10 is not null;
+create index if not exists idx_card_index_bgs_synced
+    on card_index (bgs_synced_at asc nulls first);


### PR DESCRIPTION
## Summary

Treats **CGC** and **Beckett (BGS)** exactly like TAG/PSA: each publishes its own authoritative population report, both **fully reverse-engineered** (plain JSON, no auth, no Cloudflare, works from a datacenter IP):

- **CGC** — `production.api.aws.ccg-ops.com/api/cards/research/trading-cards`: categories → subcategories → groups → `/population?researchGroupID=` per-card full ladder (half grades + GemMint/Pristine/Perfect 10 + Authentic).
- **BGS** — `www.beckett.com/api/grading/pop-report` (Pokémon `sport_id=477173`): two id spaces (display vs `lpg`), full `fg10..fgB100` ladder (half grades + Black Label 10).

Mirrors the TAG Track-A pattern: shared clients (`cgc-grading.ts` / `bgs-grading.ts`), gap-prioritised crawlers (`cgc-pop.ts` / `bgs-pop.ts`) with fuzzy set-match **proven by card-number overlap before any write** (honesty gate — a wrong match is rejected, never persisted), per-set isolation, heartbeat, dry-run. On-query single-card re-verify wired into `refresh-index --card`. Migration `021` adds `cgc_grades`/`bgs_grades` jsonb + provenance (add-only/idempotent, like 019). `engine-cgc` / `engine-bgs` GitHub Actions crons. Card page renders both full distributions like the TAG ladder (real counts only, hidden until 021 + crawl).

## Test plan

- [x] svelte-check 18/2 — baseline, **0 new**
- [x] vitest 64/64
- [x] **CGC live**: base1 → "Base Set - 1st Edition" **100% overlap (102/102)**, 729 Pokémon groups, full real ladder
- [x] **BGS live**: base1/base2/base3/sv1 all **100% overlap**, full real ladders (incl. half grades + Black Label)
- [ ] **Migration `021_cgc_bgs_pop.sql` needs hand-apply** (add-only, like 019). Until then card page renders fine (ladders hidden) and crawlers no-op per-set — nothing breaks
- [ ] Note: Beckett's set naming is idiosyncratic; the card-number overlap gate guarantees correctness (writes real data where confidently matched, **nothing** where it can't — honest-or-null, expands via the same alias path as TAG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)