### PR TITLE
Sprint 1C: CGC grading ROI on card page

### DIFF
--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -102,6 +102,33 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		  )
 		: null;
 
+	// CGC ROI — same math, with CGC's grade-10 price + gem rate + pop. The
+	// GradingROIInput field names say "psa_*" but the function is service-
+	// generic: it computes premium = (gem_rate/100) × (grade10 − raw), which
+	// works for any grader whose data we pass in. Surfaced on the card page
+	// next to the PSA ROI block so users can compare grader profitability at
+	// a glance without leaving the card view (Sprint-1 audit consolidation).
+	const cgcRow = indexRow as unknown as {
+		raw_nm_price: number | null;
+		cgc10_price: number | null;
+		cgc_gem_rate: number | null;
+		cgc_pop_total: number | null;
+	} | null;
+	const cgcGradingROI =
+		cgcRow && cgcRow.cgc10_price != null
+			? computeGradingROI(
+					{
+						raw_nm_price: cgcRow.raw_nm_price,
+						psa10_price: cgcRow.cgc10_price,
+						psa_gem_rate: cgcRow.cgc_gem_rate,
+						psa_pop_total: cgcRow.cgc_pop_total
+					},
+					'CGC' as GradingService,
+					DEFAULT_TIER_BY_SERVICE.CGC,
+					gradingFees
+			  )
+			: null;
+
 	const similarCards = indexRow
 		? await getSimilarCards(
 				params.id,
@@ -297,6 +324,7 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		gradeLadderFetchedAt,
 		cardSignal,
 		gradingROI,
+		cgcGradingROI,
 		similarCards,
 		psa10Sales,
 		pcUrlOverride,

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -75,6 +75,7 @@
 	);
 	let cardSignal = $derived(data.cardSignal as CardSignal | null);
 	let gradingROI = $derived(data.gradingROI as GradingROIResult | null);
+	let cgcGradingROI = $derived(data.cgcGradingROI as GradingROIResult | null);
 	let similarCards = $derived((data.similarCards ?? []) as SimilarCard[]);
 	interface Psa10Sale { sold_at: string; price_cents: number; marketplace: string | null; }
 	let psa10Sales = $derived(((data as Record<string, unknown>).psa10Sales ?? []) as Psa10Sale[]);
@@ -904,6 +905,50 @@
 							{#if !gradingROI.confident}
 								<p class="mt-3 text-[10px] italic text-amber-400">
 									Low PSA sample ({indexRow.psa_pop_total ?? 0} graded) — gem rate estimate is noisy.
+								</p>
+							{/if}
+						</div>
+					{/if}
+
+					<!-- Grading ROI (CGC) — same math, with CGC's grade-10 price + gem
+					     rate + pop. Renders only when CGC data exists for this card so
+					     thin-data cards stay quiet (honesty doctrine). Absorbed from
+					     /grading per the Sprint 1 simplification mandate — /grading
+					     stays alive but per-card ROI lives on the card. -->
+					{#if cgcGradingROI && cgcGradingROI.gradingCost > 0 && indexRow.raw_nm_price != null && indexRow.cgc10_price != null}
+						<div class="mt-3 rounded-xl border border-vault-border bg-vault-bg p-3 sm:p-4">
+							<div class="flex items-center justify-between">
+								<p class="text-sm font-medium text-white">Grading ROI (CGC)</p>
+								<span class="text-[10px] text-vault-text-muted">
+									{cgcGradingROI.resolvedTier?.name} · ${cgcGradingROI.gradingCost}
+								</span>
+							</div>
+							<div class="mt-3 grid grid-cols-3 gap-2 text-center">
+								<div>
+									<p class="text-[10px] text-vault-text-muted">Realistic</p>
+									<p class="mt-0.5 text-sm font-bold {cgcGradingROI.realisticProfit != null && cgcGradingROI.realisticProfit > 0 ? 'text-vault-green' : 'text-vault-red'}">
+										{cgcGradingROI.realisticProfit != null ? fmtMoney(cgcGradingROI.realisticProfit) : '—'}
+									</p>
+									<p class="text-[10px] text-vault-text-muted">using gem rate</p>
+								</div>
+								<div>
+									<p class="text-[10px] text-vault-text-muted">If it 10s</p>
+									<p class="mt-0.5 text-sm font-bold {cgcGradingROI.optimisticProfit != null && cgcGradingROI.optimisticProfit > 0 ? 'text-vault-green' : 'text-vault-red'}">
+										{cgcGradingROI.optimisticProfit != null ? fmtMoney(cgcGradingROI.optimisticProfit) : '—'}
+									</p>
+									<p class="text-[10px] text-vault-text-muted">upside cap</p>
+								</div>
+								<div>
+									<p class="text-[10px] text-vault-text-muted">Break-even</p>
+									<p class="mt-0.5 text-sm font-bold text-white">
+										{cgcGradingROI.breakEvenGemRate != null ? cgcGradingROI.breakEvenGemRate.toFixed(0) + '%' : '—'}
+									</p>
+									<p class="text-[10px] text-vault-text-muted">gem rate needed</p>
+								</div>
+							</div>
+							{#if !cgcGradingROI.confident}
+								<p class="mt-3 text-[10px] italic text-amber-400">
+									Low CGC sample ({indexRow.cgc_pop_total ?? 0} graded) — gem rate estimate is noisy.
 								</p>
 							{/if}
 						</div>


### PR DESCRIPTION
## Summary

Card page now shows grading ROI for CGC alongside the existing PSA block. Absorbs the multi-grader switching that previously required a trip to `/grading`, per the Sprint 1 simplification mandate. `/grading` route stays alive (route-preservation rule).

Per the [smart-eager-load doctrine](https://github.com/tommymarcheschi/rsmc/blob/main/.claude/projects/-Users-tommymarcheschi-dev-rsmc/memory/feedback_smart_lazy_load_pattern.md), card page is fully eager on click — no lazy section here.

## What changed

- **`src/routes/card/[id]/+page.server.ts`** — compute `cgcGradingROI` via the same `computeGradingROI` helper, passing CGC's grade-10 price + gem rate + pop as inputs. (The helper's `psa_*` field names are legacy; the math is service-generic.) Returned in PageData. A typed local cast avoids adding any new svelte-check errors over the 18-baseline.
- **`src/routes/card/[id]/+page.svelte`** — new "Grading ROI (CGC)" block rendered just below the PSA block when CGC data exists. Same rich UI pattern (realistic / if-it-10s / break-even) for consistency. Honesty-gated: card without CGC data shows no CGC block.

## Verification

- `svelte-check`: **18 errors** (baseline matched, no new)
- `vitest`: **75/75 pass**
- Live data cross-check on `swsh45sv-SV101` (Rookidee): raw $2.50, cgc10 $13, cgc_gem_rate 27.14%, cgc_pop_total 140 → confident. Renders both PSA + CGC blocks. CGC realistic profit = `0.2714 × ($13 − $2.50) − $18 = -$15.15` — matches rendered value exactly.
- `ecard3-146` (Charizard, PSA-only): renders ONLY the PSA block, no CGC. Honesty-gate confirmed.
- Both pages return 200 in <1s.

## Out of scope (deferred)

- **TAG ROI** — requires widening the `GradingService` type (`'PSA' | 'CGC' | 'BGS' | 'SGC'` → add `'TAG'`) + a TAG entry in `grading_fee_schedules`. Belongs with the Sprint 3 TAG-grading wedge work.
- **BGS / SGC ROI** — pricing not yet in the card_index projection.
- **Analytics single-card comp chart** — `/analytics` is fundamentally a multi-card surface; "this card vs similar" on the card page is a different design problem (which similars to chart, time-series availability). Own follow-up if we want it.

## Test plan

- [ ] Visit `/card/swsh45sv-SV101` — see both "Grading ROI (PSA)" and "Grading ROI (CGC)" blocks stacked
- [ ] Visit `/card/ecard3-146` — see only "Grading ROI (PSA)" block
- [ ] CGC block's "Realistic" profit color = red when negative, green when positive
- [ ] CGC block shows "Low CGC sample (N graded) — gem rate estimate is noisy" when cgc_pop_total < 20
- [ ] `/grading` route still works (`/grading` URL still loads its standalone page; not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)