### PR TITLE
build(vercel): skip builds on the rsmc Vercel project

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_PROJECT_ID\" = \"prj_xcgn6IO99G8ymjJPMnUt63LsScXZ\" ]"
+}


### PR DESCRIPTION
## Summary

Stops Trove pushes from deploying to the **rsmc** Vercel project (`prj_xcgn6IO99G8ymjJPMnUt63LsScXZ`), which actually belongs to a separate joint codebase Tommy and Erik own. The project is still wired to this GitHub repo (`tommymarcheschi/rsmc`) from before this repo was repurposed for Trove, so every push currently deploys Trove's code to a URL where it doesn't belong AND consumes double the Vercel build minutes.

## How it works

Adds a tiny `vercel.json` with an `ignoreCommand` that runs before every Vercel build:

```json
"ignoreCommand": "[ \"$VERCEL_PROJECT_ID\" = \"prj_xcgn6IO99G8ymjJPMnUt63LsScXZ\" ]"
```

Vercel's contract: **exit 0 → skip the build, exit 1 → proceed**. The bash test returns 0 only when the project ID matches the rsmc project, so:

- rsmc project build → exit 0 → **skipped** ✅
- pokeapp project build → exit 1 → proceeds normally ✅

## Test plan

- [ ] After merge: push to any branch (or merge this PR). In the Vercel dashboard, the rsmc project's build should report **"Ignored Build"** for the deploy. The pokeapp project should build normally.
- [ ] Spot-check that `pokeapp-git-<branch>-tommys-projects-94689560.vercel.app` still serves Trove after the next push.
- [ ] Spot-check that `rsmc-git-<branch>-tommys-projects-94689560.vercel.app` no longer updates with new Trove content (will stay frozen at the last build before this lands, or 404 once Vercel garbage-collects).

## Followup (out of scope, dashboard-only)

The real fix is to **disconnect Git Integration on the rsmc project** in Vercel: rsmc project → Settings → Git → **Disconnect Git Repository**. Then Erik can wire it to the correct codebase. This PR is the safety net so the bleed stops immediately — even if someone accidentally reconnects later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)