### PR TITLE
Hunt-DSL search on /rankings (Gap #4)

### DIFF
--- a/src/routes/rankings/+page.server.ts
+++ b/src/routes/rankings/+page.server.ts
@@ -1,6 +1,24 @@
 import { supabase } from '$services/supabase';
 import { AXES, LENSES, LENS_KEYS, type LensKey } from '$services/lenses';
+import { parseHuntDSL } from '$services/hunt-dsl';
 import type { PageServerLoad } from './$types';
+
+// Human-readable echo of an applied DSL filter, so the user sees how
+// their query was interpreted (and trusts the result set).
+function describeFilters(p: Record<string, string | undefined>): string[] {
+	const out: string[] = [];
+	if (p.q) out.push(`name ~ "${p.q}"`);
+	if (p.set) out.push(`set: ${p.set}`);
+	if (p.pop_lt) out.push(`graded pop < ${p.pop_lt}`);
+	if (p.after) out.push(`released ≥ ${p.after}`);
+	if (p.before) out.push(`released < ${p.before}`);
+	if (p.raw_gt) out.push(`raw > $${p.raw_gt}`);
+	if (p.raw_lt) out.push(`raw < $${p.raw_lt}`);
+	if (p.require_psa10) out.push('has PSA 10 price');
+	if (p.rarity_like) out.push(`rarity ~ "${p.rarity_like}"`);
+	if (p.variants) out.push(`variant: ${p.variants}`);
+	return out;
+}
 
 const PAGE_SIZE = 60;
 
@@ -26,6 +44,18 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 
 	const q = url.searchParams.get('q')?.trim() ?? '';
 	const setId = url.searchParams.get('set')?.trim() ?? '';
+
+	// The search box is now hunt-DSL aware (same grammar as /browse): e.g.
+	// `charizard pop:<500 year:1999-2003 rarity:holo psa10`. Barewords →
+	// name search; field:value → structured card_index filters. Unknown
+	// tokens are echoed back, not silently dropped.
+	const dsl = q ? parseHuntDSL(q) : { params: {}, errors: [] };
+	const dslParams = dsl.params;
+	const nameQ = dslParams.q ?? '';
+	// Explicit ?set= (focused link from the card-detail Discovery panel)
+	// wins; otherwise honor a `set:` token from the DSL.
+	const effectiveSetId = setId || (dslParams.set ?? '');
+	const dslFilterDesc = describeFilters({ ...dslParams, set: effectiveSetId || undefined });
 	const lensParam = (url.searchParams.get('lens') ?? 'investor') as LensKey;
 	const lens: LensKey = LENS_KEYS.includes(lensParam) ? lensParam : 'investor';
 	const confidence = url.searchParams.get('confidence') ?? 'all'; // all | high | nolow
@@ -38,8 +68,22 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 		.from('card_index')
 		.select(SELECT_COLS, { count: 'exact' });
 
-	if (q) query = query.ilike('name', `%${q}%`);
-	if (setId) query = query.eq('set_id', setId);
+	if (nameQ) query = query.ilike('name', `%${nameQ}%`);
+	if (effectiveSetId) query = query.eq('set_id', effectiveSetId);
+	if (dslParams.pop_lt) query = query.lt('combined_pop_total', parseInt(dslParams.pop_lt));
+	if (dslParams.before) query = query.lt('set_release_date', `${dslParams.before}-01-01`);
+	if (dslParams.after) query = query.gte('set_release_date', `${dslParams.after}-01-01`);
+	if (dslParams.raw_lt) query = query.lt('raw_nm_price', parseFloat(dslParams.raw_lt));
+	if (dslParams.raw_gt) query = query.gt('raw_nm_price', parseFloat(dslParams.raw_gt));
+	if (dslParams.require_psa10) query = query.not('psa10_price', 'is', null);
+	if (dslParams.rarity_like) query = query.ilike('rarity', `%${dslParams.rarity_like}%`);
+	if (dslParams.variants) {
+		const vs = dslParams.variants.split(',');
+		if (vs.includes('holo') && vs.includes('reverse'))
+			query = query.or('has_holofoil.eq.true,has_reverse_holofoil.eq.true');
+		else if (vs.includes('holo')) query = query.eq('has_holofoil', true);
+		else if (vs.includes('reverse')) query = query.eq('has_reverse_holofoil', true);
+	}
 	if (confidence === 'high') query = query.eq('ranking_confidence', 'high');
 	else if (confidence === 'nolow') query = query.in('ranking_confidence', ['high', 'medium']);
 
@@ -85,6 +129,8 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 		pageSize: PAGE_SIZE,
 		q,
 		setId,
+		dslFilters: dslFilterDesc,
+		dslErrors: dsl.errors,
 		lens,
 		sortCol,
 		confidence,

--- a/src/routes/rankings/+page.svelte
+++ b/src/routes/rankings/+page.svelte
@@ -82,8 +82,9 @@
 				type="text"
 				name="q"
 				value={data.q}
-				placeholder="Search card name…"
-				class="rounded-xl border border-vault-border bg-vault-bg px-3 py-1.5 text-sm text-vault-text placeholder-vault-text-muted focus:border-vault-purple focus:outline-none"
+				placeholder="charizard pop:<500 year:1999-2003 rarity:holo psa10"
+				title="Hunt-DSL: barewords search the name; field:value filters — pop:<N year:A-B price:A-B raw:>N rarity:holo set:base1 psa10"
+				class="w-80 max-w-full rounded-xl border border-vault-border bg-vault-bg px-3 py-1.5 text-sm text-vault-text placeholder-vault-text-muted focus:border-vault-purple focus:outline-none"
 			/>
 			<button class="rounded-xl bg-vault-surface px-3 py-1.5 text-sm text-vault-text hover:bg-vault-surface-hover">Search</button>
 		</form>
@@ -102,6 +103,23 @@
 			{data.count.toLocaleString()} cards · page {data.page}/{data.totalPages}
 		</span>
 	</div>
+
+	<!-- DSL interpretation echo — shows the user how their query was parsed
+	     so a filtered result set is trustworthy, and flags tokens we didn't
+	     understand instead of silently dropping them. -->
+	{#if data.dslFilters.length > 0 || data.dslErrors.length > 0}
+		<div class="mb-4 flex flex-wrap items-center gap-1.5 text-xs">
+			{#if data.dslFilters.length > 0}
+				<span class="text-vault-text-muted">Filtered by:</span>
+				{#each data.dslFilters as f}
+					<span class="rounded-chip bg-vault-purple/15 px-2 py-0.5 text-vault-purple">{f}</span>
+				{/each}
+			{/if}
+			{#each data.dslErrors as e}
+				<span class="rounded-chip bg-vault-red/15 px-2 py-0.5 text-vault-red" title="Unrecognized — ignored. Try field:value, e.g. pop:<500">didn't understand "{e}"</span>
+			{/each}
+		</div>
+	{/if}
 
 	{#if !data.rankingsReady}
 		<div class="rounded-card border border-vault-border bg-vault-surface p-8 text-center">


### PR DESCRIPTION
## Summary
Continues the discovery-UX wedge. `/rankings` search was a plain name `ilike`; this makes it **hunt-DSL aware** (same grammar as `/browse`), so rankings is a discovery tool, not just a sortable spreadsheet. (Thumbnails already render in the table — the real Gap #4 was DSL.)

- Route the `q` box through `parseHuntDSL`: barewords → name search; `pop:<N year:A-B price/raw:A-B rarity: set: psa10 holo/reverse` → structured `card_index` filters, applied exactly like browse.
- **Interpreted-filter echo**: parsed filters render as purple chips ("graded pop < 500", "released ≥ 1999", …); unrecognized tokens show "didn't understand X" instead of being silently dropped.
- Explicit `?set=` (the focused card-detail Discovery link) still wins over a `set:` token.

No migration. Additive.

## Verification (both directions)
Query `charizard pop:<500 year:1999-2003 rarity:holo psa10 wat:xyz`:
- 6 filter chips rendered (name/pop/≥1999/<2004/psa10/rarity) + `didn't understand "wat:xyz"`.
- Result set == `card_index` with identical filters: `content-range 0-0/1` → **base1-4 Charizard** (pop 369<500, Rare Holo, released 1999-01-09, psa10 not null). Exact 1:1.

## Test plan
- [x] `svelte-check`: 18 err / 2 warn — **0-new** vs baseline
- [x] `vitest`: 70/70
- [x] `trove-verify`: `/rankings?q=…` SSR rendered + cross-checked vs service-role `card_index`

🤖 Generated with [Claude Code](https://claude.com/claude-code)