### PR TITLE
Sprint 1A: Show Mode toggle + Service Worker scaffold (foundation)

### DIFF
--- a/src/lib/components/ShowModeToggle.svelte
+++ b/src/lib/components/ShowModeToggle.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { showMode } from '$stores/show-mode';
+</script>
+
+<button
+	type="button"
+	onclick={() => showMode.toggle()}
+	aria-pressed={$showMode}
+	aria-label={$showMode ? 'Turn off Show Mode' : 'Turn on Show Mode'}
+	title={$showMode
+		? 'Show Mode is ON — optimized for in-person card lookups'
+		: 'Show Mode — fast lookups for card shows + bad WiFi'}
+	class="inline-flex items-center gap-1.5 rounded-xl border px-2.5 py-1.5 text-xs font-semibold transition-all
+		{$showMode
+			? 'border-amber-400/60 bg-amber-400/10 text-amber-300 shadow-[0_0_0_1px_rgba(251,191,36,0.25)] hover:bg-amber-400/20'
+			: 'border-vault-border text-vault-text-muted hover:bg-vault-surface-hover hover:text-white'}"
+>
+	<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+		<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+	</svg>
+	<span class="hidden sm:inline">Show</span>
+</button>

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -8,3 +8,4 @@ export { default as ApiStatus } from './ApiStatus.svelte';
 export { default as Icon } from './Icon.svelte';
 export type { IconName } from './icon-names';
 export { default as CommandPalette } from './CommandPalette.svelte';
+export { default as ShowModeToggle } from './ShowModeToggle.svelte';

--- a/src/lib/stores/show-mode.ts
+++ b/src/lib/stores/show-mode.ts
@@ -1,0 +1,33 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'trove:show-mode';
+const DOM_ATTR = 'showMode';
+
+function readInitial(): boolean {
+	if (!browser) return false;
+	try {
+		return localStorage.getItem(STORAGE_KEY) === '1';
+	} catch {
+		return false;
+	}
+}
+
+const store = writable<boolean>(readInitial());
+
+if (browser) {
+	store.subscribe((value) => {
+		try {
+			localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
+		} catch {
+			// localStorage can throw in private mode / quota; show-mode UX still works in-session
+		}
+		document.documentElement.dataset[DOM_ATTR] = value ? 'on' : 'off';
+	});
+}
+
+export const showMode = {
+	subscribe: store.subscribe,
+	toggle: () => store.update((v) => !v),
+	set: (v: boolean) => store.set(v)
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/stores';
-	import { ApiStatus, Icon, CommandPalette } from '$components';
+	import { ApiStatus, Icon, CommandPalette, ShowModeToggle } from '$components';
 
 	interface Props {
 		children: import('svelte').Snippet;
@@ -138,7 +138,10 @@
 				</div>
 			</form>
 
-			<ApiStatus />
+			<div class="flex items-center gap-2">
+				<ShowModeToggle />
+				<ApiStatus />
+			</div>
 		</header>
 
 		<!-- Page content -->

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,66 @@
+/// <reference types="@sveltejs/kit" />
+/// <reference no-default-lib="true"/>
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+
+import { build, files, version } from '$service-worker';
+
+const sw = self as unknown as ServiceWorkerGlobalScope;
+
+const CACHE = `trove-static-${version}`;
+const ASSETS = [...build, ...files];
+
+sw.addEventListener('install', (event) => {
+	event.waitUntil(
+		(async () => {
+			const cache = await caches.open(CACHE);
+			await cache.addAll(ASSETS);
+		})()
+	);
+});
+
+sw.addEventListener('activate', (event) => {
+	event.waitUntil(
+		(async () => {
+			for (const key of await caches.keys()) {
+				if (key !== CACHE) await caches.delete(key);
+			}
+			await sw.clients.claim();
+		})()
+	);
+});
+
+sw.addEventListener('fetch', (event) => {
+	if (event.request.method !== 'GET') return;
+
+	const url = new URL(event.request.url);
+
+	if (url.origin !== sw.location.origin) return;
+
+	if (ASSETS.includes(url.pathname)) {
+		event.respondWith(
+			(async () => {
+				const cache = await caches.open(CACHE);
+				const cached = await cache.match(url.pathname);
+				if (cached) return cached;
+				return fetch(event.request);
+			})()
+		);
+		return;
+	}
+
+	event.respondWith(
+		(async () => {
+			try {
+				return await fetch(event.request);
+			} catch {
+				const cache = await caches.open(CACHE);
+				const cached = await cache.match(event.request);
+				if (cached) return cached;
+				throw new Error('Offline and no cached response available');
+			}
+		})()
+	);
+});
+
+export {};


### PR DESCRIPTION
## Summary

Foundation PR for the Show Mode pivot (see `project_show_mode_pivot` memory). Pure additive — no nav changes, no deletions, no UI flips yet. Sets up the plumbing that PRs 1B–1D and Sprint 3 will build on.

- **`src/lib/stores/show-mode.ts`** — writable store, persists to `localStorage['trove:show-mode']`, mirrors state to `document.documentElement.dataset.showMode` so future CSS can hook off `[data-show-mode="on"]`. SSR-safe (browser-only init/persist), tolerates private-mode/quota errors.
- **`src/lib/components/ShowModeToggle.svelte`** — header button. Off state: subtle muted. On state: amber border + glow so users see they're in show mode. Proper `aria-pressed` + `aria-label` for both states.
- **`src/routes/+layout.svelte`** — renders `<ShowModeToggle />` next to `<ApiStatus />` in the global header.
- **`src/service-worker.ts`** — minimal SW (SvelteKit's built-in registration). Precaches build + static assets at install; network-first for runtime fetches with cache fallback only when offline. Groundwork for Sprint 3's aggressive card-data caching.

## What this PR is NOT

- Not changing the sidebar (PR 1B).
- Not moving content onto `/card/[id]` (PR 1C).
- Not folding Rankings/Insights/Analytics/Watchlist (PR 1D).
- Not adding the actual high-contrast Show Mode UI (Sprint 3 builds on the data-attribute hook).

## Verification

- `svelte-check`: **0 new errors** (18 baseline matches `project_discovery_ux_wedge`)
- `vitest`: **75/75 pass**
- Production build: **1.62s**, succeeds with the new SW module
- SSR-curl confirmed toggle markup renders on `/`, `/browse`, `/collection` in the off state, positioned correctly in the header alongside `<ApiStatus />`

Client-side localStorage persistence + `dataset.showMode` mutation are not browser-exercised here (curl can't run JS), but the code paths are trivial: `localStorage.setItem` + `document.documentElement.dataset[...] = ...` inside the writable's subscribe callback that fires on every state change.

## Test plan

- [ ] Click the lightning-bolt "Show" button in the header → it turns amber, `aria-pressed="true"`
- [ ] Reload the page → button stays amber (localStorage persistence)
- [ ] DevTools → `document.documentElement.dataset.showMode` returns `"on"` when toggled
- [ ] Click again → returns to subtle/muted, localStorage cleared, dataset = `"off"`
- [ ] Application tab → Service Workers → `service-worker.js` registered (prod only; dev doesn't register)
- [ ] No console errors on any route

🤖 Generated with [Claude Code](https://claude.com/claude-code)