### PR TITLE
feat: surface real PSA gem rate on the discovery grid

### DIFF
--- a/src/lib/components/CardThumbnail.svelte
+++ b/src/lib/components/CardThumbnail.svelte
@@ -9,6 +9,8 @@
 		psa10_multiple?: number | null;
 		psa10_last_sold_at?: string | null;
 		psa_pop_total?: number | null;
+		psa_pop_10?: number | null;
+		psa_gem_rate?: number | null;
 		cgc_pop_total?: number | null;
 		combined_pop_total?: number | null;
 		pcUrl?: string | null;
@@ -28,6 +30,16 @@
 	let enrichment = $derived(card._enrichment);
 	let hasDelta = $derived(enrichment?.psa10_delta != null && enrichment.psa10_delta > 0);
 	let hasPop = $derived(enrichment?.combined_pop_total != null);
+	// Real PSA gem rate (psa_pop_10 / psa_pop_total, persisted as a %). Only
+	// surface it when it's genuinely backed by a scraped PSA pop — never
+	// derive or estimate it. A lower rate = harder to pull a 10, the single
+	// most decision-relevant graded signal and (until now) sortable on hunt
+	// but invisible on the grid. null ⇒ render nothing (honesty doctrine).
+	let gemRate = $derived(
+		enrichment?.psa_gem_rate != null && (enrichment?.psa_pop_total ?? 0) > 0
+			? enrichment.psa_gem_rate
+			: null
+	);
 
 	function fmtPrice(n: number): string {
 		return n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${n.toFixed(2)}`;
@@ -97,7 +109,7 @@
 		{@const cgc = enrichment!.cgc_pop_total ?? 0}
 		{@const combined = enrichment!.combined_pop_total ?? 0}
 		<div class="absolute bottom-14 left-2 rounded-full bg-vault-bg/90 px-2 py-0.5 text-[10px] font-medium text-vault-text-muted shadow-lg backdrop-blur-sm"
-			title="PSA: {psa.toLocaleString()}{cgc ? ` + CGC: ${cgc.toLocaleString()}` : ''} = {combined.toLocaleString()} total graded">
+			title="PSA: {psa.toLocaleString()}{cgc ? ` + CGC: ${cgc.toLocaleString()}` : ''} = {combined.toLocaleString()} total graded{gemRate != null ? ` · PSA ${(enrichment!.psa_pop_10 ?? 0).toLocaleString()} of ${psa.toLocaleString()} are a 10 → ${gemRate}% gem rate (lower = harder pull)` : ''}">
 			{#if psa && cgc}
 				PSA {psa.toLocaleString()} + CGC {cgc.toLocaleString()}
 			{:else if psa}
@@ -106,7 +118,7 @@
 				CGC pop {cgc.toLocaleString()}
 			{:else}
 				pop {combined.toLocaleString()}
-			{/if}
+			{/if}{#if gemRate != null}<span class="ml-1 text-vault-gold">· {gemRate}% gem</span>{/if}
 		</div>
 	{/if}
 

--- a/src/lib/services/sort.ts
+++ b/src/lib/services/sort.ts
@@ -215,6 +215,9 @@ export interface EnrichedCard extends PokemonCard {
 		psa10_price: number | null;
 		psa10_delta: number | null;
 		psa10_multiple: number | null;
+		psa_pop_total?: number | null;
+		psa_pop_10?: number | null;
+		psa_gem_rate?: number | null;
 		pcUrl: string | null;
 	};
 }

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -138,7 +138,7 @@ async function attachCardIndexEnrichment(cards: PokemonCard[]): Promise<Enriched
 	const ids = cards.map((c) => c.id);
 	const { data } = await supabase
 		.from('card_index')
-		.select('card_id, raw_nm_price, raw_source, psa10_price, psa10_delta, psa10_multiple, psa_pop_total, cgc_pop_total, combined_pop_total')
+		.select('card_id, raw_nm_price, raw_source, psa10_price, psa10_delta, psa10_multiple, psa_pop_total, psa_pop_10, psa_gem_rate, cgc_pop_total, combined_pop_total')
 		.in('card_id', ids);
 	const byId = new Map<string, Record<string, unknown>>();
 	for (const row of (data ?? []) as Array<Record<string, unknown>>) {
@@ -156,6 +156,8 @@ async function attachCardIndexEnrichment(cards: PokemonCard[]): Promise<Enriched
 				psa10_delta: idx.psa10_delta as number | null,
 				psa10_multiple: idx.psa10_multiple as number | null,
 				psa_pop_total: idx.psa_pop_total as number | null,
+				psa_pop_10: idx.psa_pop_10 as number | null,
+				psa_gem_rate: idx.psa_gem_rate as number | null,
 				cgc_pop_total: idx.cgc_pop_total as number | null,
 				combined_pop_total: idx.combined_pop_total as number | null,
 				pcUrl: null
@@ -445,6 +447,8 @@ async function loadHuntMode(url: URL, _setHeaders: (headers: Record<string, stri
 			psa10_multiple: row.psa10_multiple as number | null,
 			psa10_last_sold_at: row.psa10_last_sold_at as string | null,
 			psa_pop_total: row.psa_pop_total as number | null,
+			psa_pop_10: row.psa_pop_10 as number | null,
+			psa_gem_rate: row.psa_gem_rate as number | null,
 			cgc_pop_total: row.cgc_pop_total as number | null,
 			combined_pop_total: row.combined_pop_total as number,
 			pcUrl: null


### PR DESCRIPTION
## Why

The browse grid — Trove's primary discovery surface — was a lossy 3-signal summary (raw $, PSA10 delta, total pop). **Gem rate**, the single most decision-relevant graded signal ("how hard is it to pull a PSA 10?"), was computed nightly, stored in `card_index`, and *sortable* in hunt mode — but **invisible on every card** until you clicked through to the detail page. North-star #5 explicitly wants each grid card "showing raw + PSA10 + pop + arbitrage score **at a glance**." This closes the audit's #1 gap.

## What

- Adds `psa_gem_rate` (+ `psa_pop_10` for the tooltip) to the shared `EnrichedCard` type and `CardThumbnail`.
- Renders a compact gold `· N% gem` suffix on the existing pop badge, with an honest tooltip: *"PSA X of Y are a 10 → N% gem rate (lower = harder pull)"*.
- Wires the columns through **both** browse enrichment paths (hunt-mode mapping; default-mode `select` widened).
- Additive, optional fields — no existing caller changes behaviour.

## Honesty doctrine

The signal renders **only** when `psa_gem_rate` is real and backed by a scraped PSA pop (`psa_pop_total > 0`); null ⇒ renders nothing, mirroring the existing `hasDelta`/`hasPop` gating. Never derived or estimated. `score_momentum`/`score_liquidity` were deliberately **not** surfaced — they're ~null in prod (Track A not landed), and showing an empty axis would violate the doctrine.

## Verification (live, against prod data via service-role cross-check)

- `base1` Mewtwo renders `· 1.85% gem` = exactly the stored `psa_gem_rate` 1.85.
- A `0% gem` card (base1-3 Chansey) is genuinely 0 PSA 10s of 23 graded — a real, meaningful hard-pull signal, not a fabricated zero.
- `sv8`: renders **19** gem spans for exactly the **19** cards that have real `psa_gem_rate`; the 5 ungraded cards (e.g. sv8-113, `psa_gem_rate` NULL) correctly show **no span**. Honest-null confirmed.

## Test plan

- [x] `svelte-check`: 18 errors / 2 warnings — exactly baseline, **0 new**
- [x] `vitest`: **64/64** green
- [x] Live SSR render verified (Bash-launched dev; preview MCP has no network here per project setup): grid renders gem rate on real graded cards, omits it on ungraded — cross-checked against `card_index` via service-role
- [ ] Author to confirm before merge (do not merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)