### PR TITLE
feat(card): link Recent PSA 10 sales to the source auction

### DIFF
--- a/scripts/refresh-index.ts
+++ b/scripts/refresh-index.ts
@@ -165,7 +165,12 @@ function getHeadline(card: TcgCard): { market: number | null; low: number | null
 
 interface EnrichedCardOutput {
 	row: Record<string, unknown>;
-	psa10Sales: Array<{ sold_at: string; price: number; marketplace: string | null }>;
+	psa10Sales: Array<{
+		sold_at: string;
+		price: number;
+		marketplace: string | null;
+		url: string | null;
+	}>;
 }
 
 async function enrichOneCard(card: TcgCard): Promise<EnrichedCardOutput> {
@@ -347,9 +352,12 @@ async function indexSet(setId: string, concurrency: number, dryRun: boolean) {
 							card_id: card.id,
 							sold_at: s.sold_at,
 							price_cents: Math.round(s.price * 100),
-							marketplace: s.marketplace
+							marketplace: s.marketplace,
+							source_url: s.url
 						})),
-						{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: true }
+						// DO UPDATE (not DO NOTHING) so an already-stored sale
+						// backfills source_url/marketplace on re-scrape.
+						{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: false }
 					)
 					.then(() => {}, () => {});
 			}
@@ -627,9 +635,11 @@ async function indexStale(
 							card_id: cardId,
 							sold_at: s.sold_at,
 							price_cents: Math.round(s.price * 100),
-							marketplace: s.marketplace
+							marketplace: s.marketplace,
+							source_url: s.url
 						})),
-						{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: true }
+						// DO UPDATE so a stored sale backfills source_url.
+						{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: false }
 					)
 					.then(() => {}, () => {});
 			}
@@ -842,9 +852,10 @@ async function main() {
 						card_id: cardId,
 						sold_at: s.sold_at,
 						price_cents: Math.round(s.price * 100),
-						marketplace: s.marketplace
+						marketplace: s.marketplace,
+						source_url: s.url
 					})),
-					{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: true }
+					{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: false }
 				);
 			}
 			console.log(JSON.stringify(row, null, 2));

--- a/src/lib/services/pricecharting-scraper.ts
+++ b/src/lib/services/pricecharting-scraper.ts
@@ -85,8 +85,15 @@ export interface PriceChartingData {
 	psa10LastSold: string | null;
 	/** Up to 30 most recent PSA 10 sold comps, newest first. Each row has
 	 *  an ISO date, a USD price, and the marketplace the sale happened on
-	 *  (eBay, Goldin, Fanatics, etc.) when detectable. */
-	psa10Sales: Array<{ sold_at: string; price: number; marketplace: string | null }>;
+	 *  (eBay, Goldin, Fanatics, etc.) when detectable, and the source
+	 *  listing URL (the PriceCharting title anchor → goldin.co / ebay /
+	 *  fanatics item page) when present, so a comp can be confirmed. */
+	psa10Sales: Array<{
+		sold_at: string;
+		price: number;
+		marketplace: string | null;
+		url: string | null;
+	}>;
 	/** Full URL of the matched product page */
 	pcUrl: string;
 	/** The product name as shown on PriceCharting */
@@ -390,13 +397,18 @@ function parsePopData(html: string): { psa: PopDistribution | null; cgc: PopDist
  */
 function parsePsa10Sales(
 	html: string
-): Array<{ sold_at: string; price: number; marketplace: string | null }> {
+): Array<{ sold_at: string; price: number; marketplace: string | null; url: string | null }> {
 	const section = html.match(
 		/<div class="completed-auctions-manual-only">([\s\S]*?)<\/div>\s*<div class="/i
 	);
 	if (!section) return [];
 
-	const rows: Array<{ sold_at: string; price: number; marketplace: string | null }> = [];
+	const rows: Array<{
+		sold_at: string;
+		price: number;
+		marketplace: string | null;
+		url: string | null;
+	}> = [];
 	// Iterate each <tr>…</tr> within the section's tbody.
 	const trRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
 	for (const m of section[1].matchAll(trRegex)) {
@@ -410,10 +422,14 @@ function parsePsa10Sales(
 		// Marketplace: PriceCharting appends `[eBay]`, `[Goldin]`, `[Fanatics]`, etc.
 		// after the auction title. It's not always present on every row.
 		const mpMatch = row.match(/\[([A-Za-z][A-Za-z ]{1,40})\]/);
+		// Source listing link: the title-cell anchor PriceCharting points
+		// at the real auction (goldin.co / ebay / fanatics item page).
+		const urlMatch = row.match(/<td class="title">\s*<a\b[^>]*\bhref="([^"]+)"/i);
 		rows.push({
 			sold_at: dateMatch[1],
 			price,
-			marketplace: mpMatch ? mpMatch[1].trim() : null
+			marketplace: mpMatch ? mpMatch[1].trim() : null,
+			url: urlMatch ? urlMatch[1].replace(/&amp;/g, '&') : null
 		});
 	}
 	return rows;

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -113,14 +113,27 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 
 	// PSA 10 historical sales for the time-series list on card detail.
 	// Newest first, capped at 30 — matches what PriceCharting surfaces.
-	interface Psa10SaleRow { sold_at: string; price_cents: number; marketplace: string | null; }
-	const psa10SalesRes = await supabase
-		.from('psa10_sales')
-		.select('sold_at, price_cents, marketplace')
-		.eq('card_id', params.id)
-		.order('sold_at', { ascending: false })
-		.limit(30);
-	const psa10Sales: Psa10SaleRow[] = (psa10SalesRes.data ?? []) as Psa10SaleRow[];
+	interface Psa10SaleRow {
+		sold_at: string;
+		price_cents: number;
+		marketplace: string | null;
+		source_url?: string | null;
+	}
+	// source_url needs migration 022. Degrade gracefully if it's not yet
+	// applied (column-missing → retry without it) so the sales list never
+	// disappears just because the migration is pending.
+	const selSales = (cols: string) =>
+		supabase
+			.from('psa10_sales')
+			.select(cols)
+			.eq('card_id', params.id)
+			.order('sold_at', { ascending: false })
+			.limit(30);
+	let psa10SalesRes = await selSales('sold_at, price_cents, marketplace, source_url');
+	if (psa10SalesRes.error) {
+		psa10SalesRes = await selSales('sold_at, price_cents, marketplace');
+	}
+	const psa10Sales: Psa10SaleRow[] = (psa10SalesRes.data ?? []) as unknown as Psa10SaleRow[];
 
 	// Separate read for the PriceCharting override URL so pre-migration-012
 	// environments don't kill the whole market-signals block. Any error
@@ -450,7 +463,12 @@ export const actions: Actions = {
 			psaPop: { total: number; grade10: number; gemRate: number } | null;
 			cgcPop: { total: number; grade10: number; gemRate: number } | null;
 			psa10LastSold: string | null;
-			psa10Sales: Array<{ sold_at: string; price: number; marketplace: string | null }>;
+			psa10Sales: Array<{
+				sold_at: string;
+				price: number;
+				marketplace: string | null;
+				url: string | null;
+			}>;
 			gradeLadder?: Record<string, Record<string, number>> | null;
 		} | null = null;
 		try {
@@ -548,9 +566,12 @@ export const actions: Actions = {
 						card_id: cardId,
 						sold_at: s.sold_at,
 						price_cents: Math.round(s.price * 100),
-						marketplace: s.marketplace
+						marketplace: s.marketplace,
+						source_url: s.url
 					})),
-					{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: true }
+					// DO UPDATE so "Refresh now" backfills source_url onto
+					// sales already stored for this card.
+					{ onConflict: 'card_id,sold_at,price_cents', ignoreDuplicates: false }
 				)
 				.then(
 					() => {},

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -76,7 +76,7 @@
 	let cardSignal = $derived(data.cardSignal as CardSignal | null);
 	let gradingROI = $derived(data.gradingROI as GradingROIResult | null);
 	let similarCards = $derived((data.similarCards ?? []) as SimilarCard[]);
-	interface Psa10Sale { sold_at: string; price_cents: number; marketplace: string | null; }
+	interface Psa10Sale { sold_at: string; price_cents: number; marketplace: string | null; source_url?: string | null; }
 	let psa10Sales = $derived(((data as Record<string, unknown>).psa10Sales ?? []) as Psa10Sale[]);
 	let pcUrlOverride = $derived(((data as Record<string, unknown>).pcUrlOverride ?? null) as string | null);
 
@@ -1179,15 +1179,35 @@
 					{/if}
 					<div class="mt-3 divide-y divide-vault-border rounded-xl border border-vault-border">
 						{#each psa10Sales.slice(0, 10) as sale}
-							<div class="flex items-center justify-between gap-3 px-3 py-2 text-sm">
-								<div class="text-vault-text-muted">
-									{sale.sold_at}
-									{#if sale.marketplace}
-										<span class="ml-2 rounded bg-vault-bg px-1.5 py-0.5 text-[10px] text-vault-text-muted">{sale.marketplace}</span>
-									{/if}
+							{#if sale.source_url}
+								<a
+									href={sale.source_url}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="flex items-center justify-between gap-3 px-3 py-2 text-sm transition-colors hover:bg-vault-bg"
+									title="Open the source auction listing to confirm this sale"
+								>
+									<div class="text-vault-text-muted">
+										{sale.sold_at}
+										{#if sale.marketplace}
+											<span class="ml-2 rounded bg-vault-bg px-1.5 py-0.5 text-[10px] text-vault-purple">{sale.marketplace} ↗</span>
+										{:else}
+											<span class="ml-2 text-[10px] text-vault-purple">view ↗</span>
+										{/if}
+									</div>
+									<div class="font-medium text-white">{fmtMoney(sale.price_cents / 100)}</div>
+								</a>
+							{:else}
+								<div class="flex items-center justify-between gap-3 px-3 py-2 text-sm">
+									<div class="text-vault-text-muted">
+										{sale.sold_at}
+										{#if sale.marketplace}
+											<span class="ml-2 rounded bg-vault-bg px-1.5 py-0.5 text-[10px] text-vault-text-muted">{sale.marketplace}</span>
+										{/if}
+									</div>
+									<div class="font-medium text-white">{fmtMoney(sale.price_cents / 100)}</div>
 								</div>
-								<div class="font-medium text-white">{fmtMoney(sale.price_cents / 100)}</div>
-							</div>
+							{/if}
 						{/each}
 					</div>
 					{#if psa10Sales.length > 10}

--- a/supabase/migrations/022_psa10_sales_source_url.sql
+++ b/supabase/migrations/022_psa10_sales_source_url.sql
@@ -1,0 +1,15 @@
+-- Trove: per-sale source link for PSA 10 comps
+--
+-- PriceCharting's completed-auction rows carry an <a href> to the actual
+-- source listing (Goldin / eBay / Fanatics, e.g.
+-- https://goldin.co/item/...). We already parse date/price/marketplace
+-- from that row but discarded the link. Storing it lets the card-detail
+-- "Recent PSA 10 sales" rows deep-link to the real auction so a comp can
+-- be independently confirmed.
+--
+-- Add-only + idempotent. Existing rows backfill source_url on their next
+-- enrichment cycle (the psa10_sales upserts switch to ON CONFLICT DO
+-- UPDATE so a re-scraped sale refreshes this column).
+
+alter table psa10_sales
+    add column if not exists source_url text;


### PR DESCRIPTION
## What

Each "Recent PSA 10 sales" row on the card-detail page now links to the **real source auction** (Goldin / eBay / Fanatics) so a comp can be independently confirmed — e.g. the Magnezone LV.X Legends Awakened sale → `https://goldin.co/item/2008-pokemon-diamond-pearl-legends-awakened-holo-142-magnezone-lv-x-psl913c`.

PriceCharting's completed-auction `<tr>` already contained an `<a href>` in the title cell; `parsePsa10Sales` was throwing it away.

## Changes

- `pricecharting-scraper.ts`: parse the title-anchor href → `psa10Sales[].url`.
- **migration 022** (add-only, idempotent): `psa10_sales.source_url text`.
- All 4 `psa10_sales` upserts persist `source_url` and switch to `ON CONFLICT DO UPDATE` (was `DO NOTHING`) so sales **already stored** backfill the link on the next enrich cycle / "Refresh now".
- card loader selects `source_url`, degrading gracefully if 022 isn't applied yet (column-missing → retry without it; the sales list never disappears).
- UI: sale row becomes a `target=_blank rel=noopener` link with a `↗` affordance when a URL is present; plain row otherwise.

## ⚠️ Migration required

Apply `supabase/migrations/022_psa10_sales_source_url.sql` in the Trove Supabase SQL editor. Until then: links don't appear (loader degrades, list still works); after applying, links populate as cards are re-enriched, or immediately per-card via "Refresh now".

## Verification

- `svelte-check` 18/2 — **0 new** vs baseline.
- `vitest` 75/75.
- End-to-end: `tsx scripts/refresh-index.ts --card dp6-142 --dry-run` returns the real Goldin item URL in `psa10Sales[].url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)