### PR TITLE
fix(home): hydrate Top Holdings + Portfolio Value from card_index

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,6 +1,4 @@
 import { supabase } from '$services/supabase';
-import { getCard } from '$services/tcg-api';
-import { getCachedPricesForCards } from '$services/price-cache';
 import { getPsa10Momentum } from '$services/insights';
 import type { PageServerLoad } from './$types';
 
@@ -81,45 +79,55 @@ export const load: PageServerLoad = async ({ setHeaders }) => {
 	);
 
 	let portfolioValue = 0;
-	let topHoldings: { card_id: string; name: string; quantity: number; marketPrice: number; totalValue: number; imageUrl: string; gainLoss: number }[] = [];
+	let topHoldings: { card_id: string; name: string; quantity: number; marketPrice: number | null; totalValue: number; imageUrl: string | null; gainLoss: number | null }[] = [];
 
 	if (collection.length > 0) {
-		const uniqueCardIds = [...new Set(collection.map((e: { card_id: string }) => e.card_id))].slice(0, 20);
+		// Source of truth for card metadata + raw_nm_price is card_index — the
+		// same table the card page, /browse, /rankings and /sets all read from.
+		// The dashboard used to call getCard() (pokemontcg.io) + price_cache
+		// (TCGPlayer market), which silently dropped cards from non-pokemontcg
+		// sets (e.g. the `me3` Scrydex set) and showed prices that disagreed
+		// with the card page. Reading card_index here keeps every surface
+		// consistent and lets us honestly render "—" when no price exists.
+		const uniqueCardIds = [...new Set(collection.map((e: { card_id: string }) => e.card_id))];
 
-		// Get cached prices + fetch card metadata in one pass
-		const [cachedPrices, ...cardResults] = await Promise.all([
-			getCachedPricesForCards(uniqueCardIds),
-			...uniqueCardIds.map((id) => getCard(id).catch(() => null))
-		]);
+		const { data: idxRows } = await supabase
+			.from('card_index')
+			.select('card_id, name, image_small_url, raw_nm_price')
+			.in('card_id', uniqueCardIds);
 
-		const cardMap = new Map<string, { name: string; marketPrice: number; imageUrl: string }>();
-
-		for (const card of cardResults) {
-			if (!card) continue;
-			let marketPrice = (cachedPrices as Map<string, number>).get(card.id) ?? 0;
-			if (marketPrice === 0 && card.tcgplayer?.prices) {
-				for (const variant of Object.values(card.tcgplayer.prices)) {
-					if (variant.market) { marketPrice = variant.market; break; }
-					if (variant.mid) { marketPrice = variant.mid; break; }
-				}
-			}
-			cardMap.set(card.id, { name: card.name, marketPrice, imageUrl: card.images.small });
+		const cardMap = new Map<string, { name: string; marketPrice: number | null; imageUrl: string | null }>();
+		for (const r of (idxRows ?? []) as Array<{
+			card_id: string;
+			name: string;
+			image_small_url: string | null;
+			raw_nm_price: number | null;
+		}>) {
+			cardMap.set(r.card_id, {
+				name: r.name,
+				marketPrice: r.raw_nm_price,
+				imageUrl: r.image_small_url
+			});
 		}
 
 		for (const entry of collection) {
-			const card = cardMap.get(entry.card_id);
-			if (!card) continue;
-			const totalValue = card.marketPrice * entry.quantity;
+			const meta = cardMap.get(entry.card_id);
+			// Even with no card_index row (shouldn't normally happen), still
+			// surface the holding so the count matches Total Cards.
+			const name = meta?.name ?? entry.card_id;
+			const imageUrl = meta?.imageUrl ?? null;
+			const marketPrice = meta?.marketPrice ?? null;
+			const totalValue = marketPrice != null ? marketPrice * entry.quantity : 0;
 			portfolioValue += totalValue;
 			const costBasis = (entry.purchase_price ?? 0) * entry.quantity;
 			topHoldings.push({
 				card_id: entry.card_id,
-				name: card.name,
+				name,
 				quantity: entry.quantity,
-				marketPrice: card.marketPrice,
+				marketPrice,
 				totalValue,
-				imageUrl: card.imageUrl,
-				gainLoss: totalValue - costBasis
+				imageUrl,
+				gainLoss: marketPrice != null ? totalValue - costBasis : null
 			});
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 
 	let { data } = $props();
 	let stats = $derived(data.stats);
-	let topHoldings = $derived(data.topHoldings as { card_id: string; name: string; quantity: number; marketPrice: number; totalValue: number; imageUrl: string; gainLoss: number }[]);
+	let topHoldings = $derived(data.topHoldings as { card_id: string; name: string; quantity: number; marketPrice: number | null; totalValue: number; imageUrl: string | null; gainLoss: number | null }[]);
 	let attention = $derived(((data as Record<string, unknown>).attention ?? { triggeredAlerts: [], triggeredAlertsTotal: 0, rising: [] }) as Attention);
 
 	function fmtMoney(n: number | null | undefined): string {
@@ -116,15 +116,15 @@
 	<div class="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
 		<div class="stat-card rounded-2xl border border-vault-border bg-vault-surface p-4 sm:p-6">
 			<div class="flex items-center justify-between">
-				<p class="text-sm text-vault-text-muted">Total Invested</p>
+				<p class="text-sm text-vault-text-muted">Portfolio Value</p>
 				<div class="flex h-10 w-10 items-center justify-center rounded-xl bg-vault-gold/10">
 					<svg class="h-5 w-5 text-vault-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
 					</svg>
 				</div>
 			</div>
-			<p class="mt-2 text-2xl font-bold sm:mt-3 sm:text-3xl text-vault-gold">${stats.totalInvested.toFixed(2)}</p>
-			<p class="mt-1 text-sm text-vault-text-muted">purchase cost basis</p>
+			<p class="mt-2 text-2xl font-bold sm:mt-3 sm:text-3xl text-vault-gold">${stats.portfolioValue.toFixed(2)}</p>
+			<p class="mt-1 text-sm text-vault-text-muted">cost basis ${stats.totalInvested.toFixed(2)}</p>
 		</div>
 		<div class="stat-card rounded-2xl border border-vault-border bg-vault-surface p-4 sm:p-6">
 			<div class="flex items-center justify-between">
@@ -175,16 +175,27 @@
 			<div class="divide-y divide-vault-border">
 				{#each topHoldings as holding}
 					<a href="/card/{holding.card_id}" class="flex items-center gap-3 px-3 py-3 transition-colors hover:bg-vault-surface-hover sm:gap-4 sm:px-6">
-						<img src={holding.imageUrl} alt={holding.name} class="h-14 w-10 rounded-lg object-cover" loading="lazy" />
+						{#if holding.imageUrl}
+							<img src={holding.imageUrl} alt={holding.name} class="h-14 w-10 rounded-lg object-cover" loading="lazy" />
+						{:else}
+							<div class="h-14 w-10 rounded-lg bg-vault-bg"></div>
+						{/if}
 						<div class="min-w-0 flex-1">
 							<p class="truncate text-sm font-medium text-white">{holding.name}</p>
-							<p class="text-xs text-vault-text-muted">Qty: {holding.quantity} &middot; ${holding.marketPrice.toFixed(2)} each</p>
+							<p class="text-xs text-vault-text-muted">
+								Qty: {holding.quantity} &middot;
+								{holding.marketPrice != null ? `$${holding.marketPrice.toFixed(2)} each` : 'price —'}
+							</p>
 						</div>
 						<div class="text-right">
-							<p class="text-sm font-bold text-vault-gold">${holding.totalValue.toFixed(2)}</p>
-							<p class="text-xs {holding.gainLoss >= 0 ? 'text-vault-green' : 'text-vault-red'}">
-								{holding.gainLoss >= 0 ? '+' : ''}${holding.gainLoss.toFixed(2)}
+							<p class="text-sm font-bold text-vault-gold">
+								{holding.marketPrice != null ? `$${holding.totalValue.toFixed(2)}` : '—'}
 							</p>
+							{#if holding.gainLoss != null}
+								<p class="text-xs {holding.gainLoss >= 0 ? 'text-vault-green' : 'text-vault-red'}">
+									{holding.gainLoss >= 0 ? '+' : ''}${holding.gainLoss.toFixed(2)}
+								</p>
+							{/if}
 						</div>
 					</a>
 				{/each}


### PR DESCRIPTION
## Summary

- Dashboard was the only surface still reading card data from `pokemontcg.io` + the TCGPlayer `price_cache` table; every other surface (`/card`, `/browse`, `/rankings`, `/sets`, `/sleepers`) reads from `card_index.raw_nm_price`. The mismatch silently dropped holdings whose set has no pokemontcg.io row (e.g. the Scrydex-sourced `me3` set) and showed stale TCGPlayer prices that disagreed with the card page. Under a 429 storm on pokemontcg.io the entire Portfolio Value banner could vanish even with a populated collection (live prod is in this state right now — 1 of 4 holdings rendering, banner hidden).
- Switch the dashboard to a single `card_index` batch query for `name`, `image_small_url`, `raw_nm_price`. Render `—` honestly when no price exists instead of fabricating `$0`. Holdings render even with a missing price so the count matches Total Cards.
- Swap the redundant "Total Invested" gold tile for "Portfolio Value" (cost basis demoted to the subtitle — banner already shows both).

## Before → after (local verify)

| | Before | After |
|---|---|---|
| Banner | hidden (portfolioValue=0) | **Portfolio Market Value $85.22** |
| Gold tile | Total Invested $70.00 | **Portfolio Value $85.22** |
| Dedenne `me3-93` | missing | $7.75 |
| Clefairy `me3-94` | $0.00 | $31.89 |
| Arceus LV.X `pl4-95` | missing on prod / $65.96 stale | $31.55 |
| Gimmighoul `sv4-198` | missing on prod / $14.44 stale | $14.03 |

All four values now match what each card's `/card/<id>` page shows.

## Test plan

- [x] Curl `/` locally, confirm all 4 holdings render with correct prices
- [x] Cross-check each rendered price against the source row in `card_index`
- [x] Banner sum matches gold tile matches Σ(holdings)
- [ ] Smoke check `/` on Vercel preview after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)