### PR TITLE
fix(engine): stop null-clobber of graded data on failed scrapes

### DIFF
--- a/scripts/refresh-index.ts
+++ b/scripts/refresh-index.ts
@@ -54,6 +54,7 @@ import { fetchPriceCharting as fetchPriceChartingDirect } from '../src/lib/servi
 import { getTagCardPop, tagPopScalars, TagGradingError } from '../src/lib/services/tag-grading.js';
 import { getCgcCardPop, cgcPopScalars, CgcGradingError } from '../src/lib/services/cgc-grading.js';
 import { getBgsCardPop, bgsDrillKeyword, bgsPopScalars, BgsGradingError } from '../src/lib/services/bgs-grading.js';
+import { pcGradedFields } from '../src/lib/services/enrich-graded-fields.js';
 
 const DEV_SERVER_URL = process.env.DEV_SERVER_URL ?? '';
 
@@ -196,10 +197,6 @@ async function enrichOneCard(card: TcgCard): Promise<EnrichedCardOutput> {
 	const holoPrices = card.tcgplayer?.prices?.['holofoil'];
 	const reversePrices = card.tcgplayer?.prices?.['reverseHolofoil'];
 
-	// Pop data from PriceCharting's embedded pop_data variable
-	const psaPop = pc?.psaPop ?? null;
-	const cgcPop = pc?.cgcPop ?? null;
-
 	return {
 		row: {
 			card_id: card.id,
@@ -225,29 +222,10 @@ async function enrichOneCard(card: TcgCard): Promise<EnrichedCardOutput> {
 			raw_nm_price: rawPrice,
 			raw_source: rawSource,
 			raw_fetched_at: now,
-			psa10_price: pc?.psa10 ?? null,
-			psa10_source: pc?.psa10 != null ? 'pricecharting' : null,
-			tag10_price: pc?.tag10 ?? null,
-			tag10_source: pc?.tag10 != null ? 'pricecharting' : null,
-			cgc10_price: pc?.cgc10 ?? null,
-			cgc10_source: pc?.cgc10 != null ? 'pricecharting' : null,
-			// Real per-grade ladder (migration 020). Real cells only —
-			// PriceCharting blank `-` rows are already dropped upstream.
-			grade_ladder: pc?.gradeLadder ?? null,
-			grade_ladder_fetched_at: pc ? now : null,
-			graded_prices_fetched_at: pc ? now : null,
-			psa10_last_sold_at: pc?.psa10LastSold ?? null,
-			psa_pop_total: psaPop?.total ?? null,
-			psa_pop_10: psaPop?.grade10 ?? null,
-			psa_gem_rate: psaPop?.gemRate ?? null,
-			psa_fetched_at: psaPop ? now : null,
-			// Real CGC pop into its own columns (migration 007). tag_pop_*
-			// is left untouched — PriceCharting has no TAG pop; writing CGC
-			// there fabricated TAG. Omitted from the upsert = never clobbered.
-			cgc_pop_total: cgcPop?.total ?? null,
-			cgc_pop_10: cgcPop?.grade10 ?? null,
-			cgc_gem_rate: cgcPop?.gemRate ?? null,
-			cgc_fetched_at: cgcPop ? now : null,
+			// Graded/pop fields are added ONLY when the scrape returned them
+			// (see enrich-graded-fields.ts). A transient miss omits these
+			// keys so the upsert never nulls previously-good values.
+			...pcGradedFields(pc, now),
 			last_enriched_at: now,
 			enrich_version: 2,
 			enrich_errors: errors
@@ -277,12 +255,12 @@ interface StoredCardMeta {
 }
 
 // Build the PriceCharting-derived upsert subset from stored metadata + a
-// fresh scrape. Mirrors the PriceCharting fields of enrichOneCard exactly
-// (honesty doctrine: only real scraped values; null beats fabricated; a
-// transient miss never clobbers a good stored value because we only set a
-// field when the scrape actually returned it). Crucially this writes ONLY
-// price/pop fields — it never touches immutable metadata, so there is no
-// metadata-clobber risk from not having a fresh TCG payload.
+// fresh scrape. Graded/pop fields come from the shared pcGradedFields()
+// helper (enrich-graded-fields.ts) — the SAME builder enrichOneCard uses,
+// so the two paths can no longer drift. A transient miss omits the graded
+// keys entirely, so the upsert never clobbers a good stored value.
+// Crucially this writes ONLY price/pop fields — it never touches immutable
+// metadata, so there is no metadata-clobber risk from no fresh TCG payload.
 function stalePriceRow(
 	meta: StoredCardMeta,
 	pc: Awaited<ReturnType<typeof fetchPriceCharting>>,
@@ -294,8 +272,6 @@ function stalePriceRow(
 	// so we do not pretend it is fresher than it is (raw_source records which).
 	const rawPrice = rawFromPc ?? meta.tcg_headline_market ?? null;
 	const rawSource = rawFromPc != null ? 'pricecharting' : 'tcgplayer';
-	const psaPop = pc?.psaPop ?? null;
-	const cgcPop = pc?.cgcPop ?? null;
 
 	const row: Record<string, unknown> = {
 		card_id: meta.card_id,
@@ -315,29 +291,10 @@ function stalePriceRow(
 		raw_nm_price: rawPrice,
 		raw_source: rawSource,
 		raw_fetched_at: now,
-		psa10_price: pc?.psa10 ?? null,
-		psa10_source: pc?.psa10 != null ? 'pricecharting' : null,
-		tag10_price: pc?.tag10 ?? null,
-		tag10_source: pc?.tag10 != null ? 'pricecharting' : null,
-		cgc10_price: pc?.cgc10 ?? null,
-		cgc10_source: pc?.cgc10 != null ? 'pricecharting' : null,
-		// Real per-grade ladder (migration 020). Real cells only —
-		// PriceCharting blank `-` rows are already dropped upstream.
-		grade_ladder: pc?.gradeLadder ?? null,
-		grade_ladder_fetched_at: pc ? now : null,
-		graded_prices_fetched_at: pc ? now : null,
-		psa10_last_sold_at: pc?.psa10LastSold ?? null,
-		psa_pop_total: psaPop?.total ?? null,
-		psa_pop_10: psaPop?.grade10 ?? null,
-		psa_gem_rate: psaPop?.gemRate ?? null,
-		psa_fetched_at: psaPop ? now : null,
-		// Real CGC pop into its own columns (migration 007). tag_pop_* is
-		// left untouched — PriceCharting has no TAG pop; writing CGC there
-		// fabricated TAG. Omitted from the upsert = never clobbered.
-		cgc_pop_total: cgcPop?.total ?? null,
-		cgc_pop_10: cgcPop?.grade10 ?? null,
-		cgc_gem_rate: cgcPop?.gemRate ?? null,
-		cgc_fetched_at: cgcPop ? now : null,
+		// Graded/pop fields are added ONLY when the scrape returned them
+		// (see enrich-graded-fields.ts). A transient miss omits these keys
+		// so the upsert never nulls previously-good values.
+		...pcGradedFields(pc, now),
 		last_enriched_at: now,
 		enrich_version: 2,
 		enrich_errors: errors

--- a/src/lib/services/__tests__/enrich-graded-fields.test.ts
+++ b/src/lib/services/__tests__/enrich-graded-fields.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { pcGradedFields } from '../enrich-graded-fields';
+import type { PriceChartingData } from '../pricecharting-scraper';
+
+const NOW = '2026-05-19T12:00:00.000Z';
+
+function mk(overrides: Partial<PriceChartingData>): PriceChartingData {
+	return {
+		ungraded: 10,
+		psa10: 500,
+		cgc10: 300,
+		bgs10: 350,
+		tag10: 250,
+		allTiers: {},
+		gradeLadder: { psa: { '9': 100, '10': 500 } },
+		psaPop: { grades: [], total: 1000, grade10: 50, gemRate: 5 },
+		cgcPop: { grades: [], total: 200, grade10: 20, gemRate: 10 },
+		psa10LastSold: '2026-05-01',
+		psa10Sales: [],
+		pcUrl: 'https://www.pricecharting.com/game/x',
+		// productName etc. are unused by the helper; cast covers the rest.
+		...overrides
+	} as unknown as PriceChartingData;
+}
+
+describe('pcGradedFields — no-clobber contract', () => {
+	it('returns {} for a failed/transient scrape (pc == null)', () => {
+		// THE data-loss guard: a Cloudflare miss must touch ZERO graded
+		// columns so the upsert preserves previously-good values.
+		expect(pcGradedFields(null, NOW)).toEqual({});
+	});
+
+	it('emits every graded field when the scrape returned everything', () => {
+		const f = pcGradedFields(mk({}), NOW);
+		expect(f).toMatchObject({
+			graded_prices_fetched_at: NOW,
+			psa10_price: 500,
+			psa10_source: 'pricecharting',
+			tag10_price: 250,
+			tag10_source: 'pricecharting',
+			cgc10_price: 300,
+			cgc10_source: 'pricecharting',
+			grade_ladder: { psa: { '9': 100, '10': 500 } },
+			grade_ladder_fetched_at: NOW,
+			psa10_last_sold_at: '2026-05-01',
+			psa_pop_total: 1000,
+			psa_pop_10: 50,
+			psa_gem_rate: 5,
+			psa_fetched_at: NOW,
+			cgc_pop_total: 200,
+			cgc_pop_10: 20,
+			cgc_gem_rate: 10,
+			cgc_fetched_at: NOW
+		});
+	});
+
+	it('OMITS the key (never null) when a value is absent — the actual contract', () => {
+		// pc reached but this card has no PSA10 market: psa10 keys must be
+		// ABSENT (so ON CONFLICT UPDATE leaves the stored psa10 untouched),
+		// while graded_prices_fetched_at still advances (we did check).
+		const f = pcGradedFields(mk({ psa10: null, psa10LastSold: null }), NOW);
+		expect(f).not.toHaveProperty('psa10_price');
+		expect(f).not.toHaveProperty('psa10_source');
+		expect(f).not.toHaveProperty('psa10_last_sold_at');
+		expect(f.graded_prices_fetched_at).toBe(NOW);
+		// unrelated present values are still emitted
+		expect(f.cgc10_price).toBe(300);
+	});
+
+	it('omits grade_ladder when the ladder is empty', () => {
+		const f = pcGradedFields(mk({ gradeLadder: {} }), NOW);
+		expect(f).not.toHaveProperty('grade_ladder');
+		expect(f).not.toHaveProperty('grade_ladder_fetched_at');
+	});
+
+	it('emits each pop block independently', () => {
+		const f = pcGradedFields(mk({ cgcPop: null }), NOW);
+		expect(f.psa_pop_total).toBe(1000);
+		expect(f).not.toHaveProperty('cgc_pop_total');
+		expect(f).not.toHaveProperty('cgc_fetched_at');
+	});
+});

--- a/src/lib/services/enrich-graded-fields.ts
+++ b/src/lib/services/enrich-graded-fields.ts
@@ -1,0 +1,75 @@
+/**
+ * Graded/pop upsert fields derived from a PriceCharting scrape — the ONE
+ * place this is built, used by both refresh-index write paths
+ * (`enrichOneCard` full path + `stalePriceRow` stale path).
+ *
+ * WHY THIS EXISTS (data-loss incident 2026-05-19): both paths previously
+ * inlined `psa10_price: pc?.psa10 ?? null` (etc.) directly into the upsert
+ * row. PostgREST upsert is INSERT ... ON CONFLICT DO UPDATE and builds the
+ * UPDATE SET clause from the keys PRESENT in the payload, so a transient /
+ * Cloudflare-failed scrape (`pc == null`) wrote NULL over previously-good
+ * graded data — a 3000-card cloud run nulled ~205 real PSA10 prices. The
+ * two paths were "mirrored by hand", so the bug existed in both.
+ *
+ * The no-clobber contract: a graded field is included ONLY when the scrape
+ * actually returned a real value for it; otherwise the key is OMITTED so
+ * the ON CONFLICT UPDATE leaves the stored column untouched. This mirrors
+ * the already-correct `tag_pop_*` omission in refresh-index and the
+ * card-detail "Refresh now" action.
+ *
+ * `graded_prices_fetched_at` advances only when PriceCharting was actually
+ * reached (`pc != null`), even if the card legitimately has no PSA10/pop —
+ * that is the "checked, nothing here" signal the chronic-miss backoff
+ * relies on. A transient miss (`pc == null`) advances nothing, so the card
+ * stays top-priority for retry and no value is destroyed.
+ */
+
+import type { PriceChartingData } from './pricecharting-scraper';
+
+export function pcGradedFields(
+	pc: PriceChartingData | null,
+	now: string
+): Record<string, unknown> {
+	// Transient / Cloudflare miss: write NOTHING graded. Omitting every key
+	// means the upsert's UPDATE clause never touches these columns, so the
+	// stored values survive and the card stays due for retry.
+	if (pc == null) return {};
+
+	// PriceCharting was reached. Record that (drives chronic-miss backoff)
+	// regardless of whether this particular card has any graded market.
+	const fields: Record<string, unknown> = { graded_prices_fetched_at: now };
+
+	if (pc.psa10 != null) {
+		fields.psa10_price = pc.psa10;
+		fields.psa10_source = 'pricecharting';
+	}
+	if (pc.tag10 != null) {
+		fields.tag10_price = pc.tag10;
+		fields.tag10_source = 'pricecharting';
+	}
+	if (pc.cgc10 != null) {
+		fields.cgc10_price = pc.cgc10;
+		fields.cgc10_source = 'pricecharting';
+	}
+	// Only a non-empty ladder — never overwrite a good ladder with {}.
+	if (pc.gradeLadder && Object.keys(pc.gradeLadder).length > 0) {
+		fields.grade_ladder = pc.gradeLadder;
+		fields.grade_ladder_fetched_at = now;
+	}
+	if (pc.psa10LastSold != null) {
+		fields.psa10_last_sold_at = pc.psa10LastSold;
+	}
+	if (pc.psaPop) {
+		fields.psa_pop_total = pc.psaPop.total;
+		fields.psa_pop_10 = pc.psaPop.grade10;
+		fields.psa_gem_rate = pc.psaPop.gemRate;
+		fields.psa_fetched_at = now;
+	}
+	if (pc.cgcPop) {
+		fields.cgc_pop_total = pc.cgcPop.total;
+		fields.cgc_pop_10 = pc.cgcPop.grade10;
+		fields.cgc_gem_rate = pc.cgcPop.gemRate;
+		fields.cgc_fetched_at = now;
+	}
+	return fields;
+}


### PR DESCRIPTION
## Incident

A 3000-card cloud enrich run on 2026-05-19 **nulled ~205 real PSA10 prices** (coverage 2239→2034, reproducible on a quiescent DB). Confirmed against the append-only `psa10_sales` ground-truth: 12 provably-PSA10 cards were nulled mid-run.

## Root cause

Both `refresh-index.ts` write paths (`enrichOneCard`, `stalePriceRow`) inlined `psa10_price: pc?.psa10 ?? null` (+ source/tag10/cgc10/ladder/pop) into the upsert row. PostgREST upsert is `INSERT … ON CONFLICT DO UPDATE` and builds the `UPDATE SET` clause from the keys **present** in the payload — so when a scrape Cloudflare-fails (`pc == null`) it wrote `NULL` over previously-good graded data. The two paths were hand-mirrored, so both carried the bug. This also better explains the long-"frozen ~10%" coverage: every fast-fail cycle was acquire-a-few / **destroy**-a-few.

## Fix

Single shared builder `pcGradedFields(pc, now)` — the same omission pattern already used correctly by the card-detail "Refresh now" action and `tag_pop_*`:

- `pc == null` → returns `{}` (zero graded keys → upsert can't touch those columns → stored values survive, card stays due for retry).
- value absent → key **omitted**, never `null`.
- `graded_prices_fetched_at` advances only when PriceCharting was actually reached (preserves chronic-miss backoff semantics).

Both paths now call the one helper, so they can't drift again.

## Verification

- New deterministic unit test for the no-clobber contract (5 cases).
- `vitest` 75/75 (70 baseline + 5).
- `svelte-check` 18/2 — **0 new** vs baseline.
- Functional dry-run: success path still emits all graded keys (base1-4 → PSA10 $28,272, pop 369, ladder).

## After merge

Re-enable the engine: `gh workflow enable engine-enrich.yml`. Clobbered cards are now null → top of the gap queue → re-acquired by future successful scrapes (the 123 `psa10_sales` cards are rebuildable from that table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)