### PR TITLE
feat: bridge browse ↔ rankings (discovery scores on the grid)

### DIFF
--- a/src/lib/components/CardThumbnail.svelte
+++ b/src/lib/components/CardThumbnail.svelte
@@ -11,6 +11,8 @@
 		psa_pop_total?: number | null;
 		psa_pop_10?: number | null;
 		psa_gem_rate?: number | null;
+		score_value?: number | null;
+		ranking_confidence?: string | null;
 		cgc_pop_total?: number | null;
 		combined_pop_total?: number | null;
 		pcUrl?: string | null;
@@ -38,6 +40,19 @@
 	let gemRate = $derived(
 		enrichment?.psa_gem_rate != null && (enrichment?.psa_pop_total ?? 0) > 0
 			? enrichment.psa_gem_rate
+			: null
+	);
+	// Discovery Value rank (0–100 percentile, /rankings axis). Modeled, not
+	// a real price — so it's gated to high/medium confidence (never headline
+	// a low-confidence score) and styled distinctly from the real-$ badges
+	// (purple = "rank", not green/gold = "money"). Brings the rankings
+	// context onto the grid so the user sees where a card sits without a
+	// detour. null / low-confidence ⇒ render nothing (honesty doctrine).
+	let valueRank = $derived(
+		enrichment?.score_value != null &&
+			(enrichment?.ranking_confidence === 'high' ||
+				enrichment?.ranking_confidence === 'medium')
+			? enrichment.score_value
 			: null
 	);
 
@@ -100,6 +115,19 @@
 	{#if hasDelta}
 		<div class="absolute left-2 top-2 rounded-full bg-vault-gold/90 px-2 py-0.5 text-xs font-bold text-vault-bg shadow-lg backdrop-blur-sm" title="Raw → PSA 10 delta">
 			+{fmtPrice(enrichment!.psa10_delta!)}
+		</div>
+	{/if}
+
+	<!-- Discovery Value rank (bottom right) — percentile, not a price.
+	     Purple distinguishes "rank" from the green/gold money badges.
+	     Informational only (no nested anchor — the card already links to
+	     detail, where the focused "open in Rankings" link lives). -->
+	{#if valueRank != null}
+		<div
+			class="absolute bottom-14 right-2 rounded-full border border-vault-purple/40 bg-vault-bg/90 px-2 py-0.5 text-[10px] font-semibold text-vault-purple shadow-lg backdrop-blur-sm"
+			title="Value rank {valueRank}/100 — PSA 10 price percentile across the whole catalog ({enrichment!.ranking_confidence} confidence)"
+		>
+			Val {valueRank}
 		</div>
 	{/if}
 

--- a/src/lib/services/sort.ts
+++ b/src/lib/services/sort.ts
@@ -84,6 +84,13 @@ export const SORT_OPTIONS: SortOption[] = [
 	// across service switches. Label names "PSA gem rate" so the user knows
 	// the signal is anchored to PSA population data.
 	{ value: 'roi_desc', label: 'Grading ROI (PSA gem rate)', kind: 'index', indexColumn: 'grading_roi_premium', indexDirection: 'desc', indexNulls: 'last', availableIn: ['hunt'] },
+	// Discovery rank sorts — same percentile axes as /rankings, brought to
+	// the browse grid so "find cards I never knew were valuable / scarce" is
+	// a sort, not a separate page. Columns are indexed (migration 017
+	// idx_ci_score_value / idx_ci_score_scarcity, desc nulls last), so this
+	// stays a bounded index scan.
+	{ value: 'disc_value', label: 'Discovery: Value rank', kind: 'index', indexColumn: 'score_value', indexDirection: 'desc', indexNulls: 'last', availableIn: ['hunt'] },
+	{ value: 'disc_scarcity', label: 'Discovery: Scarcity rank', kind: 'index', indexColumn: 'score_scarcity', indexDirection: 'desc', indexNulls: 'last', availableIn: ['hunt'] },
 ];
 
 const DEFAULT_OPTION = SORT_OPTIONS[0];
@@ -218,6 +225,8 @@ export interface EnrichedCard extends PokemonCard {
 		psa_pop_total?: number | null;
 		psa_pop_10?: number | null;
 		psa_gem_rate?: number | null;
+		score_value?: number | null;
+		ranking_confidence?: string | null;
 		pcUrl: string | null;
 	};
 }

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -138,7 +138,7 @@ async function attachCardIndexEnrichment(cards: PokemonCard[]): Promise<Enriched
 	const ids = cards.map((c) => c.id);
 	const { data } = await supabase
 		.from('card_index')
-		.select('card_id, raw_nm_price, raw_source, psa10_price, psa10_delta, psa10_multiple, psa_pop_total, psa_pop_10, psa_gem_rate, cgc_pop_total, combined_pop_total')
+		.select('card_id, raw_nm_price, raw_source, psa10_price, psa10_delta, psa10_multiple, psa_pop_total, psa_pop_10, psa_gem_rate, score_value, ranking_confidence, cgc_pop_total, combined_pop_total')
 		.in('card_id', ids);
 	const byId = new Map<string, Record<string, unknown>>();
 	for (const row of (data ?? []) as Array<Record<string, unknown>>) {
@@ -158,6 +158,8 @@ async function attachCardIndexEnrichment(cards: PokemonCard[]): Promise<Enriched
 				psa_pop_total: idx.psa_pop_total as number | null,
 				psa_pop_10: idx.psa_pop_10 as number | null,
 				psa_gem_rate: idx.psa_gem_rate as number | null,
+				score_value: idx.score_value as number | null,
+				ranking_confidence: idx.ranking_confidence as string | null,
 				cgc_pop_total: idx.cgc_pop_total as number | null,
 				combined_pop_total: idx.combined_pop_total as number | null,
 				pcUrl: null
@@ -449,6 +451,8 @@ async function loadHuntMode(url: URL, _setHeaders: (headers: Record<string, stri
 			psa_pop_total: row.psa_pop_total as number | null,
 			psa_pop_10: row.psa_pop_10 as number | null,
 			psa_gem_rate: row.psa_gem_rate as number | null,
+			score_value: row.score_value as number | null,
+			ranking_confidence: row.ranking_confidence as string | null,
 			cgc_pop_total: row.cgc_pop_total as number | null,
 			combined_pop_total: row.combined_pop_total as number,
 			pcUrl: null

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -965,7 +965,7 @@
 						<div>
 							<h2 class="text-lg font-semibold text-white">Discovery Scores</h2>
 							<p class="mt-0.5 text-xs text-vault-text-muted">
-								Percentile-ranked 0–100 across the whole catalog. <a href="/rankings" class="underline hover:text-vault-purple">See all rankings →</a>
+								Percentile-ranked 0–100 across the whole catalog. <a href="/rankings?q={encodeURIComponent(card.name)}&set={card.set.id}" class="underline hover:text-vault-purple">See this card in Rankings →</a>
 							</p>
 						</div>
 						{#if rankingScores.ranking_confidence}


### PR DESCRIPTION
## Why

Browse and `/rankings` ran on the **same 6-axis scoring** but were disconnected (audit gap #1). A user finding a high-delta card on the grid had no idea whether it ranked low on scarcity or high on value, and couldn't *browse by* those axes without switching to the rankings table.

## What

**A. Confidence-gated Value-rank chip on the grid** (`CardThumbnail`) — `score_value` (0–100 percentile) rendered **only** when real *and* `ranking_confidence` ∈ {high, medium}. Modeled, not real $, so styled purple to read as a "rank", distinct from the green/gold money badges. Informational only (no nested anchor).

**B. Two hunt-mode discovery sorts** — *"Discovery: Value rank"* / *"Discovery: Scarcity rank"* (`kind:'index'` on `score_value`/`score_scarcity`, indexed via migration 017 → bounded index scan). The functional bridge: `/browse` now does `/rankings`' core discovery without leaving the grid.

**C. Focused card→rankings deep link** — the card-detail Discovery Scores panel links to `/rankings?q=<name>&set=<setId>` (was generic) — closes the audit's exact complaint.

## Honesty

Scores render only where real and confidently backed; null / low-confidence ⇒ nothing. Additive optional fields; no existing caller changes behaviour. No migration.

## Verification (live SSR + cross-checked against `card_index` via service-role)

- **A**: base1 grid — 0 low-confidence leaks; eligible count (~65/67) matches `card_index`.
- **B**: `?sort=disc_value` returns `score_value=100` cards first; sort applied (ties ordered by PG like existing index sorts).
- **C**: `/card/base1-4` → `See this card in Rankings →` → `/rankings?q=Charizard&set=base1`, which resolves to a Charizard+base1-scoped ranked view containing `base1-4`.
- `svelte-check`: 18/2 — **0 new**. `vitest`: **64/64**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)