### PR TITLE
Surface real TAG graded pop on the browse grid (Gap #5)

### DIFF
--- a/src/lib/components/CardThumbnail.svelte
+++ b/src/lib/components/CardThumbnail.svelte
@@ -11,6 +11,8 @@
 		psa_pop_total?: number | null;
 		psa_pop_10?: number | null;
 		psa_gem_rate?: number | null;
+		tag_pop_total?: number | null;
+		tag_gem_rate?: number | null;
 		score_value?: number | null;
 		ranking_confidence?: string | null;
 		cgc_pop_total?: number | null;
@@ -31,7 +33,17 @@
 
 	let enrichment = $derived(card._enrichment);
 	let hasDelta = $derived(enrichment?.psa10_delta != null && enrichment.psa10_delta > 0);
-	let hasPop = $derived(enrichment?.combined_pop_total != null);
+	// Real TAG Grading pop (taggrading.com, migration 019 — ~1.9k cards in
+	// prod, broader than PSA). Deliberately NOT folded into
+	// combined_pop_total (019 keeps that PSA+CGC so the hunt pop filter
+	// doesn't silently shift), so the grid hid it entirely. Surfaced as its
+	// own segment, gated to a real positive pop. null/0 ⇒ nothing.
+	let tagPop = $derived(
+		enrichment?.tag_pop_total != null && enrichment.tag_pop_total > 0
+			? enrichment.tag_pop_total
+			: null
+	);
+	let hasPop = $derived(enrichment?.combined_pop_total != null || tagPop != null);
 	// Real PSA gem rate (psa_pop_10 / psa_pop_total, persisted as a %). Only
 	// surface it when it's genuinely backed by a scraped PSA pop — never
 	// derive or estimate it. A lower rate = harder to pull a 10, the single
@@ -131,22 +143,25 @@
 		</div>
 	{/if}
 
-	<!-- Pop badge (bottom left) — shows in hunt mode with PSA/CGC breakdown -->
+	<!-- Pop badge (bottom left) — PSA/CGC breakdown + real TAG pop (separate
+	     from the PSA+CGC "combined" so the hunt pop filter is unaffected). -->
 	{#if hasPop}
 		{@const psa = enrichment!.psa_pop_total ?? 0}
 		{@const cgc = enrichment!.cgc_pop_total ?? 0}
 		{@const combined = enrichment!.combined_pop_total ?? 0}
 		<div class="absolute bottom-14 left-2 rounded-full bg-vault-bg/90 px-2 py-0.5 text-[10px] font-medium text-vault-text-muted shadow-lg backdrop-blur-sm"
-			title="PSA: {psa.toLocaleString()}{cgc ? ` + CGC: ${cgc.toLocaleString()}` : ''} = {combined.toLocaleString()} total graded{gemRate != null ? ` · PSA ${(enrichment!.psa_pop_10 ?? 0).toLocaleString()} of ${psa.toLocaleString()} are a 10 → ${gemRate}% gem rate (lower = harder pull)` : ''}">
+			title="PSA: {psa.toLocaleString()}{cgc ? ` + CGC: ${cgc.toLocaleString()}` : ''} = {combined.toLocaleString()} PSA+CGC graded{gemRate != null ? ` · PSA ${(enrichment!.psa_pop_10 ?? 0).toLocaleString()} of ${psa.toLocaleString()} are a 10 → ${gemRate}% gem rate (lower = harder pull)` : ''}{tagPop != null ? ` · TAG: ${tagPop.toLocaleString()} graded (taggrading.com, separate from PSA+CGC)${enrichment!.tag_gem_rate != null ? ` · ${enrichment!.tag_gem_rate}% TAG gem` : ''}` : ''}">
 			{#if psa && cgc}
 				PSA {psa.toLocaleString()} + CGC {cgc.toLocaleString()}
 			{:else if psa}
 				PSA pop {psa.toLocaleString()}
 			{:else if cgc}
 				CGC pop {cgc.toLocaleString()}
-			{:else}
+			{:else if combined}
 				pop {combined.toLocaleString()}
-			{/if}{#if gemRate != null}<span class="ml-1 text-vault-gold">· {gemRate}% gem</span>{/if}
+			{:else if tagPop != null}
+				TAG pop {tagPop.toLocaleString()}
+			{/if}{#if gemRate != null}<span class="ml-1 text-vault-gold">· {gemRate}% gem</span>{/if}{#if tagPop != null && (psa || cgc || combined)}<span class="ml-1 text-vault-cyan">· TAG {tagPop.toLocaleString()}</span>{/if}
 		</div>
 	{/if}
 

--- a/src/lib/services/sort.ts
+++ b/src/lib/services/sort.ts
@@ -225,6 +225,8 @@ export interface EnrichedCard extends PokemonCard {
 		psa_pop_total?: number | null;
 		psa_pop_10?: number | null;
 		psa_gem_rate?: number | null;
+		tag_pop_total?: number | null;
+		tag_gem_rate?: number | null;
 		score_value?: number | null;
 		ranking_confidence?: string | null;
 		pcUrl: string | null;

--- a/src/routes/browse/+page.server.ts
+++ b/src/routes/browse/+page.server.ts
@@ -138,7 +138,7 @@ async function attachCardIndexEnrichment(cards: PokemonCard[]): Promise<Enriched
 	const ids = cards.map((c) => c.id);
 	const { data } = await supabase
 		.from('card_index')
-		.select('card_id, raw_nm_price, raw_source, psa10_price, psa10_delta, psa10_multiple, psa_pop_total, psa_pop_10, psa_gem_rate, score_value, ranking_confidence, cgc_pop_total, combined_pop_total')
+		.select('card_id, raw_nm_price, raw_source, psa10_price, psa10_delta, psa10_multiple, psa_pop_total, psa_pop_10, psa_gem_rate, tag_pop_total, tag_gem_rate, score_value, ranking_confidence, cgc_pop_total, combined_pop_total')
 		.in('card_id', ids);
 	const byId = new Map<string, Record<string, unknown>>();
 	for (const row of (data ?? []) as Array<Record<string, unknown>>) {
@@ -158,6 +158,8 @@ async function attachCardIndexEnrichment(cards: PokemonCard[]): Promise<Enriched
 				psa_pop_total: idx.psa_pop_total as number | null,
 				psa_pop_10: idx.psa_pop_10 as number | null,
 				psa_gem_rate: idx.psa_gem_rate as number | null,
+				tag_pop_total: idx.tag_pop_total as number | null,
+				tag_gem_rate: idx.tag_gem_rate as number | null,
 				score_value: idx.score_value as number | null,
 				ranking_confidence: idx.ranking_confidence as string | null,
 				cgc_pop_total: idx.cgc_pop_total as number | null,
@@ -451,6 +453,8 @@ async function loadHuntMode(url: URL, _setHeaders: (headers: Record<string, stri
 			psa_pop_total: row.psa_pop_total as number | null,
 			psa_pop_10: row.psa_pop_10 as number | null,
 			psa_gem_rate: row.psa_gem_rate as number | null,
+			tag_pop_total: row.tag_pop_total as number | null,
+			tag_gem_rate: row.tag_gem_rate as number | null,
 			score_value: row.score_value as number | null,
 			ranking_confidence: row.ranking_confidence as string | null,
 			cgc_pop_total: row.cgc_pop_total as number | null,


### PR DESCRIPTION
## Summary
Final audit-ranked gap of the discovery-UX wedge. The grid pop badge showed only PSA/CGC; **TAG Grading pop** (migration 019, ~1.9k cards in prod — broader than PSA, and a user-priority grader) was 100% hidden because `combined_pop_total` deliberately stays PSA+CGC (019 warns that folding TAG in would silently shift the `/browse` hunt pop filter).

- Add `tag_pop_total`/`tag_gem_rate` to `EnrichedCard` + both browse enrichment paths.
- Render TAG as its **own gated cyan segment** in the `CardThumbnail` badge + tooltip — separate from the PSA+CGC "combined", so the hunt filter is unaffected.
- Honesty-gated: renders only when `tag_pop_total > 0`; null/0 ⇒ nothing.

**Scope deliberately excludes** BGS/SGC (`*/0` rows in prod — surfacing an empty axis violates the honesty doctrine) and `grade_ladder` on the grid (only 72 rows; the card-detail page already covers it where present). Data coverage checked via service-role before deciding what may be shown.

## Verification (both directions)
`/browse?mode=hunt&set=base1&require_psa10=1`:
- 23 TAG segments rendered; every sampled value exact vs `card_index`: base1-4→9, base1-2→7, base1-58→4955, base1-85→389, base1-83→339, base1-77→332.
- Null-`tag_pop_total` cards (base1-14/51/45) render no TAG segment.

## Test plan
- [x] `svelte-check`: 18 err / 2 warn — **0-new** vs baseline
- [x] `vitest`: 70/70
- [x] `trove-verify`: hunt grid SSR rendered + cross-checked vs service-role `card_index` (both directions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)