### PR TITLE
feat(card): SWR cache + popularity log for live listings

### DIFF
--- a/src/lib/services/live-listings/cache.ts
+++ b/src/lib/services/live-listings/cache.ts
@@ -1,0 +1,154 @@
+/**
+ * SWR cache wrapper for live-listings providers.
+ *
+ * Why this exists: the card page used to call the provider on every load
+ * (src/routes/card/[id]/+page.server.ts). Fine for the stub, but as soon
+ * as a real provider lands (eBay Browse, scraper) that's an upstream call
+ * per page view — wastes budget and adds latency. This wrapper turns each
+ * page view into a single Postgres lookup, and only hits the provider
+ * when the row is missing or older than the TTL.
+ *
+ * Stale-while-revalidate semantics:
+ *   - Fresh hit  → return cached, no provider call.
+ *   - Stale hit  → return cached, fire-and-forget refresh for next time.
+ *   - Cache miss → await the provider, store, return.
+ *
+ * The fire-and-forget refresh is best-effort. On Vercel the function
+ * instance can be frozen before the unawaited promise completes; that's
+ * OK — the cache stays stale one more cycle and the NEXT request kicks
+ * off another revalidate. The cache always catches up eventually.
+ *
+ * One row per (card_id, query_key) so PSA-only / raw-only / unfiltered
+ * fetches don't clobber each other. Key derivation lives here so the
+ * upstream `FetchForCardOptions` is the single source of truth.
+ */
+
+import { supabase } from '$services/supabase';
+import { supabaseAdmin } from '$lib/server/supabase-admin';
+import { stubProvider } from './stub';
+import type { FetchForCardOptions, LiveListingsProvider, LiveListingsResult } from './types';
+
+const DEFAULT_TTL_SECONDS = 6 * 60 * 60; // 6h — listings move fast, but not hourly fast.
+
+interface CachedRow {
+	payload: LiveListingsResult;
+	fetched_at: string;
+	provider: string;
+}
+
+/**
+ * Stable, human-readable cache key for a fetch options bundle. Sorted
+ * deterministically so {grader, grade} and {grade, grader} hash the same.
+ */
+export function deriveQueryKey(opts: FetchForCardOptions): string {
+	const parts: string[] = [];
+	if (opts.grader) parts.push(`grader=${opts.grader}`);
+	if (opts.grade != null) parts.push(`grade=${opts.grade}`);
+	if (opts.raw_only) parts.push('raw_only=1');
+	if (opts.limit != null) parts.push(`limit=${opts.limit}`);
+	return parts.length === 0 ? 'all' : parts.join('&');
+}
+
+/**
+ * SWR read: returns cached payload when fresh, cached-plus-background-
+ * refresh when stale, fetches synchronously on cache miss. Returns null
+ * only when the cache is empty AND the provider also fails.
+ */
+export async function getCachedOrFetch(
+	provider: LiveListingsProvider,
+	opts: FetchForCardOptions,
+	ttlSeconds: number = DEFAULT_TTL_SECONDS
+): Promise<LiveListingsResult | null> {
+	const queryKey = deriveQueryKey(opts);
+
+	// Anon client read — migration 022 grants anon SELECT, so this works
+	// during SSR without needing a service-role round-trip.
+	const { data: cached } = await supabase
+		.from('live_listings_cache')
+		.select('payload, fetched_at, provider')
+		.eq('card_id', opts.card_id)
+		.eq('query_key', queryKey)
+		.maybeSingle<CachedRow>();
+
+	const ageMs = cached ? Date.now() - new Date(cached.fetched_at).getTime() : Infinity;
+	const isFresh = ageMs < ttlSeconds * 1000;
+
+	if (cached && isFresh) {
+		return cached.payload;
+	}
+
+	if (cached && !isFresh) {
+		// Stale → return cached, kick off background refresh.
+		void refreshAndStore(provider, opts, queryKey);
+		return cached.payload;
+	}
+
+	// Cache miss → must wait so the user gets data this render.
+	return await refreshAndStore(provider, opts, queryKey);
+}
+
+async function refreshAndStore(
+	provider: LiveListingsProvider,
+	opts: FetchForCardOptions,
+	queryKey: string
+): Promise<LiveListingsResult | null> {
+	let result: LiveListingsResult | null = null;
+	try {
+		result = await provider.fetchForCard(opts);
+	} catch {
+		// Provider failed — don't poison the cache; just return null and let
+		// the existing-cached-row (if any) keep serving on the next read.
+		return null;
+	}
+
+	// Persist via service-role: anon role has no write policy (migration
+	// 022 keeps writes service-role-only, matching the engine-table posture
+	// from migration 018). If supabaseAdmin is null (env not configured)
+	// the data still rendered — just nothing got cached.
+	if (supabaseAdmin && result) {
+		await supabaseAdmin
+			.from('live_listings_cache')
+			.upsert(
+				{
+					card_id: opts.card_id,
+					query_key: queryKey,
+					provider: result.source,
+					payload: result,
+					lowest_ask_cents: result.lowest_ask_cents,
+					listings_count: result.listings.length,
+					fetched_at: result.fetched_at
+				},
+				{ onConflict: 'card_id,query_key' }
+			)
+			.then(({ error }) => {
+				// Swallow — caching is best-effort. A logged warning is fine
+				// but throwing here would break a working page render.
+				if (error) console.warn('[live-listings cache] upsert failed:', error.message);
+			});
+	}
+
+	return result;
+}
+
+/**
+ * Fire-and-forget popularity log. Records that `card_id` was viewed so
+ * the warming cron can rank cards by recent hits. Errors are swallowed —
+ * the page should NEVER fail because the popularity log is unreachable.
+ *
+ * Caller does not await; the promise dangles intentionally. The Supabase
+ * client batches the insert into its own request, so the SSR response is
+ * not blocked on the network round-trip.
+ */
+export function logCardQueryHit(card_id: string): void {
+	if (!supabaseAdmin) return;
+	void supabaseAdmin
+		.from('card_query_log')
+		.insert({ card_id })
+		.then(({ error }) => {
+			if (error) console.warn('[card_query_log] insert failed:', error.message);
+		});
+}
+
+// Re-export the default provider for callers that want to bypass the
+// factory — keeps the import surface small for the common case.
+export { stubProvider };

--- a/src/lib/services/live-listings/index.ts
+++ b/src/lib/services/live-listings/index.ts
@@ -15,6 +15,7 @@ import { stubProvider } from './stub';
 import type { LiveListingsProvider } from './types';
 
 export type { LiveListing, LiveListingsResult, LiveListingsProvider } from './types';
+export { getCachedOrFetch, logCardQueryHit, deriveQueryKey } from './cache';
 
 export function getLiveListingsProvider(): LiveListingsProvider {
 	const choice = (process.env.LIVE_LISTINGS_PROVIDER ?? 'stub').toLowerCase();

--- a/src/routes/card/[id]/+page.server.ts
+++ b/src/routes/card/[id]/+page.server.ts
@@ -7,7 +7,11 @@ import { supabase } from '$services/supabase';
 import { supabaseAdmin } from '$lib/server/supabase-admin';
 import { getCardSignal, getSimilarCards } from '$services/insights';
 import { computeGradingROI, DEFAULT_TIER_BY_SERVICE } from '$services/grading-roi';
-import { getLiveListingsProvider } from '$services/live-listings';
+import {
+	getLiveListingsProvider,
+	getCachedOrFetch,
+	logCardQueryHit
+} from '$services/live-listings';
 import { buildGradeLadders, type CohortRow } from '$services/grade-estimate';
 import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
@@ -139,18 +143,25 @@ export const load: PageServerLoad = async ({ params, setHeaders }) => {
 		  ).catch(() => [])
 		: [];
 
-	// Live active listings (project_live_listings_first_principle). Provider
-	// is selected by LIVE_LISTINGS_PROVIDER env var, defaulting to 'stub' so
-	// the page always has content. Any failure returns a null result and the
-	// UI just doesn't render the section — never crashes the page.
-	const liveListings = await getLiveListingsProvider()
-		.fetchForCard({
-			card_id: params.id,
-			name: card.name,
-			set_name: card.set?.name ?? '',
-			card_number: card.number ?? ''
-		})
-		.catch(() => null);
+	// Live active listings (project_live_listings_first_principle). Goes
+	// through the SWR cache wrapper so each page view is a Postgres lookup
+	// instead of an upstream provider call. The provider only runs when
+	// the cache row is missing or older than the TTL (default 6h); stale
+	// rows are returned immediately while a background refresh repopulates
+	// for the next read. Any failure returns null and the UI section just
+	// doesn't render — never crashes the page.
+	const liveListings = await getCachedOrFetch(getLiveListingsProvider(), {
+		card_id: params.id,
+		name: card.name,
+		set_name: card.set?.name ?? '',
+		card_number: card.number ?? ''
+	}).catch(() => null);
+
+	// Popularity log: fire-and-forget. Feeds the warming cron's "what's
+	// hot?" ranking so we can pre-fetch the most-viewed cards before the
+	// next user lands on them. Never blocks the render; insert errors are
+	// swallowed inside logCardQueryHit.
+	logCardQueryHit(params.id);
 
 	// PSA 10 historical sales for the time-series list on card detail.
 	// Newest first, capped at 30 — matches what PriceCharting surfaces.

--- a/supabase/migrations/022_live_listings_cache.sql
+++ b/supabase/migrations/022_live_listings_cache.sql
@@ -1,0 +1,69 @@
+-- Trove: live_listings cache + SWR read path
+--
+-- WHY: the card page currently calls the live-listings provider on every
+-- single load (src/routes/card/[id]/+page.server.ts → getLiveListingsProvider().fetchForCard).
+-- That's fine for the stub (sync, deterministic) but as soon as a real
+-- provider lands (eBay Browse, 130point scrape, residential-proxy scrape),
+-- every card page view = an outbound API/scrape call. Three problems:
+--   1. Wasted budget (eBay Browse = 5k/day cap),
+--   2. Page latency spikes on cold sources,
+--   3. No way to feed a "delta hunter" surface (SELECT … FROM live_listings
+--      JOIN card_index) — the data has to be persisted somewhere first.
+--
+-- This table stores the LAST result per (card_id, query_key) so a card page
+-- read is a single Postgres lookup, and the provider is only invoked when
+-- the row is missing or older than the TTL (default 6h). Stale-while-
+-- revalidate: when the row exists but is stale, the page returns cached
+-- immediately and a background fetch is fired to refresh for next time.
+--
+-- query_key encodes the filter combo so PSA-only / raw-only / all get
+-- their own cache rows — otherwise a PSA-10-only fetch would clobber the
+-- general "all listings" row.
+--
+-- ADD-ONLY and idempotent.
+
+create table if not exists live_listings_cache (
+    card_id           text        not null,
+    -- Filter key: "all" | "grader=PSA&grade=10" | "raw_only=1" | etc.
+    -- Derived in app code so the schema doesn't have to grow a column for
+    -- every new filter dimension. Stable serialization is the caller's job.
+    query_key         text        not null default 'all',
+    -- Which provider produced this row: 'stub' | 'ebay-browse' | '130point' | ...
+    -- Surfaced in UI for honesty labels and used to gate cache TTLs per
+    -- source (real providers may want longer TTLs than the stub).
+    provider          text        not null,
+    -- Full LiveListingsResult — listings array + fetched_at + source + query
+    -- + lowest_ask_cents. Storing the whole object means a cache hit needs
+    -- zero transformation back into what the UI already consumes.
+    payload           jsonb       not null,
+    -- Denormalized for cheap sort/filter queries — the "delta hunter"
+    -- surface ("biggest gap between last sold and cheapest active ask")
+    -- needs to range-scan this without parsing payload jsonb on every row.
+    lowest_ask_cents  integer,
+    listings_count    integer     not null default 0,
+    fetched_at        timestamptz not null default now(),
+    primary key (card_id, query_key)
+);
+
+-- Range-scan support for the delta-hunter feed and any "all cards with
+-- live asks under $X" surface. Partial index — only rows that actually
+-- have a price are useful for sort/filter.
+create index if not exists live_listings_cache_lowest_ask_idx
+    on live_listings_cache (lowest_ask_cents)
+    where lowest_ask_cents is not null;
+
+-- Drives the warming cron's "what's stalest?" query. Covers staleness
+-- sweeps and the SWR check ("is this row older than TTL?").
+create index if not exists live_listings_cache_fetched_at_idx
+    on live_listings_cache (fetched_at);
+
+-- RLS posture matches migration 018: anon = SELECT only, writes are
+-- service-role only (the SWR wrapper does writes via supabaseAdmin).
+-- Without an explicit anon SELECT policy, the card page (which reads via
+-- the publishable-key anon client during SSR) gets a silent HTTP-200 with
+-- zero rows — the exact bug project_publishable_key_card_index documents.
+alter table live_listings_cache enable row level security;
+grant select on live_listings_cache to anon, authenticated;
+drop policy if exists "public read live_listings_cache" on live_listings_cache;
+create policy "public read live_listings_cache" on live_listings_cache
+    for select to anon, authenticated using (true);

--- a/supabase/migrations/023_card_query_log.sql
+++ b/supabase/migrations/023_card_query_log.sql
@@ -1,0 +1,45 @@
+-- Trove: card view popularity log (drives priority warming + delta-hunter)
+--
+-- WHY: the live_listings cache (migration 022) needs a "warming" cron that
+-- pre-fetches popular cards before users visit them — otherwise the first
+-- visitor to a cold card pays the provider-latency tax. To pick what's
+-- popular, we need to know what's actually being viewed. This table is the
+-- raw signal: every card page load appends one row, fire-and-forget.
+--
+-- Append-only intentionally. Roll-ups + cleanup (e.g. "delete rows older
+-- than 90d", "materialize top-100 weekly") happen in app/cron code, not
+-- here. Keeping the source table dumb means we can change the rollup
+-- without losing history.
+--
+-- Volume math: if we hit 100k card-page views/month, that's ~100k rows/mo
+-- = ~1.2M/yr. At ~50 bytes/row that's ~60MB/yr — trivial. Long-term we
+-- can add a partition or a 90-day TTL but premature for current traffic.
+--
+-- ADD-ONLY and idempotent.
+
+create table if not exists card_query_log (
+    -- Surrogate PK so duplicate (card_id, hit_at) within the same ms is
+    -- legal (concurrent SSR renders for the same card). bigserial > uuid
+    -- here because we don't need cross-shard uniqueness.
+    id      bigserial   primary key,
+    card_id text        not null,
+    hit_at  timestamptz not null default now()
+);
+
+-- Top-N-by-recent-hits query: WHERE hit_at > now() - '7 days' GROUP BY
+-- card_id ORDER BY count(*) DESC LIMIT 100. The (card_id, hit_at) index
+-- supports both the group-by and the per-card "last viewed at" lookup the
+-- card page may want eventually.
+create index if not exists card_query_log_card_id_hit_at_idx
+    on card_query_log (card_id, hit_at desc);
+
+-- Time-range scans for window queries and eventual cleanup
+-- (DELETE … WHERE hit_at < now() - '90 days').
+create index if not exists card_query_log_hit_at_idx
+    on card_query_log (hit_at desc);
+
+-- RLS: writes are service-role only (the card page server load uses
+-- supabaseAdmin to insert). NO anon read policy — this is internal
+-- popularity data, not user-facing. The warming cron also runs as
+-- service-role so it bypasses RLS anyway.
+alter table card_query_log enable row level security;


### PR DESCRIPTION
## Summary

- Two new tables (`live_listings_cache`, `card_query_log`) + SWR wrapper in `cache.ts` so card-page views become Postgres lookups instead of provider calls.
- Card page now goes through `getCachedOrFetch()` and fires `logCardQueryHit()` per view.
- TTL 6h, stale-while-revalidate (fresh→cached, stale→cached + background refresh, miss→sync fetch). Per-`(card_id, query_key)` so PSA-only / raw-only fetches don't clobber.
- Lays groundwork for: real eBay provider (drop in behind existing factory), warming cron (top-N by 7d hits in `card_query_log`), delta-hunter view (range-scan `lowest_ask_cents` partial index).

## Why

Stub provider works fine on every load; real providers (eBay Browse 5k/day cap, scrape budgets) would burn through quota and add latency tax otherwise.

## Migrations

Both **already applied to prod 2026-05-25**. Add-only + idempotent; safe to re-run.

- `022_live_listings_cache.sql` — cache table, partial index on `lowest_ask_cents`, RLS + anon read policy (matches migration 018 posture).
- `023_card_query_log.sql` — append-only `(card_id, hit_at)` with composite + time-range indexes. RLS on, no anon policies (internal popularity data).

## Test plan

- [x] `npm run check` — no new typecheck errors (18 pre-existing in unrelated code)
- [x] Local dev server: 2 page loads of `/card/base1-4` succeeded, zero cache-layer warnings
- [x] Service-role REST cross-check: `live_listings_cache` has 1 row (`provider=stub`, `lowest_ask=$27.06`, `listings_count=6`), `card_query_log` has 2 rows (one per load)
- [x] Cache hit confirmed: second-load `fetched_at` did not advance → provider was skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)