### PR TITLE
Sprint 2.x: real eBay Browse API provider (flag-gated, awaiting Erik's keys)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,16 @@ POKETRACE_API_KEY=your-api-key-here
 
 # PokemonPriceTracker (Required for grading features)
 PRICE_TRACKER_API_KEY=your-api-key-here
+
+# Live listings provider — see src/lib/services/live-listings/.
+# 'stub' (default) renders deterministic sample data clearly labeled as such.
+# 'ebay' uses the official eBay Browse API and requires EBAY_CLIENT_ID +
+# EBAY_CLIENT_SECRET below. Anything else falls back to 'stub'.
+LIVE_LISTINGS_PROVIDER=stub
+
+# eBay Browse API — production keyset from developer.ebay.com.
+# Client-credentials OAuth, scope https://api.ebay.com/oauth/api_scope.
+# Free 5k calls/day per keyset. Without both values set, the 'ebay' provider
+# fails safe and returns empty results (the page still renders).
+EBAY_CLIENT_ID=
+EBAY_CLIENT_SECRET=

--- a/src/lib/services/__tests__/live-listings-ebay-browse.test.ts
+++ b/src/lib/services/__tests__/live-listings-ebay-browse.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ebayBrowseProvider, __ebayBrowseInternals } from '../live-listings/ebay-browse';
+
+const TOKEN_URL = 'https://api.ebay.com/identity/v1/oauth2/token';
+const SEARCH_URL_PREFIX = 'https://api.ebay.com/buy/browse/v1/item_summary/search';
+
+type FetchInput = string | URL | Request;
+interface MockResponse {
+	ok: boolean;
+	status?: number;
+	json: () => Promise<unknown>;
+}
+
+function urlStr(input: FetchInput): string {
+	if (typeof input === 'string') return input;
+	if (input instanceof URL) return input.toString();
+	return input.url;
+}
+
+function makeFetch(handler: (url: string, init?: RequestInit) => MockResponse) {
+	return vi.fn(async (input: FetchInput, init?: RequestInit) =>
+		handler(urlStr(input), init) as unknown as Response
+	);
+}
+
+const baseOpts = {
+	card_id: 'base1-4',
+	name: 'Charizard',
+	set_name: 'Base Set',
+	card_number: '4/102'
+};
+
+describe('ebayBrowseProvider — fail-safe', () => {
+	beforeEach(() => {
+		__ebayBrowseInternals.resetCaches();
+		delete process.env.EBAY_CLIENT_ID;
+		delete process.env.EBAY_CLIENT_SECRET;
+	});
+
+	it('returns an empty result (does not throw) when EBAY_CLIENT_ID is missing', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+			throw new Error('should not be called');
+		});
+
+		const res = await ebayBrowseProvider.fetchForCard(baseOpts);
+		expect(res.listings).toEqual([]);
+		expect(res.source).toBe('ebay-browse');
+		expect(res.lowest_ask_cents).toBeNull();
+		expect(fetchSpy).not.toHaveBeenCalled();
+
+		fetchSpy.mockRestore();
+	});
+
+	it('returns an empty result on token-endpoint 401', async () => {
+		process.env.EBAY_CLIENT_ID = 'id';
+		process.env.EBAY_CLIENT_SECRET = 'secret';
+		const fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(
+				makeFetch(() => ({ ok: false, status: 401, json: async () => ({}) }))
+			);
+
+		const res = await ebayBrowseProvider.fetchForCard(baseOpts);
+		expect(res.listings).toEqual([]);
+		expect(res.lowest_ask_cents).toBeNull();
+
+		fetchSpy.mockRestore();
+	});
+
+	it('returns an empty result when search throws (network failure)', async () => {
+		process.env.EBAY_CLIENT_ID = 'id';
+		process.env.EBAY_CLIENT_SECRET = 'secret';
+		const fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (url: FetchInput) => {
+				if (url === TOKEN_URL) {
+					return {
+						ok: true,
+						json: async () => ({ access_token: 'tok', expires_in: 7200 })
+					} as Response;
+				}
+				throw new Error('socket reset');
+			});
+
+		const res = await ebayBrowseProvider.fetchForCard(baseOpts);
+		expect(res.listings).toEqual([]);
+
+		fetchSpy.mockRestore();
+	});
+});
+
+describe('ebayBrowseProvider — happy path', () => {
+	beforeEach(() => {
+		__ebayBrowseInternals.resetCaches();
+		process.env.EBAY_CLIENT_ID = 'id';
+		process.env.EBAY_CLIENT_SECRET = 'secret';
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('maps item summaries, sorts ascending by price, and reports the low ask', async () => {
+		const items = [
+			{
+				title: 'PSA 10 Charizard Base Set 4/102 1999',
+				price: { value: '950.00' },
+				shippingOptions: [{ shippingCost: { value: '5.00' } }],
+				condition: 'Used',
+				buyingOptions: ['FIXED_PRICE'],
+				itemWebUrl: 'https://www.ebay.com/itm/1',
+				image: { imageUrl: 'https://i.ebayimg.com/1.jpg' }
+			},
+			{
+				title: 'CGC 9.5 Charizard Base 4',
+				price: { value: '720.00' },
+				shippingOptions: [],
+				condition: 'Used',
+				buyingOptions: ['FIXED_PRICE', 'BEST_OFFER'],
+				itemWebUrl: 'https://www.ebay.com/itm/2',
+				image: { imageUrl: 'https://i.ebayimg.com/2.jpg' }
+			},
+			{
+				title: 'Charizard Base Set 4/102 Raw NM',
+				price: { value: '300.00' },
+				shippingOptions: [{ shippingCost: { value: '0' } }],
+				condition: 'Used',
+				buyingOptions: ['AUCTION'],
+				itemWebUrl: 'https://www.ebay.com/itm/3',
+				image: { imageUrl: 'https://i.ebayimg.com/3.jpg' },
+				itemEndDate: '2026-05-30T18:00:00.000Z'
+			}
+		];
+
+		let capturedUrl = '';
+		let capturedHeaders: Record<string, string> = {};
+		vi.spyOn(globalThis, 'fetch').mockImplementation(
+			async (input: FetchInput, init?: RequestInit) => {
+				const url = urlStr(input);
+				if (url === TOKEN_URL) {
+					return {
+						ok: true,
+						json: async () => ({ access_token: 'tok', expires_in: 7200 })
+					} as Response;
+				}
+				if (typeof url === 'string' && url.startsWith(SEARCH_URL_PREFIX)) {
+					capturedUrl = url;
+					capturedHeaders = (init?.headers as Record<string, string>) ?? {};
+					return {
+						ok: true,
+						json: async () => ({ itemSummaries: items })
+					} as Response;
+				}
+				throw new Error(`unexpected fetch ${String(url)}`);
+			}
+		);
+
+		const res = await ebayBrowseProvider.fetchForCard(baseOpts);
+
+		expect(capturedHeaders['X-EBAY-C-MARKETPLACE-ID']).toBe('EBAY_US');
+		expect(capturedHeaders.Authorization).toBe('Bearer tok');
+		const params = new URLSearchParams(capturedUrl.split('?')[1]);
+		expect(params.get('q')).toBe('Charizard Base Set 4/102');
+		expect(params.get('category_ids')).toBe('183454');
+		expect(params.get('sort')).toBe('price');
+		expect(params.get('filter')).toContain('buyingOptions:{FIXED_PRICE|AUCTION}');
+
+		expect(res.source).toBe('ebay-browse');
+		expect(res.listings).toHaveLength(3);
+		expect(res.listings.map((l) => l.price_cents)).toEqual([30000, 72000, 95000]);
+		expect(res.lowest_ask_cents).toBe(30000);
+
+		const psa10 = res.listings.find((l) => l.grader === 'PSA');
+		expect(psa10).toBeDefined();
+		expect(psa10?.grade).toBe(10);
+		expect(psa10?.condition).toBe('graded');
+		expect(psa10?.shipping_cents).toBe(500);
+
+		const cgc = res.listings.find((l) => l.grader === 'CGC');
+		expect(cgc?.grade).toBe(9.5);
+		expect(cgc?.buying_option).toBe('best_offer');
+
+		const auction = res.listings.find((l) => l.buying_option === 'auction');
+		expect(auction?.ends_at).toBe('2026-05-30T18:00:00.000Z');
+		expect(auction?.condition).toBe('raw');
+		expect(auction?.grader).toBeNull();
+	});
+
+	it('filters by grader + grade when requested', async () => {
+		const items = [
+			{
+				title: 'PSA 10 Charizard Base 4',
+				price: { value: '900.00' },
+				buyingOptions: ['FIXED_PRICE'],
+				itemWebUrl: 'https://www.ebay.com/itm/a'
+			},
+			{
+				title: 'PSA 9 Charizard Base 4',
+				price: { value: '400.00' },
+				buyingOptions: ['FIXED_PRICE'],
+				itemWebUrl: 'https://www.ebay.com/itm/b'
+			},
+			{
+				title: 'CGC 10 Charizard Base 4',
+				price: { value: '700.00' },
+				buyingOptions: ['FIXED_PRICE'],
+				itemWebUrl: 'https://www.ebay.com/itm/c'
+			},
+			{
+				title: 'Charizard Base 4 Raw',
+				price: { value: '250.00' },
+				buyingOptions: ['FIXED_PRICE'],
+				itemWebUrl: 'https://www.ebay.com/itm/d'
+			}
+		];
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: FetchInput) => {
+			const url = urlStr(input);
+			if (url === TOKEN_URL) {
+				return {
+					ok: true,
+					json: async () => ({ access_token: 'tok', expires_in: 7200 })
+				} as Response;
+			}
+			return {
+				ok: true,
+				json: async () => ({ itemSummaries: items })
+			} as Response;
+		});
+
+		const res = await ebayBrowseProvider.fetchForCard({
+			...baseOpts,
+			grader: 'PSA',
+			grade: 10
+		});
+		expect(res.listings).toHaveLength(1);
+		expect(res.listings[0].grader).toBe('PSA');
+		expect(res.listings[0].grade).toBe(10);
+	});
+
+	it('filters to raw-only when raw_only is set', async () => {
+		const items = [
+			{
+				title: 'PSA 10 Charizard Base 4',
+				price: { value: '900.00' },
+				buyingOptions: ['FIXED_PRICE'],
+				itemWebUrl: 'https://www.ebay.com/itm/a'
+			},
+			{
+				title: 'Charizard Base 4 Raw NM',
+				price: { value: '300.00' },
+				buyingOptions: ['FIXED_PRICE'],
+				itemWebUrl: 'https://www.ebay.com/itm/b'
+			}
+		];
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: FetchInput) => {
+			const url = urlStr(input);
+			if (url === TOKEN_URL) {
+				return {
+					ok: true,
+					json: async () => ({ access_token: 'tok', expires_in: 7200 })
+				} as Response;
+			}
+			return { ok: true, json: async () => ({ itemSummaries: items }) } as Response;
+		});
+
+		const res = await ebayBrowseProvider.fetchForCard({ ...baseOpts, raw_only: true });
+		expect(res.listings).toHaveLength(1);
+		expect(res.listings[0].condition).toBe('raw');
+	});
+
+	it('caches by card key — second call within TTL does not re-hit the search endpoint', async () => {
+		const fetchImpl = vi.fn(async (input: FetchInput) => {
+			const url = urlStr(input);
+			if (url === TOKEN_URL) {
+				return {
+					ok: true,
+					json: async () => ({ access_token: 'tok', expires_in: 7200 })
+				} as Response;
+			}
+			return {
+				ok: true,
+				json: async () => ({
+					itemSummaries: [
+						{
+							title: 'Charizard',
+							price: { value: '100' },
+							buyingOptions: ['FIXED_PRICE'],
+							itemWebUrl: 'https://www.ebay.com/itm/x'
+						}
+					]
+				})
+			} as Response;
+		});
+		vi.spyOn(globalThis, 'fetch').mockImplementation(fetchImpl);
+
+		await ebayBrowseProvider.fetchForCard(baseOpts);
+		await ebayBrowseProvider.fetchForCard(baseOpts);
+
+		const searchCalls = fetchImpl.mock.calls.filter(([u]) =>
+			typeof u === 'string' && u.startsWith(SEARCH_URL_PREFIX)
+		);
+		expect(searchCalls).toHaveLength(1);
+	});
+});

--- a/src/lib/services/live-listings/ebay-browse.ts
+++ b/src/lib/services/live-listings/ebay-browse.ts
@@ -1,0 +1,320 @@
+/**
+ * eBay Browse API live-listings provider.
+ *
+ * Implements `LiveListingsProvider` against eBay's official Browse API
+ * (project_ebay_listings_path). Uses client-credentials OAuth — no end-user
+ * sign-in — and the `/buy/browse/v1/item_summary/search` endpoint for active
+ * fixed-price + auction listings, scoped to category 183454 (Pokémon TCG).
+ *
+ * Credentials are Erik's borrowed keyset (project_ebay_dev_rejected). His
+ * keyset = his daily quota — we cache aggressively (30 min/card) to stay
+ * well under the 5k/day default ceiling.
+ *
+ * Fail-safe: with no `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET` in env, every
+ * call returns an empty result rather than throwing. The factory in
+ * `./index.ts` only routes here when `LIVE_LISTINGS_PROVIDER=ebay` is
+ * explicitly set, so the page keeps working on the stub otherwise.
+ */
+
+import type {
+	BuyingOption,
+	FetchForCardOptions,
+	LiveListing,
+	LiveListingsProvider,
+	LiveListingsResult,
+	ListingCondition,
+	Marketplace
+} from './types';
+
+const SOURCE = 'ebay-browse';
+const TOKEN_URL = 'https://api.ebay.com/identity/v1/oauth2/token';
+const SEARCH_URL = 'https://api.ebay.com/buy/browse/v1/item_summary/search';
+const MARKETPLACE_HEADER = 'EBAY_US';
+const POKEMON_TCG_CATEGORY = '183454';
+const CACHE_TTL_MS = 30 * 60 * 1000;
+// Token TTL is 7200s per eBay docs; renew a minute early to avoid edge expiry.
+const TOKEN_RENEW_LEAD_MS = 60 * 1000;
+
+interface TokenCache {
+	token: string;
+	expires_at: number;
+}
+let tokenCache: TokenCache | null = null;
+let tokenInFlight: Promise<string | null> | null = null;
+
+interface CacheEntry {
+	result: LiveListingsResult;
+	expires_at: number;
+}
+const listingCache = new Map<string, CacheEntry>();
+
+function emptyResult(query: string): LiveListingsResult {
+	return {
+		listings: [],
+		fetched_at: new Date().toISOString(),
+		source: SOURCE,
+		query,
+		lowest_ask_cents: null
+	};
+}
+
+function cacheKey(opts: FetchForCardOptions): string {
+	return [
+		opts.card_id,
+		opts.grader ?? '',
+		opts.grade ?? '',
+		opts.raw_only ? 'raw' : '',
+		opts.limit ?? 20
+	].join('|');
+}
+
+async function getAccessToken(): Promise<string | null> {
+	const clientId = process.env.EBAY_CLIENT_ID;
+	const clientSecret = process.env.EBAY_CLIENT_SECRET;
+	if (!clientId || !clientSecret) return null;
+
+	const now = Date.now();
+	if (tokenCache && tokenCache.expires_at - TOKEN_RENEW_LEAD_MS > now) {
+		return tokenCache.token;
+	}
+
+	// Coalesce concurrent renewals — if a refresh is already in flight, await it
+	// instead of stampeding the token endpoint.
+	if (tokenInFlight) return tokenInFlight;
+
+	tokenInFlight = (async () => {
+		try {
+			const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+			const body = new URLSearchParams({
+				grant_type: 'client_credentials',
+				scope: 'https://api.ebay.com/oauth/api_scope'
+			});
+			const res = await fetch(TOKEN_URL, {
+				method: 'POST',
+				headers: {
+					Authorization: `Basic ${basic}`,
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body
+			});
+			if (!res.ok) return null;
+			const json = (await res.json()) as { access_token?: string; expires_in?: number };
+			if (!json.access_token) return null;
+			const ttlSec = json.expires_in ?? 7200;
+			tokenCache = {
+				token: json.access_token,
+				expires_at: Date.now() + ttlSec * 1000
+			};
+			return tokenCache.token;
+		} catch {
+			return null;
+		} finally {
+			tokenInFlight = null;
+		}
+	})();
+
+	return tokenInFlight;
+}
+
+// Title heuristics. eBay listings encode condition + grader + grade in free
+// text — there is no clean structured field for "PSA 10". These regexes cover
+// the patterns vendors actually use; anything ambiguous falls back to nulls.
+const GRADER_PATTERNS: Array<{ grader: NonNullable<LiveListing['grader']>; re: RegExp }> = [
+	{ grader: 'PSA', re: /\bPSA\s*(\d{1,2})\b/i },
+	{ grader: 'CGC', re: /\bCGC\s*(\d{1,2}(?:\.\d)?)\b/i },
+	{ grader: 'BGS', re: /\bBGS\s*(\d{1,2}(?:\.\d)?)\b/i },
+	{ grader: 'SGC', re: /\bSGC\s*(\d{1,2}(?:\.\d)?)\b/i },
+	{ grader: 'TAG', re: /\bTAG\s*(\d{1,3}(?:\.\d)?)\b/i }
+];
+
+function parseGradedFromTitle(
+	title: string
+): { grader: LiveListing['grader']; grade: number | null } {
+	for (const { grader, re } of GRADER_PATTERNS) {
+		const m = title.match(re);
+		if (m) {
+			const grade = parseFloat(m[1]);
+			return { grader, grade: Number.isFinite(grade) ? grade : null };
+		}
+	}
+	return { grader: null, grade: null };
+}
+
+function inferCondition(
+	title: string,
+	apiCondition: string | undefined
+): ListingCondition {
+	if (parseGradedFromTitle(title).grader != null) return 'graded';
+	// eBay's `condition` strings: "New", "Used", "Like New", "Pre-Owned", etc.
+	// All of those are raw for a single Pokémon card.
+	if (apiCondition && /new|used|pre-?owned|like new|mint/i.test(apiCondition)) return 'raw';
+	if (/\b(NM|LP|MP|HP|DMG|near mint|raw|ungraded)\b/i.test(title)) return 'raw';
+	return 'unknown';
+}
+
+function mapBuyingOption(options: string[] | undefined): BuyingOption {
+	if (!options || options.length === 0) return 'fixed_price';
+	// eBay returns an array, e.g. ["FIXED_PRICE", "BEST_OFFER"]. Prefer the
+	// most user-facing semantic — auction beats best-offer beats fixed-price.
+	const upper = options.map((o) => o.toUpperCase());
+	if (upper.includes('AUCTION')) return 'auction';
+	if (upper.includes('BEST_OFFER')) return 'best_offer';
+	return 'fixed_price';
+}
+
+function priceToCents(value: string | number | undefined): number | null {
+	if (value == null) return null;
+	const n = typeof value === 'string' ? parseFloat(value) : value;
+	if (!Number.isFinite(n)) return null;
+	return Math.round(n * 100);
+}
+
+interface EbayItemSummary {
+	title?: string;
+	price?: { value?: string; currency?: string };
+	shippingOptions?: Array<{ shippingCost?: { value?: string } }>;
+	condition?: string;
+	buyingOptions?: string[];
+	itemWebUrl?: string;
+	image?: { imageUrl?: string };
+	itemEndDate?: string;
+}
+
+function mapItem(item: EbayItemSummary): LiveListing | null {
+	const price_cents = priceToCents(item.price?.value);
+	if (price_cents == null) return null;
+	const title = item.title ?? '';
+	const url = item.itemWebUrl;
+	if (!url) return null;
+
+	const { grader, grade } = parseGradedFromTitle(title);
+	const condition = inferCondition(title, item.condition);
+	const buying = mapBuyingOption(item.buyingOptions);
+
+	return {
+		title,
+		price_cents,
+		shipping_cents: priceToCents(item.shippingOptions?.[0]?.shippingCost?.value),
+		condition,
+		grader: condition === 'graded' ? grader : null,
+		grade: condition === 'graded' ? grade : null,
+		marketplace: 'ebay' satisfies Marketplace,
+		buying_option: buying,
+		listing_url: url,
+		image_url: item.image?.imageUrl ?? null,
+		ends_at: buying === 'auction' ? item.itemEndDate ?? null : null
+	};
+}
+
+function buildQuery(opts: FetchForCardOptions): string {
+	return [opts.name, opts.set_name, opts.card_number].filter(Boolean).join(' ').trim();
+}
+
+function buildSearchParams(opts: FetchForCardOptions, q: string): URLSearchParams {
+	const limit = Math.min(opts.limit ?? 20, 50);
+	const params = new URLSearchParams({
+		q,
+		category_ids: POKEMON_TCG_CATEGORY,
+		limit: String(limit),
+		sort: 'price'
+	});
+
+	// Filter syntax is comma-separated `key:{val|val}` clauses.
+	const filters: string[] = ['buyingOptions:{FIXED_PRICE|AUCTION}'];
+
+	if (opts.grader && opts.grade != null) {
+		// eBay's `condition` enum doesn't model graded cards distinctly; vendors
+		// encode grading in the title. Narrow by also requiring the grader name
+		// + grade to appear via a description filter — this is best-effort, the
+		// final source of truth is the title-parse on the way back.
+		// (eBay doesn't accept arbitrary text filters; the title-parse is the
+		// only reliable gate. We leave the API filter list to non-text axes.)
+	} else if (opts.raw_only) {
+		// "NEW" + "USED_*" cover all raw-card listings.
+		filters.push('conditions:{NEW|USED_EXCELLENT|USED_VERY_GOOD|USED_GOOD|USED_ACCEPTABLE}');
+	}
+
+	params.set('filter', filters.join(','));
+	return params;
+}
+
+function filterByGraderGrade(
+	listings: LiveListing[],
+	grader: FetchForCardOptions['grader'],
+	grade: FetchForCardOptions['grade'],
+	raw_only: boolean | undefined
+): LiveListing[] {
+	if (grader) {
+		return listings.filter(
+			(l) => l.grader === grader && (grade == null || l.grade === grade)
+		);
+	}
+	if (raw_only) {
+		return listings.filter((l) => l.condition === 'raw');
+	}
+	return listings;
+}
+
+export const ebayBrowseProvider: LiveListingsProvider = {
+	name: SOURCE,
+
+	async fetchForCard(opts: FetchForCardOptions): Promise<LiveListingsResult> {
+		const query = buildQuery(opts);
+		const key = cacheKey(opts);
+		const now = Date.now();
+		const cached = listingCache.get(key);
+		if (cached && cached.expires_at > now) {
+			return cached.result;
+		}
+
+		const token = await getAccessToken();
+		if (!token) return emptyResult(query);
+
+		try {
+			const params = buildSearchParams(opts, query);
+			const res = await fetch(`${SEARCH_URL}?${params}`, {
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'X-EBAY-C-MARKETPLACE-ID': MARKETPLACE_HEADER,
+					Accept: 'application/json'
+				}
+			});
+			if (!res.ok) {
+				// Cache a short empty result on 4xx/5xx so a sustained eBay outage
+				// doesn't hammer the upstream on every page view. 5 min is short
+				// enough that a real recovery shows up promptly.
+				const stale = emptyResult(query);
+				listingCache.set(key, { result: stale, expires_at: now + 5 * 60 * 1000 });
+				return stale;
+			}
+			const json = (await res.json()) as { itemSummaries?: EbayItemSummary[] };
+			const raw = (json.itemSummaries ?? [])
+				.map(mapItem)
+				.filter((l): l is LiveListing => l != null);
+			const filtered = filterByGraderGrade(raw, opts.grader, opts.grade, opts.raw_only);
+			filtered.sort((a, b) => a.price_cents - b.price_cents);
+
+			const result: LiveListingsResult = {
+				listings: filtered,
+				fetched_at: new Date().toISOString(),
+				source: SOURCE,
+				query,
+				lowest_ask_cents: filtered.length > 0 ? filtered[0].price_cents : null
+			};
+			listingCache.set(key, { result, expires_at: now + CACHE_TTL_MS });
+			return result;
+		} catch {
+			return emptyResult(query);
+		}
+	}
+};
+
+// Exported for tests only — lets the test reset the in-process token + listing
+// caches between cases without resorting to module re-import tricks.
+export const __ebayBrowseInternals = {
+	resetCaches(): void {
+		tokenCache = null;
+		tokenInFlight = null;
+		listingCache.clear();
+	}
+};

--- a/src/lib/services/live-listings/provider.ts
+++ b/src/lib/services/live-listings/provider.ts
@@ -11,6 +11,7 @@
  * state — so this file is safe to load in any runtime.
  */
 
+import { ebayBrowseProvider } from './ebay-browse';
 import { stubProvider } from './stub';
 import type { FetchForCardOptions, LiveListingsProvider } from './types';
 
@@ -19,7 +20,8 @@ export function getLiveListingsProvider(): LiveListingsProvider {
 	switch (choice) {
 		case 'stub':
 			return stubProvider;
-		// case 'ebay':     return ebayBrowseProvider;        // Sprint 2.x — when EBAY_CLIENT_ID is set
+		case 'ebay':
+			return ebayBrowseProvider;
 		// case '130point': return onethreezeropointProvider; // Sprint 2.x — when partnership signed
 		// case 'brightdata': return brightDataProvider;      // Sprint 2.x — when paid subscription active
 		default:


### PR DESCRIPTION
## Summary

Implements the real eBay Browse API behind the `LiveListingsProvider` interface shipped in [rsmc#45](https://github.com/tommymarcheschi/rsmc/pull/45). Drops in as a swap-the-source change: set `LIVE_LISTINGS_PROVIDER=ebay` + `EBAY_CLIENT_ID` + `EBAY_CLIENT_SECRET` and the Live Listings card-page section becomes real eBay active asks.

## ⚠️ Safe to merge code-wise, gate flip is the real ship event

The default `LIVE_LISTINGS_PROVIDER` remains `stub`, so merging this PR changes nothing user-visible until the env flip. The provider also fail-safes to an empty result when the eBay keys are missing — never throws, never breaks the page. Merging without the keys is harmless but pointless feature-wise; ideal sequencing is to wait for Erik's keys, validate end-to-end against real eBay responses on a preview deploy, then merge + flip.

Replaces closed [rsmc#46](https://github.com/tommymarcheschi/rsmc/pull/46) (closed automatically when its base branch was deleted by the merge of #45).

## Files

- `src/lib/services/live-listings/ebay-browse.ts` (new) — `LiveListingsProvider` implementation
- `src/lib/services/live-listings/index.ts` — wires `case 'ebay': return ebayBrowseProvider`
- `.env.example` — documents `LIVE_LISTINGS_PROVIDER`, `EBAY_CLIENT_ID`, `EBAY_CLIENT_SECRET`
- `src/lib/services/__tests__/live-listings-ebay-browse.test.ts` (new) — 7 tests

## OAuth + endpoint

- POST `https://api.ebay.com/identity/v1/oauth2/token` with Basic-auth client credentials + scope `https://api.ebay.com/oauth/api_scope`; token TTL ~7200s, cached in-process with a 60s renewal lead. Concurrent renewals coalesced via a single in-flight promise so we never stampede the token endpoint.
- GET `/buy/browse/v1/item_summary/search` with `X-EBAY-C-MARKETPLACE-ID: EBAY_US`, params `q={name} {set_name} {card_number}`, `category_ids=183454`, `filter=buyingOptions:{FIXED_PRICE|AUCTION}`, `limit=20`, `sort=price`. Raw-only search adds eBay's `conditions:{NEW|USED_*}` filter.

## Mapping

| LiveListing field | Source |
|---|---|
| `price_cents` | `price.value` × 100 |
| `shipping_cents` | `shippingOptions[0].shippingCost.value` × 100 (nullable) |
| `condition` | inferred — `graded` if title parses; else mapped from eBay's `condition` |
| `grader` + `grade` | regex parse over title: `/(PSA\|CGC\|BGS\|SGC\|TAG)\s*(\d+(\.\d)?)/i` |
| `buying_option` | `buyingOptions[]`, prefer `auction` > `best_offer` > `fixed_price` |
| `listing_url` | `itemWebUrl` |
| `image_url` | `image.imageUrl` (nullable) |
| `ends_at` | `itemEndDate` (only when `auction`) |

When `fetchForCard` is called with `grader`/`grade`/`raw_only`, we filter the mapped listings client-side — eBay's API doesn't model graded distinctly, so title-parse is the only reliable gate.

## Erik's quota — protected by aggressive cache

- **Per-(card, grader, grade, raw_only) cache, 30-min TTL** on success.
- **5-min negative cache** on 4xx/5xx so a sustained eBay outage doesn't hammer the upstream on every card view.
- Token cached for full 7200s minus 60s.

Back-of-envelope: even at 100 unique-card views/hour with single-grader access, daily call count sits in the low thousands — well under the 5k/day default ceiling.

## Fail-safe

- No `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET` in env → token returns null → empty `LiveListingsResult`, never throws.
- Token endpoint 4xx/5xx → empty result.
- Network failure mid-fetch → caught, empty result.
- All three paths verified by tests.

## Verification

- `svelte-check`: **18 errors** (baseline from main — zero net new)
- `vitest`: **82/82 pass** (was 75, +7 new)
- Local SSR-curl, `LIVE_LISTINGS_PROVIDER` unset (default): `/card/base1-4` renders \"Live listings\" + \"Sample data\" chip (stub path intact).
- Local SSR-curl, `LIVE_LISTINGS_PROVIDER=ebay`, no keys: `/card/base1-4` returns HTTP 200, bootstrap shows `source:\"ebay-browse\"` + `listings:[]`, component hides itself gracefully. Fail-safe confirmed live.

## Flip-it-on checklist (when Erik delivers keys)

- [ ] Set `EBAY_CLIENT_ID` + `EBAY_CLIENT_SECRET` in Vercel env (Production + Preview)
- [ ] Set `LIVE_LISTINGS_PROVIDER=ebay` in Vercel env
- [ ] Add the same three to `.env.local` for local dev
- [ ] Visit `/card/base1-4` — confirm \"Live listings\" chip says \"via ebay-browse\", prices look like real eBay numbers, click-throughs land on real `itemWebUrls`
- [ ] Watch first day's quota burn — should sit well under 5k

🤖 Generated with [Claude Code](https://claude.com/claude-code)