### PR TITLE
feat(legal): /privacy and /terms public pages

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,7 +8,7 @@ import {
 
 // Paths that don't require an authenticated session.
 // Everything else (pages AND api routes) requires login.
-const PUBLIC_PATHS = new Set(['/login', '/logout']);
+const PUBLIC_PATHS = new Set(['/login', '/logout', '/privacy', '/terms']);
 
 function isPublicPath(pathname: string): boolean {
 	if (PUBLIC_PATHS.has(pathname)) return true;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,8 +33,11 @@
 
 	let mobileMenuOpen = $state(false);
 
-	// /login uses its own standalone layout — skip the sidebar chrome there.
-	let isLoginPage = $derived($page.url.pathname === '/login');
+	// Standalone (no sidebar chrome) pages: /login, /privacy, /terms. The
+	// latter two need to be readable by unauthenticated visitors (e.g. eBay
+	// reviewers checking links from the developer-program application).
+	const STANDALONE_PATHS = new Set(['/login', '/privacy', '/terms']);
+	let isLoginPage = $derived(STANDALONE_PATHS.has($page.url.pathname));
 
 	function isActive(href: string, currentPath: string): boolean {
 		if (href === '/') return currentPath === '/';

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,0 +1,80 @@
+<svelte:head>
+	<title>Privacy Policy — Trove</title>
+	<meta name="description" content="Trove privacy policy" />
+</svelte:head>
+
+<div class="min-h-screen bg-vault-bg text-vault-text">
+	<header class="border-b border-vault-border bg-vault-surface/80 backdrop-blur-sm">
+		<div class="mx-auto flex max-w-3xl items-center gap-3 px-6 py-4">
+			<a href="/" class="flex items-center gap-3 text-white transition-opacity hover:opacity-80">
+				<div class="brand-chip h-7 w-7">
+					<svg class="h-4 w-4 text-vault-bg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" />
+						<line x1="2" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="2" />
+						<circle cx="12" cy="12" r="3" fill="currentColor" />
+					</svg>
+				</div>
+				<span class="text-lg font-bold text-gradient">Trove</span>
+			</a>
+		</div>
+	</header>
+
+	<article class="mx-auto max-w-3xl space-y-6 px-6 py-10 sm:py-16">
+		<div>
+			<h1 class="text-3xl font-bold text-white sm:text-4xl">Privacy Policy</h1>
+			<p class="mt-2 text-sm text-vault-text-muted">Last updated: May 24, 2026</p>
+		</div>
+
+		<section class="space-y-4 text-base leading-relaxed">
+			<p>
+				Trove is a personal Pokémon trading-card research tool. This page describes what data we collect
+				and how we use it.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">What we collect</h2>
+			<ul class="list-disc space-y-2 pl-6">
+				<li>Your email address, used only for sign-in.</li>
+				<li>
+					Cards you mark as owned or watched, plus any notes / target prices you attach to them. Stored
+					in our Supabase database to render your collection and watchlist when you sign in.
+				</li>
+				<li>
+					Anonymized request logs (timestamps, paths, response codes) for debugging. No request bodies,
+					no user-identifiable data.
+				</li>
+			</ul>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">What we don't do</h2>
+			<ul class="list-disc space-y-2 pl-6">
+				<li>We do not sell, share, or transmit your data to third parties.</li>
+				<li>We do not run advertising trackers.</li>
+				<li>
+					We query third-party data sources (eBay, PriceCharting, pokemontcg.io) as a research client.
+					No personally-identifiable information about you is sent to those services.
+				</li>
+			</ul>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">Data deletion</h2>
+			<p>
+				You can request deletion of all your data by emailing
+				<a class="text-vault-purple hover:underline" href="mailto:tommymarcheschi@gmail.com">
+					tommymarcheschi@gmail.com
+				</a>. We will confirm and remove within 7 days.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">Contact</h2>
+			<p>
+				Questions, concerns, or requests:
+				<a class="text-vault-purple hover:underline" href="mailto:tommymarcheschi@gmail.com">
+					tommymarcheschi@gmail.com
+				</a>.
+			</p>
+		</section>
+
+		<footer class="border-t border-vault-border pt-6 text-sm text-vault-text-muted">
+			<a class="hover:text-vault-purple" href="/terms">Terms of Service</a>
+			<span class="mx-2">·</span>
+			<a class="hover:text-vault-purple" href="/">Trove</a>
+		</footer>
+	</article>
+</div>

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,0 +1,79 @@
+<svelte:head>
+	<title>Terms of Service — Trove</title>
+	<meta name="description" content="Trove terms of service" />
+</svelte:head>
+
+<div class="min-h-screen bg-vault-bg text-vault-text">
+	<header class="border-b border-vault-border bg-vault-surface/80 backdrop-blur-sm">
+		<div class="mx-auto flex max-w-3xl items-center gap-3 px-6 py-4">
+			<a href="/" class="flex items-center gap-3 text-white transition-opacity hover:opacity-80">
+				<div class="brand-chip h-7 w-7">
+					<svg class="h-4 w-4 text-vault-bg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" />
+						<line x1="2" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="2" />
+						<circle cx="12" cy="12" r="3" fill="currentColor" />
+					</svg>
+				</div>
+				<span class="text-lg font-bold text-gradient">Trove</span>
+			</a>
+		</div>
+	</header>
+
+	<article class="mx-auto max-w-3xl space-y-6 px-6 py-10 sm:py-16">
+		<div>
+			<h1 class="text-3xl font-bold text-white sm:text-4xl">Terms of Service</h1>
+			<p class="mt-2 text-sm text-vault-text-muted">Last updated: May 24, 2026</p>
+		</div>
+
+		<section class="space-y-4 text-base leading-relaxed">
+			<h2 class="text-xl font-semibold text-white">Informational purpose only</h2>
+			<p>
+				Trove provides Pokémon TCG pricing, population, and research data for informational purposes
+				only. Prices, population reports, grade ladders, and listings are aggregated from third-party
+				sources and may be inaccurate or out of date.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">Not a marketplace or advisor</h2>
+			<p>
+				Trove is not a marketplace, broker, dealer, or financial advisor. We do not facilitate
+				transactions. Any decisions you make to buy, sell, grade, hold, or trade cards based on
+				information seen in Trove are your own responsibility — please verify data with the original
+				source before transacting.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">Not affiliated</h2>
+			<p>
+				Trove is an independent project. We are not affiliated with eBay, PriceCharting, PSA, CGC, BGS,
+				SGC, TAG Grading, The Pokémon Company International, Wizards of the Coast, or any other
+				company or grading service. All trademarks belong to their respective owners.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">No warranty</h2>
+			<p>
+				The service is provided "as is" without warranty of any kind. We may modify, suspend, or
+				discontinue the service at any time without notice.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">Acceptable use</h2>
+			<p>
+				You agree not to scrape, redistribute, or commercially resell data presented by Trove. The
+				underlying data is licensed to us by upstream providers under their terms; we may not
+				sub-license it to you.
+			</p>
+
+			<h2 class="pt-4 text-xl font-semibold text-white">Contact</h2>
+			<p>
+				Questions or concerns:
+				<a class="text-vault-purple hover:underline" href="mailto:tommymarcheschi@gmail.com">
+					tommymarcheschi@gmail.com
+				</a>.
+			</p>
+		</section>
+
+		<footer class="border-t border-vault-border pt-6 text-sm text-vault-text-muted">
+			<a class="hover:text-vault-purple" href="/privacy">Privacy Policy</a>
+			<span class="mx-2">·</span>
+			<a class="hover:text-vault-purple" href="/">Trove</a>
+		</footer>
+	</article>
+</div>


### PR DESCRIPTION
## Summary

Adds two public static pages that the eBay developer-program re-application (and other future API provider registrations) need to point to.

- `/privacy` — what Trove collects, what we don't do, deletion contact
- `/terms` — informational-only disclaimer, not-a-marketplace / not-affiliated language, contact

Both pages render with a minimal standalone layout (no sidebar) and are added to `PUBLIC_PATHS` in `hooks.server.ts` so unauthenticated visitors (eBay reviewers) can fetch them.

## Verification

- svelte-check 0-new errors (18 baseline)
- vitest 75/75
- `/privacy` and `/terms` both return 200 from the local dev server
- Both pages render with their own header (Trove logo) and no `<aside>` (no app sidebar leaks through)
- Cross-links between the two pages and back to `/` are present
- Mailto contact present in both

## Test plan

- [ ] Hit `https://pokeapp-nu.vercel.app/privacy` while signed out — should load (no /login redirect)
- [ ] Same for `/terms`
- [ ] Click "Terms of Service" link from /privacy — lands on /terms
- [ ] Click "Privacy Policy" link from /terms — lands on /privacy
- [ ] Click Trove logo from either — goes to /

🤖 Generated with [Claude Code](https://claude.com/claude-code)