### PR TITLE
feat(show): /show — standalone card-show search-engine page

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,10 @@
 	import '../app.css';
 	import { page } from '$app/stores';
 	import { ApiStatus, Icon, CommandPalette, ShowModeToggle } from '$components';
-	import { showMode } from '$stores/show-mode';
+	// `showMode` store no longer read here — the sidebar Show button is now
+	// a link to /show (project_show_mode_page). The header ShowModeToggle
+	// component still reads the store on its own; a follow-up PR can
+	// retire it entirely along with the store.
 
 	interface Props {
 		children: import('svelte').Snippet;
@@ -37,10 +40,13 @@
 
 	let mobileMenuOpen = $state(false);
 
-	// Standalone (no sidebar chrome) pages: /login, /privacy, /terms. The
-	// latter two need to be readable by unauthenticated visitors (e.g. eBay
-	// reviewers checking links from the developer-program application).
-	const STANDALONE_PATHS = new Set(['/login', '/privacy', '/terms']);
+	// Standalone (no sidebar chrome) pages: /login, /privacy, /terms, /show.
+	// /privacy + /terms need to be readable by unauthenticated visitors
+	// (e.g. eBay reviewers checking the developer-program links). /show
+	// is the card-show search-engine page (project_show_mode_page) — it
+	// wants maximum screen real estate for the search field + results,
+	// so we skip the sidebar/header entirely.
+	const STANDALONE_PATHS = new Set(['/login', '/privacy', '/terms', '/show']);
 	let isLoginPage = $derived(STANDALONE_PATHS.has($page.url.pathname));
 
 	function isActive(href: string, currentPath: string): boolean {
@@ -98,24 +104,17 @@
 					{item.label}
 				</a>
 				{#if item.href === '/browse'}
-					<button
-						type="button"
-						onclick={() => showMode.toggle()}
-						aria-pressed={$showMode}
-						aria-label={$showMode ? 'Turn off Show Mode' : 'Turn on Show Mode'}
-						class="flex w-full items-center gap-3 rounded-xl border px-3 py-2.5 text-left text-sm font-medium transition-all duration-200
-							{$showMode
-								? 'border-amber-400/60 bg-amber-400/10 text-amber-300 shadow-[0_0_0_1px_rgba(251,191,36,0.18)] hover:bg-amber-400/15'
-								: 'border-transparent text-vault-text-muted hover:bg-vault-surface-hover hover:text-white'}"
+					<!-- Was a runtime toggle; now a link to the standalone /show
+					     page (project_show_mode_page, decided 2026-05-25). -->
+					<a
+						href="/show"
+						class="flex w-full items-center gap-3 rounded-xl border border-amber-400/40 bg-amber-400/5 px-3 py-2.5 text-sm font-medium text-amber-300 transition-all duration-200 hover:border-amber-400/60 hover:bg-amber-400/10"
 					>
 						<svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
 							<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
 						</svg>
-						Show Mode
-						{#if $showMode}
-							<span class="ml-auto text-[10px] font-bold uppercase tracking-wider opacity-80">on</span>
-						{/if}
-					</button>
+						Show
+					</a>
 				{/if}
 			{/each}
 
@@ -265,24 +264,16 @@
 						{item.label}
 					</a>
 					{#if item.href === '/browse'}
-						<button
-							type="button"
-							onclick={() => showMode.toggle()}
-							aria-pressed={$showMode}
-							aria-label={$showMode ? 'Turn off Show Mode' : 'Turn on Show Mode'}
-							class="flex w-full items-center gap-3 rounded-xl border px-3 py-2.5 text-left text-sm font-medium transition-all
-								{$showMode
-									? 'border-amber-400/60 bg-amber-400/10 text-amber-300'
-									: 'border-transparent text-vault-text-muted hover:bg-vault-surface-hover hover:text-white'}"
+						<a
+							href="/show"
+							onclick={() => (mobileMenuOpen = false)}
+							class="flex w-full items-center gap-3 rounded-xl border border-amber-400/40 bg-amber-400/5 px-3 py-2.5 text-sm font-medium text-amber-300 transition-all hover:border-amber-400/60 hover:bg-amber-400/10"
 						>
 							<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
 							</svg>
-							Show Mode
-							{#if $showMode}
-								<span class="ml-auto text-[10px] font-bold uppercase tracking-wider opacity-80">on</span>
-							{/if}
-						</button>
+							Show
+						</a>
 					{/if}
 				{/each}
 

--- a/src/routes/show/+page.server.ts
+++ b/src/routes/show/+page.server.ts
@@ -1,0 +1,129 @@
+/**
+ * /show — the card-show search-engine page.
+ *
+ * Standalone, stripped-down lookup surface (project_show_mode_page).
+ * One job: type a name, see the matching cards, click the right one,
+ * land on the existing /card/[id] for the full data. Designed for the
+ * card-show failure modes — bad WiFi, one-handed phone, glare.
+ *
+ * The actual rendering is in +page.svelte and the layout-skip is in
+ * src/routes/+layout.svelte (STANDALONE_PATHS). This loader stays
+ * lightweight: a single ILIKE on card_index, capped, value-sorted so
+ * the most expensive matches surface first (vendors usually care about
+ * the big cards). Optional low-ask join from live_listings_cache only
+ * for the rows we're actually rendering — keeps the round-trip count
+ * down.
+ */
+
+import { supabase } from '$services/supabase';
+import type { PageServerLoad } from './$types';
+
+const RESULT_LIMIT = 30;
+
+interface IndexRow {
+	card_id: string;
+	name: string;
+	set_name: string | null;
+	card_number: string | null;
+	image_small_url: string | null;
+	rarity: string | null;
+	raw_nm_price: number | null;
+	psa10_price: number | null;
+}
+
+interface CacheRow {
+	card_id: string;
+	lowest_ask_cents: number | null;
+	provider: string;
+	fetched_at: string;
+}
+
+export interface ShowResult {
+	card_id: string;
+	name: string;
+	set_name: string;
+	card_number: string;
+	image_small_url: string | null;
+	rarity: string | null;
+	raw_nm_price: number | null;
+	psa10_price: number | null;
+	lowest_ask_cents: number | null;
+	low_ask_is_sample: boolean;
+}
+
+export const load: PageServerLoad = async ({ url, setHeaders }) => {
+	// Same posture as the rest of the app — never let Vercel cache the
+	// HTML shell (deploys would otherwise serve dead JS hashes). See the
+	// /browse loader for the full rationale.
+	setHeaders({ 'cache-control': 'private, no-cache, must-revalidate' });
+
+	const q = (url.searchParams.get('q') ?? '').trim();
+
+	if (!q) {
+		return {
+			q,
+			results: [] as ShowResult[],
+			truncated: false,
+			limit: RESULT_LIMIT
+		};
+	}
+
+	// Plain ILIKE name match — the show-floor user wants speed and
+	// predictability, not a fancy DSL. Sort by PSA 10 price desc so the
+	// "big cards" surface first when a name is ambiguous (e.g. "charizard"
+	// → Base Set Charizard before Neo Genesis Charizard); fall back to
+	// raw_nm so cards without a graded comp still rank. Stable tiebreak
+	// keeps pagination predictable if we ever add it.
+	const { data: rows } = await supabase
+		.from('card_index')
+		.select(
+			'card_id, name, set_name, card_number, image_small_url, rarity, raw_nm_price, psa10_price'
+		)
+		.ilike('name', `%${q}%`)
+		.order('psa10_price', { ascending: false, nullsFirst: false })
+		.order('raw_nm_price', { ascending: false, nullsFirst: false })
+		.order('card_id', { ascending: true })
+		.limit(RESULT_LIMIT + 1)
+		.returns<IndexRow[]>();
+
+	const truncated = (rows?.length ?? 0) > RESULT_LIMIT;
+	const matched = (rows ?? []).slice(0, RESULT_LIMIT);
+
+	// Pull low-ask cents for just these card_ids in one round-trip. Anon
+	// SELECT on live_listings_cache works (migration 022). We only need
+	// rows tied to the current results; this is small and cheap.
+	const cardIds = matched.map((r) => r.card_id);
+	let cacheByCardId = new Map<string, CacheRow>();
+	if (cardIds.length > 0) {
+		const { data: cacheRows } = await supabase
+			.from('live_listings_cache')
+			.select('card_id, lowest_ask_cents, provider, fetched_at')
+			.in('card_id', cardIds)
+			.eq('query_key', 'all')
+			.returns<CacheRow[]>();
+		for (const c of cacheRows ?? []) cacheByCardId.set(c.card_id, c);
+	}
+
+	const results: ShowResult[] = matched.map((r) => {
+		const cache = cacheByCardId.get(r.card_id);
+		return {
+			card_id: r.card_id,
+			name: r.name,
+			set_name: r.set_name ?? '',
+			card_number: r.card_number ?? '',
+			image_small_url: r.image_small_url,
+			rarity: r.rarity,
+			raw_nm_price: r.raw_nm_price,
+			psa10_price: r.psa10_price,
+			lowest_ask_cents: cache?.lowest_ask_cents ?? null,
+			low_ask_is_sample: cache?.provider === 'stub'
+		};
+	});
+
+	return {
+		q,
+		results,
+		truncated,
+		limit: RESULT_LIMIT
+	};
+};

--- a/src/routes/show/+page.svelte
+++ b/src/routes/show/+page.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	function money(cents: number): string {
+		return `$${(cents / 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+	}
+
+	function dollars(n: number | null): string {
+		if (n == null) return '—';
+		return `$${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+	}
+</script>
+
+<svelte:head>
+	<title>Show · Trove</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+</svelte:head>
+
+<!--
+  Show Mode page. Standalone layout (no sidebar / no global header — gated
+  in src/routes/+layout.svelte via STANDALONE_PATHS) so the screen is
+  maximized for the show-floor flow: type → see → tap → /card/[id].
+
+  Design intent (project_show_mode_page):
+    - One big search input, focused on mount, sticky on mobile.
+    - Lean result rows — image, name, set/number, price headline.
+    - Click → /card/[id]; that page is the unified data home.
+    - High contrast + chunky touch targets (glove + glare friendly).
+-->
+
+<div class="min-h-screen bg-vault-bg text-vault-text">
+	<!-- Sticky top bar: title + back to main app. Kept thin so the search
+	     input sits as close to the top as possible. -->
+	<div class="sticky top-0 z-10 border-b border-vault-border bg-vault-bg/95 backdrop-blur">
+		<div class="mx-auto flex max-w-3xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
+			<div class="flex items-center gap-2">
+				<svg class="h-6 w-6 text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+				</svg>
+				<span class="text-base font-bold text-gradient sm:text-lg">Show</span>
+			</div>
+			<a
+				href="/"
+				class="rounded-xl px-3 py-1.5 text-xs font-medium text-vault-text-muted transition-colors hover:bg-vault-surface-hover hover:text-white"
+			>
+				Exit
+			</a>
+		</div>
+
+		<!-- Search input — full width, big, plain GET form so it works
+		     without JS. On submit we navigate to /show?q=... and the
+		     loader runs. autofocus on first load. -->
+		<form method="GET" action="/show" class="mx-auto max-w-3xl px-4 pb-3 sm:px-6">
+			<label class="sr-only" for="show-search">Search cards</label>
+			<div class="relative">
+				<svg class="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-vault-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+				</svg>
+				<input
+					id="show-search"
+					type="search"
+					name="q"
+					value={data.q}
+					placeholder="Search any card — name, e.g. Charizard"
+					autocomplete="off"
+					autocapitalize="off"
+					spellcheck="false"
+					autofocus
+					class="w-full rounded-2xl border border-vault-border bg-vault-surface py-4 pl-12 pr-4 text-lg font-medium text-white placeholder-vault-text-muted/70 transition-colors focus:border-amber-400/60 focus:bg-vault-surface focus:outline-none focus:ring-2 focus:ring-amber-400/30 sm:text-xl"
+				/>
+			</div>
+		</form>
+	</div>
+
+	<main class="mx-auto max-w-3xl px-4 py-4 sm:px-6">
+		{#if !data.q}
+			<!-- Empty state: hint, not a tutorial. -->
+			<div class="mt-12 text-center">
+				<svg class="mx-auto h-12 w-12 text-vault-text-muted/40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+				</svg>
+				<p class="mt-4 text-lg font-medium text-vault-text">Type a card name above</p>
+				<p class="mt-1 text-sm text-vault-text-muted">
+					Fast lookup for the card show floor. Results tap through to the full data view.
+				</p>
+			</div>
+		{:else if data.results.length === 0}
+			<div class="mt-12 text-center">
+				<p class="text-lg font-medium text-vault-text">No matches for "{data.q}"</p>
+				<p class="mt-1 text-sm text-vault-text-muted">
+					Try a shorter name or check the spelling.
+				</p>
+			</div>
+		{:else}
+			<p class="mb-3 text-xs uppercase tracking-wider text-vault-text-muted">
+				{data.results.length}{data.truncated ? '+' : ''} result{data.results.length === 1 ? '' : 's'}
+				{#if data.truncated} · narrow your search to see more{/if}
+			</p>
+
+			<ul class="space-y-2">
+				{#each data.results as r (r.card_id)}
+					<li>
+						<a
+							href={`/card/${r.card_id}`}
+							class="flex items-center gap-3 rounded-2xl border border-vault-border bg-vault-surface p-3 transition-colors hover:bg-vault-surface-hover active:bg-vault-surface-hover sm:gap-4 sm:p-4"
+						>
+							<!-- Thumbnail — large for one-handed scanning. -->
+							<div class="flex-shrink-0">
+								{#if r.image_small_url}
+									<img
+										src={r.image_small_url}
+										alt=""
+										class="h-24 w-auto rounded border border-vault-border sm:h-28"
+										loading="lazy"
+									/>
+								{:else}
+									<div class="flex h-24 w-16 items-center justify-center rounded border border-vault-border bg-vault-bg text-[10px] text-vault-text-muted sm:h-28 sm:w-20">
+										no image
+									</div>
+								{/if}
+							</div>
+
+							<!-- Name + set + price headline. Price comes from the catalog
+							     row eagerly per [[feedback_smart_lazy_load_pattern]]. -->
+							<div class="min-w-0 flex-1">
+								<p class="truncate text-base font-bold text-white sm:text-lg">{r.name}</p>
+								<p class="mt-0.5 truncate text-sm text-vault-text-muted">
+									{r.set_name}{#if r.card_number} · #{r.card_number}{/if}
+								</p>
+								{#if r.rarity}
+									<p class="mt-0.5 truncate text-xs text-vault-text-muted/80">{r.rarity}</p>
+								{/if}
+							</div>
+
+							<!-- Price column — eager, the headline for "is this card worth
+							     paying attention to right now?" Compact on mobile. -->
+							<div class="flex-shrink-0 text-right">
+								{#if r.psa10_price != null}
+									<p class="text-base font-bold text-vault-gold sm:text-lg">{dollars(r.psa10_price)}</p>
+									<p class="text-[10px] uppercase tracking-wider text-vault-text-muted">PSA 10</p>
+								{/if}
+								{#if r.raw_nm_price != null}
+									<p class="mt-1 text-sm font-semibold text-vault-text sm:text-base">{dollars(r.raw_nm_price)}</p>
+									<p class="text-[10px] uppercase tracking-wider text-vault-text-muted">Raw NM</p>
+								{/if}
+								{#if r.lowest_ask_cents != null}
+									<p class="mt-1 text-sm font-semibold text-vault-green">{money(r.lowest_ask_cents)}</p>
+									<p class="text-[10px] uppercase tracking-wider text-vault-green/80">
+										Low ask{#if r.low_ask_is_sample} <span class="text-amber-300" title="Sample data — real live-listings provider not yet wired up.">·sample</span>{/if}
+									</p>
+								{/if}
+								{#if r.psa10_price == null && r.raw_nm_price == null}
+									<p class="text-sm italic text-vault-text-muted">no price</p>
+								{/if}
+							</div>
+						</a>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</main>
+</div>


### PR DESCRIPTION
## Summary

Reframes **Show Mode** from a runtime toggle (the Sprint 1A approach) to its **own standalone route at /show** — a maximally-light card lookup surface designed for the card-show floor flow: type → see → tap → land on /card/[id] for the full data.

Why the reframe: a toggle had to leave the existing layout intact and conditionally hide pieces (fragile, half-measure). A standalone page can be aggressively lighter (no sidebar, no chrome, its own optimization budget) and keeps card pages full-fidelity regardless of context — no per-mode rendering branch.

## What's in the PR

- **New route** [`/show`](src/routes/show/+page.server.ts) — server-loaded card search.
  - Plain ILIKE on `card_index.name`, capped at 30 rows. Value-sorted (PSA 10 desc → Raw NM desc → card_id tiebreak) so the "big card" surfaces first on ambiguous names.
  - Optional low-ask join from `live_listings_cache` for displayed `card_id`s only — pulls `lowest_ask_cents` + `provider` so the row can show a "Low ask · sample" chip when a cached row exists.
- **Page UI** [`+page.svelte`](src/routes/show/+page.svelte) — standalone layout, sticky search input, big mobile-first touch targets, lean result rows (image, name/set/number, PSA 10 / Raw NM / Low ask). Click-through goes to existing `/card/[id]`.
- **Layout gate** — added `/show` to `STANDALONE_PATHS` in [src/routes/+layout.svelte](src/routes/+layout.svelte) so the sidebar/header are skipped.
- **Sidebar Show button** — converted from a runtime `showMode.toggle()` button to a `<a href="/show">` link (both desktop and mobile sidebars share the same `primaryNav` array).
- **Header `ShowModeToggle` left in place** intentionally — a follow-up PR can retire it along with the `showMode` store and `/src/lib/stores/show-mode.ts` entirely.

## Verification

Verified end-to-end via the project verify skill (local dev server + curl + cross-check against Supabase):

- [x] `GET /show` → 200, empty-state copy renders, autofocus input present
- [x] `GET /show?q=charizard` → 200, 30+ result rows, click-through hrefs to `/card/[id]`
- [x] `base1-4` row cross-checked against the source: PSA 10 \$26,698.31, Raw NM \$555.88, Low ask \$27.06 · sample (matches `card_index` + `live_listings_cache`)
- [x] Standalone layout confirmed — no sidebar markup on `/show` (only `.brand-chip` CSS class definition, not an element)
- [x] Sidebar `/show` link visible on `/` (desktop) and mobile menu
- [x] `svelte-check` produces no new errors (only the same pre-existing a11y warning about `autofocus`, which `/login` already uses — intentional for a search-first surface)

## Follow-ups (out of scope)

- Retire the header `ShowModeToggle` component + `showMode` store + `/src/lib/stores/show-mode.ts` once we're confident the standalone page is the real Show Mode.
- Voice search, photo scan, offline Service Worker cache — Sprint 3+ work; intentionally not piled into this PR.
- Memory updated: new [project_show_mode_page.md] supersedes the toggle framing in [project_show_mode_pivot.md]; new [feedback_dont_delete_under_pivot_banner.md] codifies the "fold > delete" rule from the related conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)