### PR TITLE
fix(engine): enrich concurrency 6→3 — was acquiring ZERO graded data for weeks

### DIFF
--- a/.github/workflows/engine-enrich.yml
+++ b/.github/workflows/engine-enrich.yml
@@ -14,8 +14,14 @@ on:
         description: rows to refresh this run
         default: '150'
       concurrency:
-        description: parallel scrapes
-        default: '6'
+        # 3 is the empirically-validated ceiling from the GitHub Actions
+        # runner IP: at concurrency 6 PriceCharting/Cloudflare fail-fasts
+        # parallel requests from the shared datacenter IP, so fetch returns
+        # null in ~50ms/card and the engine acquired ZERO graded data for
+        # weeks while still reporting "150 processed, 0 errors". conc 1 and
+        # 3 both pull real PSA10/pop on the same IP; 6 does not.
+        description: parallel scrapes (>3 fails on the GH runner IP — see note)
+        default: '3'
 
 concurrency:
   group: engine-enrich
@@ -40,4 +46,4 @@ jobs:
         run: |
           node_modules/.bin/tsx scripts/refresh-index.ts \
             --stale "${{ github.event.inputs.stale || '150' }}" \
-            --concurrency "${{ github.event.inputs.concurrency || '6' }}"
+            --concurrency "${{ github.event.inputs.concurrency || '3' }}"

--- a/scripts/refresh-index.ts
+++ b/scripts/refresh-index.ts
@@ -734,7 +734,7 @@ async function main() {
 			'seed-before': { type: 'string' },
 			'seed-all': { type: 'boolean', default: false },
 			'dry-run': { type: 'boolean', default: false },
-			concurrency: { type: 'string', default: '6' },
+			concurrency: { type: 'string', default: '3' },
 			force: { type: 'boolean', default: false },
 			// Stale-mode prioritisation. Default: gap-prioritised (fill the
 			// coverage gap first). `--fifo` forces the legacy pure-oldest
@@ -745,7 +745,7 @@ async function main() {
 		strict: false
 	});
 
-	const concurrency = parseInt(values.concurrency as string) || 6;
+	const concurrency = parseInt(values.concurrency as string) || 3;
 	const dryRun = !!values['dry-run'];
 
 	if (values['seed-all']) {
@@ -959,7 +959,7 @@ Usage:
   tsx scripts/refresh-index.ts --seed-before 2017   # seed only pre-year sets
 
 Options:
-  --concurrency N    Parallel enrichment (default: 6)
+  --concurrency N    Parallel enrichment (default: 3 — >3 fails on datacenter IPs)
   --dry-run          Show what would run, don't write
   --force            Bust cache and re-scrape
 `);


### PR DESCRIPTION
## The bug
Coverage flat for weeks (PSA10 ~10%; ex1/hgss1/dp1 at 0.0% PSA10 despite being scraped). The `engine-enrich` cron default **concurrency=6** fail-fasts on the shared GitHub Actions datacenter IP — Cloudflare drops 6 parallel PriceCharting requests from one IP, so `fetchPriceCharting` returns null in ~50ms/card. The run "processed" 150 cards in ~7s, wrote all-null graded data, and reported `150 processed, 0 errors` (miss isn't an error; `last_enriched_at` still advances) — looked healthy. A single fixed-URL fetch passes from the GH IP (`cf-spike` 20/20), so the reachability probe never caught it; only the concurrent flow fails.

## Empirical validation (real GH runner IP, this session)
- conc=6 (old default): 150 cards/7s, ~0% graded yield (the bug)
- conc=1: real PSA10 (Gliscor $33.79, Spiritomb $37.26…)
- conc=3: real PSA10+pop (Dialga-EX $448/pop189…)
- **conc=3 committed default, stale=30: 14/15 = 93% real PSA10** (Gengar-EX $15,269/pop4494, Florges-EX $890/pop199…)

## Change
Default 6→3 (proven ceiling) in `engine-enrich.yml` + `refresh-index.ts` + help text. ~150 real scrapes ≈ 30–75s/run (<50min timeout); clears the ~14k gradeable-gap backlog in ~2 days.

## Test plan
- [x] svelte-check 0-new (18/2 baseline), vitest 70/70
- [x] Committed default dispatched on GH runner → 93% real PSA10 vs ~0% baseline, cross-checked vs service-role card_index

🤖 Generated with [Claude Code](https://claude.com/claude-code)