### PR TITLE
UI/CSS audit: logo contrast fix + app-wide keyboard focus ring

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -67,6 +67,27 @@ html {
 	color-scheme: dark;
 }
 
+/* Keyboard focus ring. ~50 interactive elements use `focus:outline-none`
+ * with only a subtle border-color change (or nothing), leaving keyboard
+ * users with no reliable focus indicator. `:focus-visible` only triggers
+ * for keyboard/AT navigation — never on mouse click — so this restores
+ * accessibility app-wide without changing the pointer-driven visual
+ * design or touching every call site. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+	/* box-shadow (not outline): ~50 elements use Tailwind `focus:outline-none`
+	 * which forces a transparent outline and would clobber an outline-based
+	 * ring; box-shadow is untouched by it and hugs the element's radius. */
+	box-shadow:
+		0 0 0 2px var(--color-vault-bg),
+		0 0 0 4px var(--color-vault-cyan);
+	outline: none;
+}
+
 body {
 	background-color: var(--color-vault-bg);
 	color: var(--color-vault-text);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,7 +45,7 @@
 		<!-- Logo -->
 		<div class="flex h-16 items-center gap-3 border-b border-vault-border px-6">
 			<div class="brand-chip h-8 w-8">
-				<svg class="h-5 w-5 text-white" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<svg class="h-5 w-5 text-vault-bg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 					<circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
 					<line x1="2" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="2"/>
 					<circle cx="12" cy="12" r="3" fill="currentColor"/>
@@ -154,8 +154,8 @@
 		<button aria-label="Close menu" class="fixed inset-0 bg-black/70 backdrop-blur-sm" onclick={() => (mobileMenuOpen = false)}></button>
 		<div class="fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-vault-surface shadow-2xl">
 			<div class="flex h-16 items-center gap-3 border-b border-vault-border px-6">
-				<div class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-vault-accent to-vault-purple">
-					<svg class="h-5 w-5 text-white" viewBox="0 0 24 24" fill="currentColor">
+				<div class="brand-chip h-8 w-8">
+					<svg class="h-5 w-5 text-vault-bg" viewBox="0 0 24 24" fill="currentColor">
 						<circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
 						<line x1="2" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="2"/>
 						<circle cx="12" cy="12" r="3" fill="currentColor"/>


### PR DESCRIPTION
## Summary
Sprint-closing UI/CSS audit. Two concrete, low-risk improvements:

1. **Logo contrast bug** — the sidebar and mobile-menu logo SVG used `text-white` inside `.brand-chip`, whose background is the *near-white* brand-gradient. `.brand-chip` even sets `color: vault-bg`, but the `text-white` utility overrode it via `currentColor`, leaving the logo near-invisible (white-on-near-white). Switched the icon to `text-vault-bg` (matches the documented contrast rule in `app.css`) and unified the mobile logo onto `.brand-chip` (it was a one-off `bg-gradient-to-br` div).
2. **Keyboard focus accessibility** — audit found **53** `focus:outline-none` usages and **0** `:focus-visible` rules: keyboard/AT users had no reliable focus indicator. Added a single global `:focus-visible` ring in `app.css`. Uses `box-shadow` (not `outline`) because Tailwind's `outline-none` forces a transparent outline that would clobber an outline ring; box-shadow also follows each element's border-radius. `:focus-visible` never triggers on mouse click, so the pointer-driven visual design is unchanged and no call site needed editing.

## Test plan
- [x] `svelte-check`: 18 err / 2 warn — **0-new** vs baseline
- [x] `vitest`: 70/70
- [x] `trove-verify`: served `/collection` confirms logo now `text-vault-bg` (0 old `text-white` logos), `:focus-visible` box-shadow rule compiled into served `app.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)