### PR TITLE
Sprint 2: live-listings adapter pattern + stub provider (DO NOT MERGE WITHOUT REVIEW)

### DIFF
--- a/src/lib/components/LiveListings.svelte
+++ b/src/lib/components/LiveListings.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import type { LiveListingsResult } from '$services/live-listings';
+
+	interface Props {
+		result: LiveListingsResult | null;
+	}
+
+	let { result }: Props = $props();
+
+	function fmtMoney(cents: number): string {
+		return `$${(cents / 100).toFixed(2)}`;
+	}
+
+	function fmtAgo(iso: string): string {
+		const ms = Date.now() - new Date(iso).getTime();
+		const mins = Math.floor(ms / 60_000);
+		if (mins < 1) return 'just now';
+		if (mins < 60) return `${mins}m ago`;
+		const hrs = Math.floor(mins / 60);
+		if (hrs < 24) return `${hrs}h ago`;
+		return `${Math.floor(hrs / 24)}d ago`;
+	}
+
+	function marketplaceLabel(m: string): string {
+		switch (m) {
+			case 'ebay':
+				return 'eBay';
+			case 'tcgplayer':
+				return 'TCGPlayer';
+			case 'mercari':
+				return 'Mercari';
+			default:
+				return m;
+		}
+	}
+
+	function marketplaceClass(m: string): string {
+		switch (m) {
+			case 'ebay':
+				return 'bg-blue-500/15 text-blue-300';
+			case 'tcgplayer':
+				return 'bg-purple-500/15 text-purple-300';
+			case 'mercari':
+				return 'bg-red-500/15 text-red-300';
+			default:
+				return 'bg-vault-surface text-vault-text-muted';
+		}
+	}
+
+	function buyingLabel(b: string): string {
+		switch (b) {
+			case 'fixed_price':
+				return 'Buy Now';
+			case 'auction':
+				return 'Auction';
+			case 'best_offer':
+				return 'Best Offer';
+			default:
+				return b;
+		}
+	}
+</script>
+
+{#if result && result.listings.length > 0}
+	<div class="rounded-2xl border border-vault-border bg-vault-surface">
+		<div class="flex items-center justify-between gap-3 border-b border-vault-border px-4 py-3 sm:px-6">
+			<div class="min-w-0">
+				<div class="flex flex-wrap items-center gap-2">
+					<h2 class="font-semibold text-white">Live listings</h2>
+					{#if result.source === 'stub'}
+						<span
+							class="rounded-full bg-amber-400/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-300"
+							title="Sample data — real live-listings provider is being wired up (Sprint 2). Numbers are not market prices."
+						>
+							Sample data
+						</span>
+					{:else}
+						<span class="text-[10px] uppercase tracking-wider text-vault-text-muted">
+							via {result.source}
+						</span>
+					{/if}
+				</div>
+				{#if result.lowest_ask_cents != null}
+					<p class="mt-0.5 text-xs text-vault-text-muted">
+						Low ask: <span class="font-bold text-vault-green">{fmtMoney(result.lowest_ask_cents)}</span>
+						· {result.listings.length} active · refreshed {fmtAgo(result.fetched_at)}
+					</p>
+				{/if}
+			</div>
+		</div>
+
+		<ul class="divide-y divide-vault-border">
+			{#each result.listings as listing}
+				{@const isLow = listing.price_cents === result.lowest_ask_cents}
+				<li>
+					<a
+						href={listing.listing_url}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center gap-3 px-3 py-3 transition-colors hover:bg-vault-surface-hover sm:gap-4 sm:px-6"
+					>
+						<div class="min-w-0 flex-1">
+							<p class="truncate text-sm font-medium text-white">{listing.title}</p>
+							<div class="mt-1 flex flex-wrap items-center gap-1.5 text-[10px]">
+								<span class="rounded-full px-1.5 py-0.5 font-semibold {marketplaceClass(listing.marketplace)}">
+									{marketplaceLabel(listing.marketplace)}
+								</span>
+								<span class="rounded-full bg-vault-bg px-1.5 py-0.5 text-vault-text-muted">
+									{buyingLabel(listing.buying_option)}
+								</span>
+								{#if listing.grader}
+									<span class="rounded-full bg-vault-gold/15 px-1.5 py-0.5 font-semibold text-vault-gold">
+										{listing.grader} {listing.grade ?? ''}
+									</span>
+								{/if}
+								{#if listing.shipping_cents != null}
+									<span class="text-vault-text-muted">
+										+{listing.shipping_cents === 0 ? 'free' : fmtMoney(listing.shipping_cents)} ship
+									</span>
+								{/if}
+							</div>
+						</div>
+						<div class="flex-shrink-0 text-right">
+							<p class="text-base font-bold {isLow ? 'text-vault-green' : 'text-white'}">
+								{fmtMoney(listing.price_cents)}
+							</p>
+							{#if isLow}
+								<p class="text-[10px] font-bold uppercase tracking-wider text-vault-green">low ask</p>
+							{/if}
+						</div>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -9,3 +9,4 @@ export { default as Icon } from './Icon.svelte';
 export type { IconName } from './icon-names';
 export { default as CommandPalette } from './CommandPalette.svelte';
 export { default as ShowModeToggle } from './ShowModeToggle.svelte';
+export { default as LiveListings } from './LiveListings.svelte';

--- a/src/lib/services/live-listings/index.ts
+++ b/src/lib/services/live-listings/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Live-listings provider factory.
+ *
+ * Returns the configured provider based on the LIVE_LISTINGS_PROVIDER env
+ * var. Defaults to 'stub' so the card page never breaks for lack of a
+ * real source. When a real Path C source lands (eBay re-apply, 130point
+ * partnership, Bright Data scrape), add it here as a new branch.
+ *
+ * Keeping the factory tiny + the providers in separate files means the
+ * card page imports `getLiveListingsProvider()` and never touches a
+ * specific implementation — the swap is one line here.
+ */
+
+import { stubProvider } from './stub';
+import type { LiveListingsProvider } from './types';
+
+export type { LiveListing, LiveListingsResult, LiveListingsProvider } from './types';
+
+export function getLiveListingsProvider(): LiveListingsProvider {
+	const choice = (process.env.LIVE_LISTINGS_PROVIDER ?? 'stub').toLowerCase();
+	switch (choice) {
+		case 'stub':
+			return stubProvider;
+		// case 'ebay':     return ebayBrowseProvider;        // Sprint 2.x — when EBAY_CLIENT_ID is set
+		// case '130point': return onethreezeropointProvider; // Sprint 2.x — when partnership signed
+		// case 'brightdata': return brightDataProvider;      // Sprint 2.x — when paid subscription active
+		default:
+			// Unknown provider name = fall back to stub rather than crash. Real
+			// providers should be added explicitly here as they land.
+			return stubProvider;
+	}
+}

--- a/src/lib/services/live-listings/stub.ts
+++ b/src/lib/services/live-listings/stub.ts
@@ -1,0 +1,123 @@
+/**
+ * Stub live-listings provider — deterministic fake data for dev / demo.
+ *
+ * Used while the real path-C source is being decided / implemented
+ * (project_ebay_dev_rejected). The UI MUST render this with a "Sample
+ * data" label so users don't mistake it for real market prices (honesty
+ * doctrine, feedback_multipliers_vs_real_data).
+ *
+ * Deterministic: hashes the card_id + name to seed the count + price
+ * spread so the same card always shows the same stub listings across
+ * reloads. That avoids the "every refresh re-rolls fake numbers" look
+ * which screams placeholder, and makes the demo feel like real data.
+ */
+
+import type {
+	LiveListingsProvider,
+	FetchForCardOptions,
+	LiveListingsResult,
+	LiveListing,
+	BuyingOption
+} from './types';
+
+function hash(s: string): number {
+	let h = 0;
+	for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+	return Math.abs(h);
+}
+
+function pseudoRand(seed: number, n: number): number {
+	// Mulberry32 — small, deterministic, no dependency.
+	let t = (seed + n * 0x6d2b79f5) | 0;
+	t = Math.imul(t ^ (t >>> 15), t | 1);
+	t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+	return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+const STUB_MARKETPLACES: Array<{ name: 'ebay' | 'tcgplayer' | 'mercari'; share: number }> = [
+	{ name: 'ebay', share: 0.6 },
+	{ name: 'tcgplayer', share: 0.25 },
+	{ name: 'mercari', share: 0.15 }
+];
+
+function pickMarketplace(roll: number) {
+	let acc = 0;
+	for (const m of STUB_MARKETPLACES) {
+		acc += m.share;
+		if (roll < acc) return m.name;
+	}
+	return STUB_MARKETPLACES[0].name;
+}
+
+export const stubProvider: LiveListingsProvider = {
+	name: 'stub',
+
+	async fetchForCard(opts: FetchForCardOptions): Promise<LiveListingsResult> {
+		const seed = hash(`${opts.card_id}|${opts.name}|${opts.grader ?? ''}|${opts.grade ?? ''}`);
+		const limit = Math.min(opts.limit ?? 8, 20);
+
+		// 3–8 listings per card by default. Cards with low seed get fewer
+		// (mirrors thin-market reality where rare cards have few asks).
+		const count = 3 + (seed % 6);
+		const actualCount = Math.min(count, limit);
+
+		// Base price anchor — would come from the catalog row in reality.
+		// 5–500 with a long-ish tail.
+		const basePrice = 500 + (seed % 50000);
+		const isGradedQuery = opts.grader != null;
+		// Graded listings cost a multiple of raw.
+		const gradedMult = isGradedQuery ? 4 + ((seed >> 4) % 10) : 1;
+
+		const listings: LiveListing[] = [];
+		for (let i = 0; i < actualCount; i++) {
+			const r1 = pseudoRand(seed, i * 7 + 1);
+			const r2 = pseudoRand(seed, i * 7 + 2);
+			const r3 = pseudoRand(seed, i * 7 + 3);
+			const r4 = pseudoRand(seed, i * 7 + 4);
+
+			// Spread ±35% around the base, sorted asc by price.
+			const variance = 0.65 + r1 * 0.7;
+			const price = Math.round(basePrice * gradedMult * variance);
+			const shipping = r2 < 0.3 ? 0 : Math.round(300 + r2 * 700);
+			const buying: BuyingOption =
+				r3 < 0.7 ? 'fixed_price' : r3 < 0.85 ? 'best_offer' : 'auction';
+			const marketplace = pickMarketplace(r4);
+
+			const titleGrader = opts.grader ? `${opts.grader} ${opts.grade ?? 10} ` : '';
+			const titleRaw = opts.grader ? '' : ['NM', 'LP', 'MP'][i % 3] + ' ';
+			const title = `${titleGrader}${titleRaw}${opts.name} ${opts.set_name} ${opts.card_number}`.trim();
+
+			listings.push({
+				title,
+				price_cents: price,
+				shipping_cents: shipping,
+				condition: opts.grader ? 'graded' : 'raw',
+				grader: opts.grader ?? null,
+				grade: opts.grader ? opts.grade ?? 10 : null,
+				marketplace,
+				buying_option: buying,
+				// Stub listings link nowhere — explicit "javascript:void(0)" would
+				// trigger CSP issues + look broken; just point them at the search
+				// page for the marketplace so a click is at least useful.
+				listing_url:
+					marketplace === 'ebay'
+						? `https://www.ebay.com/sch/i.html?_nkw=${encodeURIComponent(opts.name + ' ' + opts.set_name)}`
+						: marketplace === 'tcgplayer'
+							? `https://www.tcgplayer.com/search/pokemon/product?q=${encodeURIComponent(opts.name)}`
+							: `https://www.mercari.com/search/?keyword=${encodeURIComponent(opts.name)}`,
+				image_url: null,
+				ends_at: buying === 'auction' ? new Date(Date.now() + (1 + i) * 86_400_000).toISOString() : null
+			});
+		}
+
+		listings.sort((a, b) => a.price_cents - b.price_cents);
+
+		return {
+			listings,
+			fetched_at: new Date().toISOString(),
+			source: 'stub',
+			query: `${opts.name} ${opts.set_name} ${opts.card_number}`.trim(),
+			lowest_ask_cents: listings.length > 0 ? listings[0].price_cents : null
+		};
+	}
+};

--- a/src/lib/services/live-listings/types.ts
+++ b/src/lib/services/live-listings/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Live listings — the provider-agnostic contract.
+ *
+ * Trove's first-principle (project_live_listings_first_principle) says
+ * active asking prices are first-class data alongside sold comps. The
+ * source for that data is in flux — the official eBay Browse API path is
+ * blocked (project_ebay_dev_rejected), so Sprint 2 builds against this
+ * interface and ships a stub provider. When a real Path C source unblocks
+ * (eBay re-apply, 130point partnership, Bright Data residential-proxy
+ * scrape), it implements `LiveListingsProvider` and we swap by changing
+ * the factory in `./index.ts` — no UI rework.
+ *
+ * Design choices baked in:
+ * - Cents (not dollars) for `price_cents` so we never multiply floats.
+ * - `marketplace` is a discriminated union so we can render per-source
+ *   chips ("eBay" / "TCGPlayer") and route different click-throughs.
+ * - `source` on the result is the actual provider that answered (`stub`,
+ *   `ebay-browse`, `130point-scrape`, `brightdata:ebay`...) — useful in
+ *   the UI to show "via 130point" honesty labels and in logs.
+ * - All fields nullable that can plausibly be missing from a real feed.
+ *   Don't over-promise structure the upstream may not provide.
+ */
+
+export type Marketplace = 'ebay' | 'tcgplayer' | 'mercari' | 'other';
+export type BuyingOption = 'fixed_price' | 'auction' | 'best_offer';
+export type ListingCondition = 'raw' | 'graded' | 'unknown';
+
+export interface LiveListing {
+	/** Listing title as the marketplace shows it. */
+	title: string;
+	/** Ask price in cents. For auctions, the current bid. */
+	price_cents: number;
+	/** Marketplace shipping cost in cents, if known. Null if not exposed. */
+	shipping_cents: number | null;
+	/** Raw vs graded; for graded, see `grader` + `grade` for specifics. */
+	condition: ListingCondition;
+	/** Grading service if condition === 'graded', else null. */
+	grader: 'PSA' | 'CGC' | 'BGS' | 'SGC' | 'TAG' | null;
+	/** Numeric grade if condition === 'graded' and the title parsed cleanly. */
+	grade: number | null;
+	marketplace: Marketplace;
+	buying_option: BuyingOption;
+	/** Click-through to the listing. */
+	listing_url: string;
+	/** Thumbnail for the listing. Null if not available. */
+	image_url: string | null;
+	/** Auction end time as ISO. Null for fixed-price. */
+	ends_at: string | null;
+}
+
+export interface LiveListingsResult {
+	listings: LiveListing[];
+	/** ISO timestamp the result was fetched. Drives "Last refreshed 5m ago". */
+	fetched_at: string;
+	/** Provider label for transparency in UI + logs. */
+	source: string;
+	/** What was actually searched, for debugging. */
+	query: string;
+	/** Best-effort low ask in cents across the returned listings. Null if empty. */
+	lowest_ask_cents: number | null;
+}
+
+export interface FetchForCardOptions {
+	card_id: string;
+	/** Card name from the catalog — e.g. "Charizard". */
+	name: string;
+	/** Set name — e.g. "Base Set". */
+	set_name: string;
+	/** Card number within the set — e.g. "4/102". */
+	card_number: string;
+	/** When set, filter to only listings of this grader (e.g. PSA-only). */
+	grader?: 'PSA' | 'CGC' | 'BGS' | 'SGC' | 'TAG';
+	/** When set, filter to only this grade (typically 10). */
+	grade?: number;
+	/** When set, only return raw (ungraded) listings. */
+	raw_only?: boolean;
+	/** Max listings to return. Default 20. */
+	limit?: number;
+}
+
+export interface LiveListingsProvider {
+	/** Provider name for logs + UI labels. */
+	readonly name: string;
+	/** Fetch active listings for a specific card. Best-effort: returns an empty
+	 *  result rather than throwing on transient upstream failures so the page
+	 *  still renders cached/stale data gracefully. */
+	fetchForCard(opts: FetchForCardOptions): Promise<LiveListingsResult>;
+}

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -7,6 +7,7 @@ import { supabase } from '$services/supabase';
 import { supabaseAdmin } from '$lib/server/supabase-admin';
 import { getCardSignal, getSimilarCards } from '$services/insights';
 import { computeGradingROI, DEFAULT_TIER_BY_SERVICE } from '$services/grading-roi';
+import { getLiveListingsProvider } from '$services/live-listings';
 import { buildGradeLadders, type CohortRow } from '$services/grade-estimate';
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
@@ -137,6 +138,19 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 				indexRow.psa10_price
 		  ).catch(() => [])
 		: [];
+
+	// Live active listings (project_live_listings_first_principle). Provider
+	// is selected by LIVE_LISTINGS_PROVIDER env var, defaulting to 'stub' so
+	// the page always has content. Any failure returns a null result and the
+	// UI just doesn't render the section — never crashes the page.
+	const liveListings = await getLiveListingsProvider()
+		.fetchForCard({
+			card_id: params.id,
+			name: card.name,
+			set_name: card.set?.name ?? '',
+			card_number: card.number ?? ''
+		})
+		.catch(() => null);
 
 	// PSA 10 historical sales for the time-series list on card detail.
 	// Newest first, capped at 30 — matches what PriceCharting surfaces.
@@ -325,6 +339,7 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		cardSignal,
 		gradingROI,
 		cgcGradingROI,
+		liveListings,
 		similarCards,
 		psa10Sales,
 		pcUrlOverride,

--- a/src/routes/card/[id]/+page.svelte
+++ b/src/routes/card/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-	import { PriceChart } from '$components';
+	import { PriceChart, LiveListings } from '$components';
 	import type { PokedexData, EvolutionNode } from '$types';
 	import type { PokeTracePrice } from '$services/poketrace';
 	import type { GradedPrice } from '$services/price-tracker';
@@ -76,6 +76,9 @@
 	let cardSignal = $derived(data.cardSignal as CardSignal | null);
 	let gradingROI = $derived(data.gradingROI as GradingROIResult | null);
 	let cgcGradingROI = $derived(data.cgcGradingROI as GradingROIResult | null);
+	let liveListings = $derived(
+		data.liveListings as import('$services/live-listings').LiveListingsResult | null
+	);
 	let similarCards = $derived((data.similarCards ?? []) as SimilarCard[]);
 	interface Psa10Sale { sold_at: string; price_cents: number; marketplace: string | null; }
 	let psa10Sales = $derived(((data as Record<string, unknown>).psa10Sales ?? []) as Psa10Sale[]);
@@ -611,6 +614,14 @@
 					</div>
 				</div>
 			{/if}
+
+			<!-- Live listings — first-class data alongside sold comps
+			     (project_live_listings_first_principle). Currently fed by the
+			     'stub' provider while we wait for a real path-C source
+			     (project_ebay_dev_rejected); the UI labels stub data as
+			     "Sample data" so users don't read fake numbers as real
+			     market prices. -->
+			<LiveListings result={liveListings} />
 
 			<!-- Market Signals — all data we have on this card from card_index -->
 			{#if hasMarketSignals && indexRow}


### PR DESCRIPTION
## Summary

Ships the infrastructure for the live-listings first-principle (`project_live_listings_first_principle`) without committing to any specific source. The official eBay Browse API path is blocked (`project_ebay_dev_rejected`); this PR builds against a `LiveListingsProvider` interface so whichever real Path C source unblocks first (eBay re-application, 130point partnership, Bright Data residential-proxy scrape) slots in by changing one line in the factory.

## ⚠️ Don't auto-merge

You wanted to eyeball this before it ships — the card page now has a new top-level section visible to users. Even with the "Sample data" label, please look at the visual treatment first.

## Architecture

| File | Role |
|---|---|
| `src/lib/services/live-listings/types.ts` | The contract: `LiveListingsProvider.fetchForCard(opts) → LiveListingsResult{listings, fetched_at, source, query, lowest_ask_cents}` |
| `src/lib/services/live-listings/stub.ts` | Deterministic fake-but-realistic data seeded from `card_id`. Mixed marketplaces (eBay 60% / TCGPlayer 25% / Mercari 15%). Sorted ascending by price. Click-throughs go to marketplace search pages (never broken links). |
| `src/lib/services/live-listings/index.ts` | Factory. `getLiveListingsProvider()` returns the provider chosen by `LIVE_LISTINGS_PROVIDER` env (default `stub`). Real providers get added here as they land. |
| `src/lib/components/LiveListings.svelte` | Renders the result. Amber "Sample data" chip when `source === 'stub'` (honesty doctrine — never present fake numbers as real). "Low ask" green badge on the cheapest listing. Each listing links to the marketplace's search page in a new tab. |
| `src/routes/card/[id]/+page.server.ts` | Fetches via the factory, fault-isolated (any provider failure → null → section just doesn't render). |
| `src/routes/card/[id]/+page.svelte` | Renders `<LiveListings />` at the TOP of the card content, above Market Signals. First-class placement per the locked first-principle. |

## Verification

- `svelte-check`: **18 errors** (baseline, no new)
- `vitest`: **75/75 pass**
- SSR-curl on `/card/base1-4` (Charizard Base Set):
  - 6 stub listings rendered
  - Sorted $27.06 → up (ascending)
  - "Sample data" amber chip with tooltip: *"Numbers are not market prices"*
  - Header: "Low ask: $27.06 · 6 active · refreshed just now"
  - Mixed marketplaces (eBay blue, Mercari red, TCGPlayer purple) color-coded
  - Buying-option labels ('Buy Now' / 'Best Offer' / 'Auction')
  - Shipping costs rendered

## Honesty doctrine compliance

The stub-provider data is clearly labeled. The amber "Sample data" chip is prominent, the tooltip explicitly says "Numbers are not market prices", and the listing titles ("LP Charizard Base 4") + shipping costs make it visually distinct from a real eBay search result. When a real provider lands, the chip changes to `via {provider name}` (e.g. "via 130point").

## What this PR is NOT

- Not a real live-listings source. Stub-only.
- Not a Show Mode integration. The card-page section works in standard mode AND Show Mode (Show Mode UI is Sprint 3).
- Not caching. Real providers (paid scrapes, rate-limited APIs) will need a cache layer — out of scope until a real provider lands.

## Test plan

- [ ] Visit `/card/base1-4` — see "Live listings" section at the top with "Sample data" amber chip
- [ ] 6 listings shown, sorted ascending by price
- [ ] Cheapest listing has green "low ask" badge
- [ ] Click a listing → opens marketplace search in new tab
- [ ] Visit `/card/sv8-60` (different card) — different stub listings, still labeled "Sample data"
- [ ] Visual treatment makes it obvious the data is sample / not real

## What's next

When you (or eBay's re-application reviewer) unblock a real source, build an `ebayBrowseProvider.ts` / `onethreezeroPointProvider.ts` / etc. that implements `LiveListingsProvider`, add a branch to the factory in `src/lib/services/live-listings/index.ts`, set `LIVE_LISTINGS_PROVIDER` in env, ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)