### PR TITLE
Fix: Refresh-now silently no-op'd in prod (RLS write block)

### DIFF
--- a/src/lib/server/supabase-admin.ts
+++ b/src/lib/server/supabase-admin.ts
@@ -1,0 +1,32 @@
+/**
+ * Server-only Supabase client (service-role).
+ *
+ * WHY: migration 018 enabled RLS on the data-engine tables with anon =
+ * SELECT only and NO write policy ("writes stay service-role-only"). The
+ * browser/SSR client (src/lib/services/supabase.ts) uses the publishable
+ * key = the `anon` role, so any server-side write it issues is silently
+ * RLS-filtered to zero rows (PostgREST returns no error) — the write
+ * looks like it succeeded but nothing lands. Server-side form actions
+ * that must persist (e.g. card-detail "Refresh now") need this
+ * privileged client instead.
+ *
+ * This file lives under `$lib/server` and imports `$env/dynamic/private`
+ * so the service-role key can NEVER be bundled into client code — a
+ * build error is raised if it is imported from the browser.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from '$env/dynamic/private';
+import { env as pubEnv } from '$env/dynamic/public';
+
+const url = pubEnv.PUBLIC_SUPABASE_URL ?? '';
+const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+
+/**
+ * The privileged client, or null when the service-role key isn't
+ * configured in this environment. Callers MUST handle null by failing
+ * honestly — never fall back to the anon client and report success
+ * (that is the exact silent-no-op bug this module exists to fix).
+ */
+export const supabaseAdmin: SupabaseClient | null =
+	url && serviceKey ? createClient(url, serviceKey, { auth: { persistSession: false } }) : null;

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -4,6 +4,7 @@ import { getCardPrices } from '$services/poketrace';
 import { getGradedPrices, getGradingFees } from '$services/price-tracker';
 import { cacheTcgPlayerPrices, getPriceHistoryFromCache } from '$services/price-cache';
 import { supabase } from '$services/supabase';
+import { supabaseAdmin } from '$lib/server/supabase-admin';
 import { getCardSignal, getSimilarCards } from '$services/insights';
 import { computeGradingROI, DEFAULT_TIER_BY_SERVICE } from '$services/grading-roi';
 import { buildGradeLadders, type CohortRow } from '$services/grade-estimate';
@@ -384,11 +385,27 @@ export const actions: Actions = {
 			});
 		}
 
-		const { error: err } = await supabase
+		// card_index writes are service-role-only (migration 018) — see the
+		// refreshNow note. Anon UPDATE here would silently affect 0 rows
+		// and falsely report the override saved.
+		if (!supabaseAdmin) {
+			return fail(500, {
+				action: 'pcOverride',
+				message: 'Saving the override is not configured on this server (missing service-role key).'
+			});
+		}
+		const { data: updated, error: err } = await supabaseAdmin
 			.from('card_index')
 			.update({ pc_url_override: value })
-			.eq('card_id', cardId);
+			.eq('card_id', cardId)
+			.select('card_id');
 		if (err) return fail(500, { action: 'pcOverride', message: err.message });
+		if (!updated || updated.length === 0) {
+			return fail(500, {
+				action: 'pcOverride',
+				message: 'Override could not be saved (no row updated).'
+			});
+		}
 		return { action: 'pcOverride', success: true, cleared: value == null };
 	},
 
@@ -496,14 +513,35 @@ export const actions: Actions = {
 		}
 		if (pc.psa10LastSold != null) upd.psa10_last_sold_at = pc.psa10LastSold;
 
-		const { error: err } = await supabase
+		// migration 018 made card_index writes service-role-only (anon =
+		// SELECT only). The browser/SSR `supabase` client is anon, so an
+		// UPDATE through it is RLS-filtered to ZERO rows and returns NO
+		// error — the action would report success while persisting nothing
+		// (the silent "Refresh now did nothing" bug). Use the server-only
+		// privileged client and verify a row actually changed.
+		if (!supabaseAdmin) {
+			return fail(500, {
+				action: 'refresh',
+				message:
+					'Live refresh is not configured on this server (missing SUPABASE_SERVICE_ROLE_KEY) — cached data unchanged.'
+			});
+		}
+
+		const { data: updated, error: err } = await supabaseAdmin
 			.from('card_index')
 			.update(upd)
-			.eq('card_id', cardId);
+			.eq('card_id', cardId)
+			.select('card_id');
 		if (err) return fail(500, { action: 'refresh', message: err.message });
+		if (!updated || updated.length === 0) {
+			return fail(500, {
+				action: 'refresh',
+				message: 'Refresh could not be saved (no row updated) — still showing cached data.'
+			});
+		}
 
 		if (pc.psa10Sales?.length) {
-			await supabase
+			await supabaseAdmin
 				.from('psa10_sales')
 				.upsert(
 					pc.psa10Sales.map((s) => ({


### PR DESCRIPTION
## Summary

Root-caused from a real user report (Gimmighoul `sv4-198` showing no graded data despite "Refresh now" reporting success).

**The scraper and PriceCharting were never the problem** — that exact card returns full data from a datacenter IP (PSA10 $101, CGC10 $49.75, BGS10 $131, TAG10 $109.99, full grade ladder, PSA pop 2,317).

**The bug:** migration 018 (live) enabled RLS on `card_index` with anon = **SELECT only, no write policy** (by design — "writes stay service-role-only"). The app's only Supabase client uses the **publishable/anon key**. The server-side `refreshNow` and `savePcOverride` form actions issued `UPDATE card_index …` through it → RLS silently filtered the write to **0 rows**, and PostgREST returns **no error** → the actions returned `success: true` and the UI showed green *"Updated with the latest live data."* while **persisting nothing**. Refresh-now has never worked in production.

## Fix

- New server-only privileged client `src/lib/server/supabase-admin.ts` (`$lib/server` + `$env/dynamic/private` so the service-role key can never be bundled client-side; `null` when unconfigured).
- `refreshNow` + `savePcOverride` now write via `supabaseAdmin` and **verify a row actually changed** (`.select()` → 0 rows ⇒ honest failure, not false success). Missing service key ⇒ explicit error message, never a green lie.
- Reads stay on the anon client (correct per 018).

## Test plan

- [x] svelte-check 18/2 — baseline, **0 new**; vitest 64/64
- [x] Data path proven end-to-end: enriching `sv4-198` via the canonical service-role path persisted real PSA10 $101 / CGC10 / TAG10 / pop 2,317 / full grade ladder (the user's reported card is now fixed live)
- [ ] **REQUIRES `SUPABASE_SERVICE_ROLE_KEY` as a Vercel server env var** (same secret the GitHub Actions crons already use). Without it the actions now fail *honestly* instead of lying.
- [ ] Note: the nightly engine (service-role) was already correct; this only fixes the interactive on-demand path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)