### PR TITLE
feat: newest-set priority tier (N1) in the data engine

### DIFF
--- a/scripts/refresh-index.ts
+++ b/scripts/refresh-index.ts
@@ -467,11 +467,31 @@ async function indexStale(
 		Date.now() - GRADED_RECHECK_DAYS * 24 * 60 * 60 * 1000
 	).toISOString();
 
-	// Every selection orders by last_enriched_at asc — that column is
-	// indexed (migration 015), so ORDER BY + LIMIT stays an index scan and
-	// can't reintroduce the seq-scan/timeout that masked the stalled
-	// pipeline. The extra equality/range filters below are selective and
-	// don't change that the driver is still the indexed ORDER BY + LIMIT.
+	// Newest-set priority window. A freshly-released set's cards qualify for
+	// the gradeable gap tier (A1) but A1 orders by last_enriched_at asc, so a
+	// new set sorts to the BACK of the ~20k aged backlog and waits a month+
+	// even though PriceCharting already has rich data for it. The N1 tier
+	// below jumps never-PriceCharting-checked gradeable cards from sets
+	// released within this window to the front, ordered by set_release_date
+	// desc. Bounded by the window AND the never-checked filter, so it drains
+	// once a new set is enriched and never starves the aged backlog.
+	// Tunable via TROVE_NEW_SET_PRIORITY_DAYS.
+	const NEW_SET_PRIORITY_DAYS =
+		Number(process.env.TROVE_NEW_SET_PRIORITY_DAYS) > 0
+			? Number(process.env.TROVE_NEW_SET_PRIORITY_DAYS)
+			: 90;
+	const newSetThreshold = new Date(
+		Date.now() - NEW_SET_PRIORITY_DAYS * 24 * 60 * 60 * 1000
+	)
+		.toISOString()
+		.slice(0, 10);
+
+	// Selections order by last_enriched_at asc (default) or set_release_date
+	// desc (N1 only) — BOTH columns are indexed (migration 015 and 003's
+	// idx_card_index_release respectively), so ORDER BY + LIMIT stays an
+	// index scan and can't reintroduce the seq-scan/timeout that masked the
+	// stalled pipeline. The extra equality/range filters below are selective
+	// and don't change that the driver is still the indexed ORDER BY + LIMIT.
 	// Errors are surfaced on EVERY query for the same reason: a swallowed
 	// selection error is exactly how the catalog hit 99% stale.
 	async function selectStale(
@@ -482,6 +502,8 @@ async function indexStale(
 			gradeableRarity?: boolean;
 			minValue?: number;
 			gradedCheck?: 'fresh' | 'recheck';
+			releasedSince?: string;
+			orderBy?: { column: 'last_enriched_at' | 'set_release_date'; ascending: boolean };
 		}
 	): Promise<StoredCardMeta[]> {
 		let q = supabase
@@ -511,8 +533,18 @@ async function indexStale(
 		if (opts.gradedCheck === 'fresh') q = q.is('graded_prices_fetched_at', null);
 		else if (opts.gradedCheck === 'recheck')
 			q = q.lt('graded_prices_fetched_at', gradedRecheckThreshold);
+		// Newest-set priority bound (N1). set_release_date is a `date` column
+		// with a dedicated btree (idx_card_index_release, migration 003), so a
+		// range predicate here plus ORDER BY set_release_date desc below is a
+		// bounded backward index scan — strictly more index-tight than the
+		// last_enriched_at tiers, not the seq-scan/timeout regression 015
+		// fixed.
+		if (opts.releasedSince != null) q = q.gte('set_release_date', opts.releasedSince);
+		// Default order is unchanged (last_enriched_at asc) so every existing
+		// caller behaves exactly as before; only N1 overrides it.
+		const order = opts.orderBy ?? { column: 'last_enriched_at' as const, ascending: true };
 		const { data, error } = await q
-			.order('last_enriched_at', { ascending: true })
+			.order(order.column, { ascending: order.ascending })
 			.limit(n);
 		if (error) {
 			console.error(`Stale selection FAILED: ${error.message}`);
@@ -542,8 +574,25 @@ async function indexStale(
 		// re-verified on the long recheck cadence; cards reached & missing
 		// within the window are intentionally skipped (the backoff) so the
 		// budget goes to cards that can actually yield graded data.
+		// N1: never-checked gradeable cards from sets released within the
+		//     priority window, newest set first. Without this a brand-new
+		//     set's cards qualify for A1 but A1's last_enriched_at-asc order
+		//     buries them behind the ~20k aged backlog for a month+ even
+		//     though PriceCharting already has rich data for them. Bounded by
+		//     the window AND gradedCheck:'fresh', so it drains as the new set
+		//     gets enriched and never starves the tiers below.
+		take(
+			await selectStale(limit, {
+				gap: true,
+				gradeableRarity: true,
+				gradedCheck: 'fresh',
+				releasedSince: newSetThreshold,
+				orderBy: { column: 'set_release_date', ascending: false }
+			})
+		);
 		// A1: gradeable rarity, never PriceCharting-checked — best bet.
-		take(await selectStale(limit, { gap: true, gradeableRarity: true, gradedCheck: 'fresh' }));
+		if (need() > 0)
+			take(await selectStale(need(), { gap: true, gradeableRarity: true, gradedCheck: 'fresh' }));
 		// B1: worth-grading by value, never-checked.
 		if (need() > 0)
 			take(await selectStale(need(), { gap: true, minValue: GRADEABLE_VALUE_FLOOR, gradedCheck: 'fresh' }));


### PR DESCRIPTION
## Problem

Brand-new sets sit un-enriched for a month+ even though PriceCharting already has rich data for them. **Verified live on prod:** me3 *Perfect Order* (released 2026-03-27) was first reached by the engine only ~53 days later. Example payload it was missing: Meowth ex #121 = $200 raw / $1,130 PSA10 / full ladder.

**Root cause:** `selectStale`'s gradeable gap tier (A1) orders the queue purely by `last_enriched_at` asc. A freshly-ingested set's cards have the *most recent* `last_enriched_at` among stale rows, so they sort to the **back** of the ~20k-card aged backlog. Proven live: under A1 ordering, me3 does **not appear in the first 150 candidates** (one full cycle's scrape budget) — the queue head is *Phantom Forces (2014)*.

## Change

Adds one new tier **N1**, ahead of A1:

- never-PriceCharting-checked (`graded_prices_fetched_at IS NULL`)
- gradeable rarity (NOT Common/Uncommon)
- from sets released within `TROVE_NEW_SET_PRIORITY_DAYS` (default **90**)
- ordered `set_release_date DESC` (newest set first)

`selectStale` gains two optional params (`releasedSince`, `orderBy`); the default order is unchanged (`last_enriched_at` asc) so **every existing caller and the non-prioritised FIFO path behave byte-identically**. The existing `picked` Map dedups, so A1 never re-processes N1's cards.

**Cannot starve the backlog:** N1 is bounded by the recency window *and* `gradedCheck:'fresh'`. Once a new set's gradeable cards are scraped, `graded_prices_fetched_at` is set → they exit `fresh` → N1 drains → backlog resumes. New sets are small/infrequent; the per-cycle `limit` is unchanged.

## Index-safety

`set_release_date >= threshold` + single-column `ORDER BY set_release_date DESC` + `LIMIT` runs on the dedicated `idx_card_index_release` btree (migration 003 — the same migration that created the live `card_index` table). Structurally identical to the existing, documented-index-safe `last_enriched_at` tiers (range + single-col ORDER BY + LIMIT); btrees scan backward for DESC natively. **No seq-scan/timeout regression.**

Literal `EXPLAIN` was unreachable from here (PostgREST plan endpoint disabled — PGRST107; no DB creds; the Supabase MCP token is BMAG-only and must not touch Trove). Verified **behaviorally on live prod instead**: the exact N1 query returns in **0.46s with no statement-timeout**, correctly ordered, returning the 24 me3 never-checked gradeable cards.

## Honesty doctrine

Only re-orders the scrape queue — never fabricates. A new set's bulk commons that PriceCharting genuinely lacks stay null (correct). Stays within the polite paced engine (no request bursting).

## Test plan

- [x] `svelte-check`: 18 errors / 2 warnings — exactly baseline, **0 new**
- [x] `vitest`: **64/64** green
- [x] `tsx scripts/refresh-index.ts --stale 150 --dry-run` against live prod: compiles & runs end-to-end, "Found 150 stale rows (gradeability-prioritised)", no errors/timeout, existing fill behavior unchanged
- [x] N1 query verified on live prod: 0.46s, correctly ordered `set_release_date` desc, surfaces me3's 24 never-checked gradeable cards
- [x] Bug reproduced on live prod: under old A1 ordering me3 is absent from the first 150 candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)