### PR TITLE
feat(sleepers): delta-hunter discovery surface at /sleepers

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,10 @@
 	const primaryNav = [
 		{ href: '/', label: 'Dashboard', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6' },
 		{ href: '/browse', label: 'Browse', icon: 'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z' },
+		// Discovery surface — biggest live-ask-vs-sold-comp gaps. Lives in
+		// the primary nav alongside Browse so it's a peer scouting view,
+		// not buried under More (vendor-grade tool per north-star).
+		{ href: '/sleepers', label: 'Sleepers', icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z' },
 		{ href: '/collection', label: 'Collection', icon: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10' }
 	];
 

--- a/src/routes/sleepers/+page.server.ts
+++ b/src/routes/sleepers/+page.server.ts
@@ -1,0 +1,267 @@
+/**
+ * Delta-hunter discovery surface.
+ *
+ * Joins live_listings_cache (lowest active ask, in cents) against
+ * card_index (last-sold comp, in dollars) and ranks by the gap — the
+ * "sleepers" with the biggest spread between what someone's asking
+ * right now and what the same card recently cleared for. Vendor-grade
+ * scouting tool, mirroring 130point's sold+live pairing
+ * (project_vendor_tools_benchmark).
+ *
+ * Read-only: anon SELECT on live_listings_cache works (migration 022),
+ * and we never write back here. The cache rows are populated by the
+ * card-page SWR wrapper and the warming cron — this page only consumes.
+ *
+ * Honesty doctrine: while `LIVE_LISTINGS_PROVIDER` is unset/stub, every
+ * row's `provider` is "stub", so the UI shows a SAMPLE DATA badge per
+ * row. % under is omitted when the sold comp is missing — we don't
+ * fabricate a percentage out of a null comp.
+ */
+
+import { supabase } from '$services/supabase';
+import type { PageServerLoad } from './$types';
+import type { LiveListingsResult } from '$services/live-listings';
+
+const PAGE_SIZE = 50;
+type Filter = 'all' | 'raw' | 'graded';
+type SortMode = 'absolute' | 'percent';
+
+interface CacheRow {
+	card_id: string;
+	query_key: string;
+	provider: string;
+	payload: LiveListingsResult;
+	lowest_ask_cents: number;
+	listings_count: number;
+	fetched_at: string;
+}
+
+interface IndexRow {
+	card_id: string;
+	name: string | null;
+	set_name: string | null;
+	card_number: string | null;
+	image_small_url: string | null;
+	raw_nm_price: number | null;
+	psa10_price: number | null;
+	cgc10_price: number | null;
+	tag10_price: number | null;
+}
+
+export interface SleeperRow {
+	card_id: string;
+	name: string;
+	set_name: string;
+	card_number: string;
+	image_small_url: string | null;
+	lowest_ask_cents: number;
+	lowest_ask_marketplace: string | null;
+	lowest_ask_url: string | null;
+	sold_comp_cents: number | null;
+	sold_comp_label: string;
+	condition: 'raw' | 'graded';
+	grader: string | null;
+	delta_cents: number | null;
+	delta_pct: number | null;
+	provider: string;
+	fetched_at: string;
+	query_key: string;
+}
+
+export const load: PageServerLoad = async ({ url, setHeaders }) => {
+	// Match the rest of the app: never cache the HTML doc itself (Vercel
+	// deploys would otherwise serve stale shells referencing dead hashed
+	// JS bundles). See /browse loader for the full rationale.
+	setHeaders({ 'cache-control': 'private, no-cache, must-revalidate' });
+
+	const filterParam = (url.searchParams.get('filter') ?? 'all') as Filter;
+	const filter: Filter = filterParam === 'raw' || filterParam === 'graded' ? filterParam : 'all';
+	const sortParam = (url.searchParams.get('sort') ?? 'absolute') as SortMode;
+	const sortMode: SortMode = sortParam === 'percent' ? 'percent' : 'absolute';
+	const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1') || 1);
+
+	// Pull every cache row with a real lowest ask. The partial index from
+	// migration 022 (`live_listings_cache_lowest_ask_idx`) covers this.
+	// Cache size is bounded by warming-cron N (default 100) plus organic
+	// card-page hits, so fetching the whole set + ranking in memory is
+	// cheap and lets us compute the per-row delta without a DB view.
+	const { data: cacheRows, error: cacheErr } = await supabase
+		.from('live_listings_cache')
+		.select('card_id, query_key, provider, payload, lowest_ask_cents, listings_count, fetched_at')
+		.not('lowest_ask_cents', 'is', null)
+		.returns<CacheRow[]>();
+
+	if (cacheErr) {
+		// Don't 500 — render the empty state with the error visible so the
+		// page is debuggable in prod without log access.
+		return emptyResult(filter, sortMode, page, cacheErr.message);
+	}
+
+	const rows = cacheRows ?? [];
+	if (rows.length === 0) {
+		return emptyResult(filter, sortMode, page, null);
+	}
+
+	// Batch-fetch the card_index rows for everything in the cache. anon
+	// SELECT was restored in migration 018 (see project_publishable_key_card_index).
+	const cardIds = Array.from(new Set(rows.map((r) => r.card_id)));
+	const { data: indexRows } = await supabase
+		.from('card_index')
+		.select(
+			'card_id, name, set_name, card_number, image_small_url, raw_nm_price, psa10_price, cgc10_price, tag10_price'
+		)
+		.in('card_id', cardIds)
+		.returns<IndexRow[]>();
+
+	const indexByCardId = new Map<string, IndexRow>();
+	for (const r of indexRows ?? []) indexByCardId.set(r.card_id, r);
+
+	const enriched: SleeperRow[] = [];
+	for (const row of rows) {
+		const idx = indexByCardId.get(row.card_id);
+		// Without a catalog row we can't render name/set/image — skip rather
+		// than show a hollow line. (Cache rows for unknown card_ids are
+		// possible if the warming cron raced an upstream deletion.)
+		if (!idx) continue;
+
+		const { condition, grader } = classifyRow(row);
+
+		// Sold-comp dollars → cents to match the live-ask cents unit.
+		const soldDollars = pickSoldComp(idx, condition, grader);
+		const soldCents = soldDollars != null ? Math.round(soldDollars * 100) : null;
+
+		// Delta is only meaningful when both sides exist.
+		const deltaCents = soldCents != null ? soldCents - row.lowest_ask_cents : null;
+		const deltaPct =
+			soldCents != null && soldCents > 0 ? (deltaCents! / soldCents) * 100 : null;
+
+		// Apply filter chip before pushing — keeps the in-memory sort small.
+		if (filter === 'raw' && condition !== 'raw') continue;
+		if (filter === 'graded' && condition !== 'graded') continue;
+
+		// Surface the cheapest listing's marketplace + URL so the user can
+		// click straight through. payload.listings is sorted asc by price
+		// in both the stub and the real eBay provider.
+		const lowListing = row.payload.listings?.[0] ?? null;
+
+		enriched.push({
+			card_id: row.card_id,
+			name: idx.name ?? row.card_id,
+			set_name: idx.set_name ?? '',
+			card_number: idx.card_number ?? '',
+			image_small_url: idx.image_small_url ?? null,
+			lowest_ask_cents: row.lowest_ask_cents,
+			lowest_ask_marketplace: lowListing?.marketplace ?? null,
+			lowest_ask_url: lowListing?.listing_url ?? null,
+			sold_comp_cents: soldCents,
+			sold_comp_label: soldCompLabel(condition, grader),
+			condition,
+			grader,
+			delta_cents: deltaCents,
+			delta_pct: deltaPct,
+			provider: row.provider,
+			fetched_at: row.fetched_at,
+			query_key: row.query_key
+		});
+	}
+
+	// Sort: nulls (missing sold comps, so no computable gap) sink to the
+	// end regardless of sort mode — they're shown for completeness but
+	// can't be ranked against rows where we know the gap. Honesty rule:
+	// don't synthesize a default to keep them in the running.
+	enriched.sort((a, b) => {
+		const aKey = sortMode === 'percent' ? a.delta_pct : a.delta_cents;
+		const bKey = sortMode === 'percent' ? b.delta_pct : b.delta_cents;
+		if (aKey == null && bKey == null) return 0;
+		if (aKey == null) return 1;
+		if (bKey == null) return -1;
+		return bKey - aKey;
+	});
+
+	const totalCount = enriched.length;
+	const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+	const from = (page - 1) * PAGE_SIZE;
+	const pageRows = enriched.slice(from, from + PAGE_SIZE);
+
+	// Whether the SAMPLE DATA badge applies at all — if every row is
+	// real-source data, drop the page-level callout (per-row badge still
+	// renders for individual stub rows if any sneak through).
+	const anyStub = pageRows.some((r) => r.provider === 'stub');
+
+	return {
+		filter,
+		sortMode,
+		page,
+		totalPages,
+		pageSize: PAGE_SIZE,
+		totalCount,
+		rows: pageRows,
+		anyStub,
+		errorMsg: null as string | null
+	};
+};
+
+function emptyResult(
+	filter: Filter,
+	sortMode: SortMode,
+	page: number,
+	errorMsg: string | null
+) {
+	return {
+		filter,
+		sortMode,
+		page,
+		totalPages: 1,
+		pageSize: PAGE_SIZE,
+		totalCount: 0,
+		rows: [] as SleeperRow[],
+		anyStub: false,
+		errorMsg
+	};
+}
+
+/**
+ * Decide whether a cache row represents a raw-listing fetch or a
+ * graded-listing fetch. Prefer the explicit query_key signal (deterministic),
+ * fall back to inspecting the actual cheapest listing in the payload (covers
+ * the query_key='all' case where the provider may have returned either).
+ */
+function classifyRow(row: CacheRow): {
+	condition: 'raw' | 'graded';
+	grader: string | null;
+} {
+	const key = row.query_key;
+	const graderMatch = key.match(/grader=([A-Z]+)/);
+	if (graderMatch) return { condition: 'graded', grader: graderMatch[1] };
+	if (key.includes('raw_only=1')) return { condition: 'raw', grader: null };
+
+	// Fallback to the payload's cheapest listing — see task spec: "pick
+	// based on the cache row's query_key or the listings in the payload".
+	const low = row.payload.listings?.[0];
+	if (low?.condition === 'graded') {
+		return { condition: 'graded', grader: low.grader ?? null };
+	}
+	return { condition: 'raw', grader: null };
+}
+
+function pickSoldComp(idx: IndexRow, condition: 'raw' | 'graded', grader: string | null): number | null {
+	if (condition === 'raw') return idx.raw_nm_price;
+	switch (grader) {
+		case 'PSA':
+			return idx.psa10_price;
+		case 'CGC':
+			return idx.cgc10_price;
+		case 'TAG':
+			return idx.tag10_price;
+		default:
+			// Graded but unknown service — best-effort PSA10 (the most
+			// common graded comp), still labeled "PSA 10" for honesty.
+			return idx.psa10_price;
+	}
+}
+
+function soldCompLabel(condition: 'raw' | 'graded', grader: string | null): string {
+	if (condition === 'raw') return 'Raw NM';
+	if (grader) return `${grader} 10`;
+	return 'PSA 10';
+}

--- a/src/routes/sleepers/+page.svelte
+++ b/src/routes/sleepers/+page.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	function href(overrides: Record<string, string | number | undefined>): string {
+		const p = new URLSearchParams();
+		const base: Record<string, string> = {
+			filter: data.filter,
+			sort: data.sortMode
+		};
+		for (const [k, v] of Object.entries(base)) if (v) p.set(k, v);
+		if (!('page' in overrides)) p.delete('page');
+		for (const [k, v] of Object.entries(overrides)) {
+			if (v === undefined || v === '') p.delete(k);
+			else p.set(k, String(v));
+		}
+		const s = p.toString();
+		return s ? `/sleepers?${s}` : '/sleepers';
+	}
+
+	function money(cents: number): string {
+		return `$${(cents / 100).toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 })}`;
+	}
+
+	function fmtAgo(iso: string): string {
+		const ms = Date.now() - new Date(iso).getTime();
+		const mins = Math.floor(ms / 60_000);
+		if (mins < 1) return 'just now';
+		if (mins < 60) return `${mins}m ago`;
+		const hrs = Math.floor(mins / 60);
+		if (hrs < 24) return `${hrs}h ago`;
+		return `${Math.floor(hrs / 24)}d ago`;
+	}
+
+	function marketplaceLabel(m: string | null): string {
+		switch (m) {
+			case 'ebay':
+				return 'eBay';
+			case 'tcgplayer':
+				return 'TCGPlayer';
+			case 'mercari':
+				return 'Mercari';
+			default:
+				return m ?? 'unknown';
+		}
+	}
+
+	function marketplaceClass(m: string | null): string {
+		switch (m) {
+			case 'ebay':
+				return 'bg-blue-500/15 text-blue-300';
+			case 'tcgplayer':
+				return 'bg-purple-500/15 text-purple-300';
+			case 'mercari':
+				return 'bg-red-500/15 text-red-300';
+			default:
+				return 'bg-vault-surface text-vault-text-muted';
+		}
+	}
+</script>
+
+<svelte:head><title>Sleepers · Trove</title></svelte:head>
+
+<div class="mx-auto max-w-7xl">
+	<header class="mb-6">
+		<h1 class="text-2xl font-bold text-gradient">Sleepers</h1>
+		<p class="mt-1 text-sm text-vault-text-muted">
+			Cards where the cheapest live ask sits well below the last sold comp — the
+			biggest spreads first. Click through to verify the listing before you act;
+			active asks move fast.
+		</p>
+	</header>
+
+	{#if data.anyStub}
+		<div
+			class="mb-4 rounded-card border border-amber-400/30 bg-amber-400/5 p-3 text-xs text-amber-300"
+		>
+			<span class="font-bold uppercase tracking-wider">Sample data</span> —
+			the live-listings provider is currently the deterministic stub, so these
+			"sleepers" are fabricated for layout/QA. Numbers become real once
+			<code class="rounded bg-amber-400/10 px-1 py-0.5">LIVE_LISTINGS_PROVIDER</code>
+			is flipped to a real source (eBay Browse / 130point).
+		</div>
+	{/if}
+
+	<!-- Filter chips + sort toggle -->
+	<div class="mb-4 flex flex-wrap items-center gap-3">
+		<div class="flex gap-1">
+			{#each [['all', 'All'], ['raw', 'Raw only'], ['graded', 'Graded only']] as [val, label]}
+				<a
+					href={href({ filter: val, page: undefined })}
+					class="rounded-chip px-3 py-1.5 text-xs font-medium transition-colors
+						{data.filter === val
+							? 'bg-vault-purple text-white'
+							: 'bg-vault-surface text-vault-text-muted hover:bg-vault-surface-hover hover:text-white'}"
+				>{label}</a>
+			{/each}
+		</div>
+		<div class="flex gap-1">
+			{#each [['absolute', '$ delta'], ['percent', '% under']] as [val, label]}
+				<a
+					href={href({ sort: val, page: undefined })}
+					class="rounded-chip px-3 py-1.5 text-xs font-medium transition-colors
+						{data.sortMode === val
+							? 'bg-vault-accent text-white'
+							: 'bg-vault-surface text-vault-text-muted hover:bg-vault-surface-hover hover:text-white'}"
+				>{label}</a>
+			{/each}
+		</div>
+		<span class="ml-auto text-xs text-vault-text-muted">
+			{data.totalCount.toLocaleString()} cards · page {data.page}/{data.totalPages}
+		</span>
+	</div>
+
+	{#if data.errorMsg}
+		<div class="rounded-card border border-vault-red/40 bg-vault-red/10 p-4 text-sm text-vault-red">
+			Couldn't read live listings: {data.errorMsg}
+		</div>
+	{:else if data.rows.length === 0}
+		<div class="rounded-card border border-vault-border bg-vault-surface p-8 text-center">
+			<p class="text-vault-text">No sleepers yet.</p>
+			<p class="mt-2 text-sm text-vault-text-muted">
+				The live-listings cache is empty for this filter. As card pages get
+				viewed and the warming cron runs, this list fills in.
+			</p>
+		</div>
+	{:else}
+		<ul class="space-y-2">
+			{#each data.rows as r (r.card_id + '|' + r.query_key)}
+				<li class="rounded-card border border-vault-border bg-vault-surface transition-colors hover:bg-vault-surface-hover">
+					<a href={`/card/${r.card_id}`} class="flex items-center gap-3 p-3 sm:gap-4 sm:p-4">
+						<!-- Thumbnail -->
+						<div class="flex-shrink-0">
+							{#if r.image_small_url}
+								<img
+									src={r.image_small_url}
+									alt=""
+									class="h-20 w-auto rounded border border-vault-border"
+									loading="lazy"
+								/>
+							{:else}
+								<div class="flex h-20 w-14 items-center justify-center rounded border border-vault-border bg-vault-bg text-[10px] text-vault-text-muted">no image</div>
+							{/if}
+						</div>
+
+						<!-- Name + set + ask metadata -->
+						<div class="min-w-0 flex-1">
+							<div class="flex flex-wrap items-center gap-1.5">
+								<p class="truncate font-semibold text-white">{r.name}</p>
+								{#if r.provider === 'stub'}
+									<span
+										class="rounded-full bg-amber-400/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-300"
+										title="Sample data — real live-listings provider not yet wired up."
+									>
+										sample data
+									</span>
+								{/if}
+								<span class="rounded-full bg-vault-bg px-2 py-0.5 text-[10px] uppercase tracking-wider text-vault-text-muted">
+									{r.condition === 'graded' ? (r.grader ?? 'graded') + ' 10' : 'raw'}
+								</span>
+							</div>
+							<p class="mt-0.5 text-xs text-vault-text-muted">
+								{r.set_name}{#if r.card_number} · #{r.card_number}{/if}
+							</p>
+							<div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+								<span class="text-vault-text-muted">
+									Low ask:
+									<span class="font-bold text-vault-green">{money(r.lowest_ask_cents)}</span>
+									{#if r.lowest_ask_marketplace}
+										<span class="ml-1 rounded-full px-1.5 py-0.5 font-semibold {marketplaceClass(r.lowest_ask_marketplace)}">
+											{marketplaceLabel(r.lowest_ask_marketplace)}
+										</span>
+									{/if}
+								</span>
+								<span class="text-vault-text-muted">
+									Last sold ({r.sold_comp_label}):
+									{#if r.sold_comp_cents != null}
+										<span class="font-bold text-vault-text">{money(r.sold_comp_cents)}</span>
+									{:else}
+										<span class="italic text-vault-text-muted/60">no comp</span>
+									{/if}
+								</span>
+								<span class="text-[10px] text-vault-text-muted/60">
+									refreshed {fmtAgo(r.fetched_at)}
+								</span>
+							</div>
+						</div>
+
+						<!-- Delta -->
+						<div class="flex-shrink-0 text-right">
+							{#if r.delta_cents != null && r.delta_cents > 0}
+								<p class="text-xl font-bold text-vault-green">
+									{money(r.delta_cents)}
+								</p>
+								<p class="text-[10px] uppercase tracking-wider text-vault-green">
+									delta{#if r.delta_pct != null} · {r.delta_pct.toFixed(0)}% under{/if}
+								</p>
+							{:else if r.delta_cents != null}
+								<!-- Ask is at or above the sold comp — not a sleeper, but
+								     still shown so the user can see the full distribution. -->
+								<p class="text-xl font-bold text-vault-text-muted">
+									{money(r.delta_cents)}
+								</p>
+								<p class="text-[10px] uppercase tracking-wider text-vault-text-muted">
+									{r.delta_pct != null && r.delta_pct < 0 ? 'over comp' : 'at comp'}
+								</p>
+							{:else}
+								<!-- No sold comp = no percentage; honesty doctrine. -->
+								<p class="text-sm italic text-vault-text-muted">no comp to compare</p>
+							{/if}
+						</div>
+					</a>
+				</li>
+			{/each}
+		</ul>
+
+		<!-- Pagination -->
+		<div class="mt-4 flex items-center justify-between text-sm">
+			<a
+				href={data.page > 1 ? href({ page: data.page - 1 }) : undefined}
+				class="rounded-xl px-3 py-1.5 {data.page > 1
+					? 'bg-vault-surface text-vault-text hover:bg-vault-surface-hover'
+					: 'pointer-events-none opacity-30'}"
+				aria-disabled={data.page <= 1}
+			>← Prev</a>
+			<span class="text-vault-text-muted">Page {data.page} of {data.totalPages}</span>
+			<a
+				href={data.page < data.totalPages ? href({ page: data.page + 1 }) : undefined}
+				class="rounded-xl px-3 py-1.5 {data.page < data.totalPages
+					? 'bg-vault-surface text-vault-text hover:bg-vault-surface-hover'
+					: 'pointer-events-none opacity-30'}"
+				aria-disabled={data.page >= data.totalPages}
+			>Next →</a>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary

- New **/sleepers** route — server-loaded ranked list that joins `live_listings_cache.lowest_ask_cents` against `card_index` sold comps and surfaces the biggest gaps first. Vendor-grade scouting tool, mirroring 130point's sold+live pairing (see `project_vendor_tools_benchmark`).
- Filter chips (All / Raw only / Graded only) + sort toggle (\$ delta vs % under), 50/page pagination.
- Sidebar entry promoted to **primary nav** as a peer to Browse — discovery is first-class, not buried under More.
- **SAMPLE DATA** badge at page + row level while `provider='stub'`; drops automatically once `LIVE_LISTINGS_PROVIDER` flips to a real source.

Sold-comp selection is driven by the cache row's `query_key` (`grader=PSA/CGC/TAG` → psa10/cgc10/tag10; `raw_only=1` → raw_nm; `all` → fall back to the payload's cheapest listing's condition). % under is omitted when no comp is available — honesty doctrine; no fabricated percentages.

## How it works

- Reads `live_listings_cache` via anon SELECT (migration 022 already grants this).
- Batch-fetches matching `card_index` rows (name/set/image/sold-comp columns) and joins in memory.
- Computes delta per row, sorts (nulls sink), paginates server-side.
- Cache size is bounded by warming-cron N + organic card-page hits, so the whole-set in-memory rank is cheap.

## Test plan

- [x] `/sleepers` returns HTTP 200 and renders header + filter chips + row content
- [x] Per-row math verified end-to-end (base1-4 Charizard: ask \$27.06 vs raw_nm \$555.88 → \$528.82 delta, 95% under) — cross-checked against service-role read of `card_index`
- [x] Filter variants (`filter=raw|graded`) return 200; `filter=graded` correctly renders empty state (cache only has raw rows today)
- [x] Sort variants (`sort=absolute|percent`) and `page=2` return 200
- [x] `SAMPLE DATA` badge renders at page + row level for stub rows
- [x] Sidebar nav entry visible on `/` and `/sleepers` (both desktop and mobile share `primaryNav`)
- [x] `svelte-check` introduces no new errors

Memory updated: `project_live_listings_cache.md` now marks delta-hunter as done (was "next move #3").

🤖 Generated with [Claude Code](https://claude.com/claude-code)