### PR TITLE
Per-card discovery variance + sort-by-axis on /sets (Gap #3)

### DIFF
--- a/src/lib/services/__tests__/discovery-signals.test.ts
+++ b/src/lib/services/__tests__/discovery-signals.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+	gateDiscoverySignals,
+	hasAnyDiscoverySignal,
+	type RawDiscoveryRow
+} from '../discovery-signals';
+
+const base: RawDiscoveryRow = {
+	score_value: null,
+	score_scarcity: null,
+	psa_gem_rate: null,
+	psa_pop_total: null,
+	psa10_delta: null,
+	psa10_multiple: null,
+	ranking_confidence: null
+};
+
+describe('gateDiscoverySignals — honesty doctrine', () => {
+	it('surfaces modeled ranks only at high/medium confidence', () => {
+		expect(
+			gateDiscoverySignals({ ...base, score_value: 69, ranking_confidence: 'high' })
+				.value_rank
+		).toBe(69);
+		expect(
+			gateDiscoverySignals({ ...base, score_value: 69, ranking_confidence: 'medium' })
+				.value_rank
+		).toBe(69);
+	});
+
+	it('suppresses a real-but-low-confidence score (the sv4-198 case)', () => {
+		const d = gateDiscoverySignals({
+			...base,
+			score_value: 69,
+			score_scarcity: 80,
+			ranking_confidence: 'low'
+		});
+		expect(d.value_rank).toBeNull();
+		expect(d.scarcity_rank).toBeNull();
+	});
+
+	it('null confidence also suppresses ranks', () => {
+		expect(gateDiscoverySignals({ ...base, score_value: 50 }).value_rank).toBeNull();
+	});
+
+	it('gem rate needs a real PSA pop behind it', () => {
+		expect(
+			gateDiscoverySignals({ ...base, psa_gem_rate: 39.97, psa_pop_total: 2317 }).gem_rate
+		).toBe(39.97);
+		expect(
+			gateDiscoverySignals({ ...base, psa_gem_rate: 39.97, psa_pop_total: 0 }).gem_rate
+		).toBeNull();
+		expect(
+			gateDiscoverySignals({ ...base, psa_gem_rate: 39.97, psa_pop_total: null }).gem_rate
+		).toBeNull();
+	});
+
+	it('only a positive psa10 delta surfaces, and the multiple rides with it', () => {
+		const ok = gateDiscoverySignals({
+			...base,
+			psa10_delta: 86.97,
+			psa10_multiple: 7.2
+		});
+		expect(ok.psa10_delta).toBe(86.97);
+		expect(ok.psa10_multiple).toBe(7.2);
+
+		const neg = gateDiscoverySignals({
+			...base,
+			psa10_delta: -5,
+			psa10_multiple: 0.9
+		});
+		expect(neg.psa10_delta).toBeNull();
+		expect(neg.psa10_multiple).toBeNull();
+	});
+
+	it('hasAnyDiscoverySignal reflects renderability', () => {
+		expect(hasAnyDiscoverySignal(gateDiscoverySignals(base))).toBe(false);
+		expect(
+			hasAnyDiscoverySignal(
+				gateDiscoverySignals({ ...base, psa10_delta: 10 })
+			)
+		).toBe(true);
+	});
+});

--- a/src/lib/services/discovery-signals.ts
+++ b/src/lib/services/discovery-signals.ts
@@ -1,0 +1,86 @@
+/**
+ * Honesty-gated discovery signals for a card.
+ *
+ * Single source of truth for the "only surface a signal when it's real /
+ * eligible, otherwise null" rule. Every field is either a trustworthy value
+ * or `null` — `null` means *do not render anything* (never a fabricated or
+ * low-confidence placeholder). This is the honesty doctrine in code.
+ *
+ * `value_rank` / `scarcity_rank` are modeled 0–100 ranks → callers MUST style
+ * them as a rank (purple), never as money. `gem_rate` / `psa10_*` are real
+ * acquired data.
+ *
+ * The grid component `CardThumbnail.svelte` predates this module and mirrors
+ * the same logic inline via reactive `$derived` (its data shape includes
+ * grid-only fields like combined_pop_total); keep the two in sync. Server
+ * loaders (collection, sets, …) should use this helper rather than
+ * re-implementing the gate.
+ *
+ * `score_momentum` / `score_liquidity` are deliberately absent — they are
+ * ~null in prod, and surfacing an empty axis is itself a doctrine violation.
+ */
+
+export interface DiscoverySignals {
+	value_rank: number | null;
+	scarcity_rank: number | null;
+	gem_rate: number | null;
+	psa10_delta: number | null;
+	psa10_multiple: number | null;
+}
+
+export interface RawDiscoveryRow {
+	score_value: number | null;
+	score_scarcity: number | null;
+	psa_gem_rate: number | null;
+	psa_pop_total: number | null;
+	psa10_delta: number | null;
+	psa10_multiple: number | null;
+	ranking_confidence: string | null;
+}
+
+/**
+ * The `card_index` columns the gate reads. Append `card_id` (and any
+ * caller-specific columns) when building a select string.
+ */
+export const DISCOVERY_SELECT_COLS =
+	'score_value, score_scarcity, psa_gem_rate, psa_pop_total, psa10_delta, psa10_multiple, ranking_confidence';
+
+/** True only when this card's modeled ranks are trustworthy enough to show. */
+function confident(ranking_confidence: string | null): boolean {
+	return ranking_confidence === 'high' || ranking_confidence === 'medium';
+}
+
+/**
+ * Apply the honesty gate to one raw `card_index` row. Pure; safe to call per
+ * row in a loop.
+ */
+export function gateDiscoverySignals(r: RawDiscoveryRow): DiscoverySignals {
+	const confOk = confident(r.ranking_confidence);
+	// Modeled ranks: only at high|medium confidence — never headline a
+	// low/null-confidence score.
+	const valueRank = r.score_value != null && confOk ? r.score_value : null;
+	const scarcityRank = r.score_scarcity != null && confOk ? r.score_scarcity : null;
+	// Real gem rate: only when a real PSA pop actually backs it.
+	const gemRate =
+		r.psa_gem_rate != null && (r.psa_pop_total ?? 0) > 0 ? r.psa_gem_rate : null;
+	// Real raw → PSA 10 uplift: only a positive number is decision-relevant;
+	// the multiple is a companion to the delta, never shown alone.
+	const psa10Delta = r.psa10_delta != null && r.psa10_delta > 0 ? r.psa10_delta : null;
+	return {
+		value_rank: valueRank,
+		scarcity_rank: scarcityRank,
+		gem_rate: gemRate,
+		psa10_delta: psa10Delta,
+		psa10_multiple: psa10Delta != null ? r.psa10_multiple : null
+	};
+}
+
+/** True when the row carries at least one renderable signal. */
+export function hasAnyDiscoverySignal(d: DiscoverySignals): boolean {
+	return (
+		d.value_rank != null ||
+		d.scarcity_rank != null ||
+		d.gem_rate != null ||
+		d.psa10_delta != null
+	);
+}

--- a/src/routes/collection/+page.server.ts
+++ b/src/routes/collection/+page.server.ts
@@ -3,21 +3,14 @@ import { getCard, searchCards } from '$services/tcg-api';
 import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import type { PokemonCard, CollectionEntry } from '$types';
+import {
+	gateDiscoverySignals,
+	DISCOVERY_SELECT_COLS,
+	type DiscoverySignals,
+	type RawDiscoveryRow
+} from '$services/discovery-signals';
 
 const ADD_SEARCH_PAGE_SIZE = 12;
-
-// Honesty-gated discovery signals for an owned card. Every field is either
-// a real/eligible value or null — null means "do not surface" (never a
-// fabricated or low-confidence placeholder). value_rank/scarcity_rank are
-// modeled 0–100 ranks (style as rank, not money); gem_rate/psa10_* are
-// real acquired data.
-interface DiscoverySignals {
-	value_rank: number | null;
-	scarcity_rank: number | null;
-	gem_rate: number | null;
-	psa10_delta: number | null;
-	psa10_multiple: number | null;
-}
 
 export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	// Do NOT cache the HTML document. See src/routes/browse/+page.server.ts
@@ -64,36 +57,13 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	if (uniqueCardIds.length > 0) {
 		const { data: indexRows } = await supabase
 			.from('card_index')
-			.select(
-				'card_id, raw_nm_price, score_value, score_scarcity, psa_gem_rate, psa_pop_total, psa10_delta, psa10_multiple, ranking_confidence'
-			)
+			.select(`card_id, raw_nm_price, ${DISCOVERY_SELECT_COLS}`)
 			.in('card_id', uniqueCardIds);
-		for (const r of (indexRows ?? []) as Array<{
-			card_id: string;
-			raw_nm_price: number | null;
-			score_value: number | null;
-			score_scarcity: number | null;
-			psa_gem_rate: number | null;
-			psa_pop_total: number | null;
-			psa10_delta: number | null;
-			psa10_multiple: number | null;
-			ranking_confidence: string | null;
-		}>) {
+		for (const r of (indexRows ?? []) as Array<
+			RawDiscoveryRow & { card_id: string; raw_nm_price: number | null }
+		>) {
 			indexPrices[r.card_id] = r.raw_nm_price;
-			const confOk =
-				r.ranking_confidence === 'high' || r.ranking_confidence === 'medium';
-			const psa10Delta =
-				r.psa10_delta != null && r.psa10_delta > 0 ? r.psa10_delta : null;
-			discoveryByCard[r.card_id] = {
-				value_rank: r.score_value != null && confOk ? r.score_value : null,
-				scarcity_rank: r.score_scarcity != null && confOk ? r.score_scarcity : null,
-				gem_rate:
-					r.psa_gem_rate != null && (r.psa_pop_total ?? 0) > 0
-						? r.psa_gem_rate
-						: null,
-				psa10_delta: psa10Delta,
-				psa10_multiple: psa10Delta != null ? r.psa10_multiple : null
-			};
+			discoveryByCard[r.card_id] = gateDiscoverySignals(r);
 		}
 	}
 

--- a/src/routes/sets/+page.server.ts
+++ b/src/routes/sets/+page.server.ts
@@ -1,6 +1,12 @@
 import { getSets, getCardsBySet } from '$services/tcg-api';
 import { supabase } from '$services/supabase';
 import { getSetValueTracker } from '$services/insights';
+import {
+	gateDiscoverySignals,
+	DISCOVERY_SELECT_COLS,
+	type DiscoverySignals,
+	type RawDiscoveryRow
+} from '$services/discovery-signals';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {
@@ -71,6 +77,7 @@ export const load: PageServerLoad = async ({ url }) => {
 		owned: boolean;
 		quantity: number;
 		marketPrice: number;
+		discovery: DiscoverySignals | null;
 	}
 
 	let selectedSet: { name: string; total: number; owned: number; cards: SetCard[] } | null = null;
@@ -78,6 +85,25 @@ export const load: PageServerLoad = async ({ url }) => {
 	if (selectedSetId) {
 		try {
 			const result = await getCardsBySet(selectedSetId, 1, 250);
+
+			// Per-card discovery signals scoped to this set — same honesty
+			// gate as /collection and the grid (null ⇒ render nothing). This
+			// is what turns the set view from "do I own it / what's it worth"
+			// into "which cards in this set are the standouts".
+			const setCardIds = result.data.map((c) => c.id);
+			const discoveryByCard: Record<string, DiscoverySignals> = {};
+			if (setCardIds.length > 0) {
+				const { data: idxRows } = await supabase
+					.from('card_index')
+					.select(`card_id, ${DISCOVERY_SELECT_COLS}`)
+					.in('card_id', setCardIds);
+				for (const r of (idxRows ?? []) as Array<
+					RawDiscoveryRow & { card_id: string }
+				>) {
+					discoveryByCard[r.card_id] = gateDiscoverySignals(r);
+				}
+			}
+
 			const cards: SetCard[] = result.data.map((card) => {
 				let marketPrice = 0;
 				if (card.tcgplayer?.prices) {
@@ -94,7 +120,8 @@ export const load: PageServerLoad = async ({ url }) => {
 					imageSmall: card.images.small,
 					owned: ownedCards.has(card.id),
 					quantity: ownedCards.get(card.id) ?? 0,
-					marketPrice
+					marketPrice,
+					discovery: discoveryByCard[card.id] ?? null
 				};
 			});
 

--- a/src/routes/sets/+page.svelte
+++ b/src/routes/sets/+page.svelte
@@ -1,5 +1,18 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import type { DiscoverySignals } from '$services/discovery-signals';
+
+	interface SetCard {
+		id: string;
+		name: string;
+		number: string;
+		rarity: string;
+		imageSmall: string;
+		owned: boolean;
+		quantity: number;
+		marketPrice: number;
+		discovery: DiscoverySignals | null;
+	}
 
 	interface MarketSet {
 		id: string;
@@ -41,21 +54,120 @@
 		return `$${n.toFixed(2)}`;
 	}
 
-	let selectedSet = $derived(data.selectedSet as {
-		name: string; total: number; owned: number;
-		cards: { id: string; name: string; number: string; rarity: string; imageSmall: string; owned: boolean; quantity: number; marketPrice: number }[];
-	} | null);
+	let selectedSet = $derived(
+		data.selectedSet as { name: string; total: number; owned: number; cards: SetCard[] } | null
+	);
 
 	let selectedSetId = $derived(data.selectedSetId as string);
 	let sets = $derived(data.sets as { id: string; name: string; images: { logo: string; symbol: string } }[]);
 	let showFilter = $state<'all' | 'owned' | 'missing'>('all');
 
+	// Sort the selected set's cards by a discovery axis. Default 'number'
+	// keeps the familiar set order. Cards lacking the chosen signal sink to
+	// the bottom (shown, never hidden — rankings doctrine), tie-broken by
+	// card number.
+	type SetSort = 'number' | 'price' | 'value' | 'scarcity' | 'gem' | 'psa10';
+	let setSort = $state<SetSort>('number');
+	const SET_SORT_LABELS: Record<SetSort, string> = {
+		number: 'Card number',
+		price: 'Market price',
+		value: 'Value rank',
+		scarcity: 'Scarcity rank',
+		gem: 'Hardest to gem',
+		psa10: 'Raw → PSA 10'
+	};
+	function cardNum(c: SetCard): number {
+		return parseInt(c.number) || 999;
+	}
+	function setSortKey(c: SetCard): number | null {
+		const d = c.discovery;
+		if (setSort === 'price') return c.marketPrice > 0 ? c.marketPrice : null;
+		if (setSort === 'value') return d?.value_rank ?? null;
+		if (setSort === 'scarcity') return d?.scarcity_rank ?? null;
+		if (setSort === 'gem') return d?.gem_rate ?? null;
+		if (setSort === 'psa10') return d?.psa10_delta ?? null;
+		return null;
+	}
+
 	let filteredCards = $derived(() => {
-		if (!selectedSet) return [];
-		if (showFilter === 'owned') return selectedSet.cards.filter((c) => c.owned);
-		if (showFilter === 'missing') return selectedSet.cards.filter((c) => !c.owned);
-		return selectedSet.cards;
+		if (!selectedSet) return [] as SetCard[];
+		let cards =
+			showFilter === 'owned'
+				? selectedSet.cards.filter((c) => c.owned)
+				: showFilter === 'missing'
+					? selectedSet.cards.filter((c) => !c.owned)
+					: selectedSet.cards;
+		if (setSort === 'number') return cards;
+		const asc = setSort === 'gem'; // lower gem rate = harder = first
+		return [...cards].sort((a, b) => {
+			const ka = setSortKey(a);
+			const kb = setSortKey(b);
+			if (ka == null && kb == null) return cardNum(a) - cardNum(b);
+			if (ka == null) return 1;
+			if (kb == null) return -1;
+			if (ka === kb) return cardNum(a) - cardNum(b);
+			return asc ? ka - kb : kb - ka;
+		});
 	});
+
+	// Set-scoped standouts — the per-card variance the set view never
+	// showed. Same honesty gate as the chips (server-gated; null ⇒ the
+	// card simply isn't a candidate). Each surfaces only if a real
+	// candidate exists in this set.
+	function topCard(
+		metric: (d: DiscoverySignals) => number | null,
+		dir: 'desc' | 'asc'
+	): SetCard | null {
+		if (!selectedSet) return null;
+		const pool = selectedSet.cards.filter((c) => c.discovery && metric(c.discovery) != null);
+		if (pool.length === 0) return null;
+		return pool.reduce((best, c) =>
+			dir === 'desc'
+				? metric(c.discovery!)! > metric(best.discovery!)!
+					? c
+					: best
+				: metric(c.discovery!)! < metric(best.discovery!)!
+					? c
+					: best
+		);
+	}
+	interface SetStandout { key: string; label: string; detail: string; accent: string; c: SetCard }
+	let standouts = $derived(
+		(
+			[
+				(() => {
+					const c = topCard((d) => d.psa10_delta, 'desc');
+					return c
+						? {
+								key: 'psa10',
+								label: 'Biggest raw → PSA 10',
+								detail: `+${fmtMoney(c.discovery!.psa10_delta!)}${c.discovery!.psa10_multiple != null ? ` (${c.discovery!.psa10_multiple}×)` : ''}`,
+								accent: 'text-vault-green',
+								c
+							}
+						: null;
+				})(),
+				(() => {
+					const c = topCard((d) => d.scarcity_rank, 'desc');
+					return c
+						? { key: 'scarce', label: 'Scarcest in set', detail: `Scarcity ${c.discovery!.scarcity_rank}/100`, accent: 'text-vault-purple', c }
+						: null;
+				})(),
+				(() => {
+					const c = topCard((d) => d.gem_rate, 'asc');
+					return c
+						? { key: 'gem', label: 'Hardest to gem', detail: `${c.discovery!.gem_rate}% gem rate`, accent: 'text-vault-gold', c }
+						: null;
+				})(),
+				(() => {
+					const c = topCard((d) => d.value_rank, 'desc');
+					return c
+						? { key: 'value', label: 'Top Value rank', detail: `Value ${c.discovery!.value_rank}/100`, accent: 'text-vault-purple', c }
+						: null;
+				})()
+			] as (SetStandout | null)[]
+		).filter((x): x is SetStandout => x != null)
+	);
 
 	let costToComplete = $derived(() => {
 		if (!selectedSet) return 0;
@@ -241,6 +353,28 @@
 			</div>
 		</div>
 
+		<!-- Set standouts — per-card variance the set view never showed.
+		     Honesty-gated server-side; a card appears only if its signal is
+		     real/eligible. Purple = modeled rank, gold/green = real data. -->
+		{#if standouts.length > 0}
+			<div class="grid grid-cols-2 gap-3 lg:grid-cols-4" data-testid="set-standouts">
+				{#each standouts as st (st.key)}
+					<a
+						href="/card/{st.c.id}"
+						data-testid="set-standout-{st.key}"
+						class="stat-card group flex items-center gap-3 rounded-2xl border border-vault-border bg-vault-surface p-3 transition-all hover:border-vault-purple/40"
+					>
+						<img src={st.c.imageSmall} alt={st.c.name} loading="lazy" class="h-16 w-11 flex-shrink-0 rounded-lg object-cover" />
+						<div class="min-w-0">
+							<p class="text-[11px] uppercase tracking-wide text-vault-text-muted">{st.label}</p>
+							<p class="truncate text-sm font-medium text-white group-hover:text-vault-purple">{st.c.name}</p>
+							<p class="mt-0.5 text-xs font-semibold {st.accent}">{st.detail}</p>
+						</div>
+					</a>
+				{/each}
+			</div>
+		{/if}
+
 		<!-- Filter tabs -->
 		<div class="flex gap-1 rounded-2xl border border-vault-border bg-vault-surface p-1">
 			<button
@@ -261,6 +395,21 @@
 			>
 				Missing ({selectedSet.total - selectedSet.owned})
 			</button>
+		</div>
+
+		<!-- Sort-by-axis at set scope -->
+		<div class="flex items-center justify-end gap-2">
+			<label for="set-sort" class="text-xs text-vault-text-muted">Sort by</label>
+			<select
+				id="set-sort"
+				bind:value={setSort}
+				data-testid="set-sort"
+				class="rounded-lg border border-vault-border bg-vault-bg px-3 py-1.5 text-xs text-vault-text focus:border-vault-purple focus:outline-none"
+			>
+				{#each Object.entries(SET_SORT_LABELS) as [val, lbl]}
+					<option value={val}>{lbl}</option>
+				{/each}
+			</select>
 		</div>
 
 		<!-- Card Grid -->
@@ -293,6 +442,26 @@
 					{#if card.marketPrice > 0}
 						<div class="absolute bottom-1 right-1 rounded-md bg-black/70 px-1.5 py-0.5 text-[10px] font-bold text-vault-gold">
 							${card.marketPrice.toFixed(2)}
+						</div>
+					{/if}
+					<!-- Discovery chips (bottom-left). Server-gated: a chip
+					     renders only when its signal is real/eligible. Purple
+					     = modeled rank, gold/green = real acquired data. -->
+					{#if card.discovery}
+						{@const d = card.discovery}
+						<div class="absolute bottom-1 left-1 flex flex-col items-start gap-0.5">
+							{#if d.psa10_delta != null}
+								<span class="rounded bg-black/75 px-1 py-0.5 text-[9px] font-bold text-vault-green" title="Real raw → PSA 10 uplift +{fmtMoney(d.psa10_delta)}{d.psa10_multiple != null ? ` (${d.psa10_multiple}× multiple)` : ''}">+{fmtMoney(d.psa10_delta)}</span>
+							{/if}
+							{#if d.gem_rate != null}
+								<span class="rounded bg-black/75 px-1 py-0.5 text-[9px] font-semibold text-vault-gold" title="Real PSA gem rate {d.gem_rate}% (lower = harder pull)">{d.gem_rate}% gem</span>
+							{/if}
+							{#if d.value_rank != null}
+								<span class="rounded bg-black/75 px-1 py-0.5 text-[9px] font-semibold text-vault-purple" title="Value rank {d.value_rank}/100 — PSA 10 price percentile (high/medium confidence)">V{d.value_rank}</span>
+							{/if}
+							{#if d.scarcity_rank != null}
+								<span class="rounded bg-black/75 px-1 py-0.5 text-[9px] font-semibold text-vault-purple" title="Scarcity rank {d.scarcity_rank}/100 — inverse graded population (high/medium confidence)">S{d.scarcity_rank}</span>
+							{/if}
 						</div>
 					{/if}
 				</a>


### PR DESCRIPTION
## Summary
Continues the discovery-UX wedge (north-star #5/#6). The selected-set view was set-level ROI + own/missing/price only — no per-card variance. This makes it answer **"which cards in this set are the standouts"**.

- **Shared helper** (`src/lib/services/discovery-signals.ts`): extracts the honesty gate now that it's reused a 3rd time (CardThumbnail, collection, sets). Pure `gateDiscoverySignals()` + `DISCOVERY_SELECT_COLS` + unit test. The collection loader is refactored onto it (removes its duplicated inline gate).
- **Sets loader**: joins the selected set's cards → `card_index`, attaches gated `DiscoverySignals`.
- **Sets UI**: a **set-scoped standouts strip** (biggest raw→PSA10 / scarcest / hardest-to-gem / top Value rank in this set), **per-tile discovery chips** (purple = modeled rank, gold = real gem rate, green = real PSA10 uplift), and a **sort-by-axis** selector that sinks signal-less cards (shown, never hidden).

No migration. Additive.

## Honesty doctrine
Verified vs real `card_index` on `base1`, **both directions**:
- 66 rendered `V` chips == 66 DB rows with `score_value` + `ranking_confidence in (high,medium)` (exact 1:1).
- `base1-14` (`score_value=89` but `ranking_confidence=low`) → **zero** rank chips.
- Charizard `base1-4` is the raw→PSA10 standout (matches DB max `psa10_delta=26333.31`); `0% gem` is real (`psa_gem_rate=0.00`, `pop=369`).

## Test plan
- [x] `svelte-check`: 18 err / 2 warn — **0-new** vs baseline
- [x] `vitest`: 70/70 (＋6 new discovery-signals tests)
- [x] `trove-verify`: `/sets?set=base1` SSR rendered + cross-checked vs service-role `card_index` (both directions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)