### PR TITLE
fix(watchlist): fall back to card_index metadata when pokemontcg.io misses

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,6 +1,4 @@
 import { supabase } from '$services/supabase';
-import { getCard } from '$services/tcg-api';
-import { getCachedPricesForCards } from '$services/price-cache';
 import { getPsa10Momentum } from '$services/insights';
 import type { PageServerLoad } from './$types';
 
@@ -81,45 +79,55 @@ export const load: PageServerLoad = async ({ setHeaders }) => {
 	);
 
 	let portfolioValue = 0;
-	let topHoldings: { card_id: string; name: string; quantity: number; marketPrice: number; totalValue: number; imageUrl: string; gainLoss: number }[] = [];
+	let topHoldings: { card_id: string; name: string; quantity: number; marketPrice: number | null; totalValue: number; imageUrl: string | null; gainLoss: number | null }[] = [];
 
 	if (collection.length > 0) {
-		const uniqueCardIds = [...new Set(collection.map((e: { card_id: string }) => e.card_id))].slice(0, 20);
+		// Source of truth for card metadata + raw_nm_price is card_index — the
+		// same table the card page, /browse, /rankings and /sets all read from.
+		// The dashboard used to call getCard() (pokemontcg.io) + price_cache
+		// (TCGPlayer market), which silently dropped cards from non-pokemontcg
+		// sets (e.g. the `me3` Scrydex set) and showed prices that disagreed
+		// with the card page. Reading card_index here keeps every surface
+		// consistent and lets us honestly render "—" when no price exists.
+		const uniqueCardIds = [...new Set(collection.map((e: { card_id: string }) => e.card_id))];
 
-		// Get cached prices + fetch card metadata in one pass
-		const [cachedPrices, ...cardResults] = await Promise.all([
-			getCachedPricesForCards(uniqueCardIds),
-			...uniqueCardIds.map((id) => getCard(id).catch(() => null))
-		]);
+		const { data: idxRows } = await supabase
+			.from('card_index')
+			.select('card_id, name, image_small_url, raw_nm_price')
+			.in('card_id', uniqueCardIds);
 
-		const cardMap = new Map<string, { name: string; marketPrice: number; imageUrl: string }>();
-
-		for (const card of cardResults) {
-			if (!card) continue;
-			let marketPrice = (cachedPrices as Map<string, number>).get(card.id) ?? 0;
-			if (marketPrice === 0 && card.tcgplayer?.prices) {
-				for (const variant of Object.values(card.tcgplayer.prices)) {
-					if (variant.market) { marketPrice = variant.market; break; }
-					if (variant.mid) { marketPrice = variant.mid; break; }
-				}
-			}
-			cardMap.set(card.id, { name: card.name, marketPrice, imageUrl: card.images.small });
+		const cardMap = new Map<string, { name: string; marketPrice: number | null; imageUrl: string | null }>();
+		for (const r of (idxRows ?? []) as Array<{
+			card_id: string;
+			name: string;
+			image_small_url: string | null;
+			raw_nm_price: number | null;
+		}>) {
+			cardMap.set(r.card_id, {
+				name: r.name,
+				marketPrice: r.raw_nm_price,
+				imageUrl: r.image_small_url
+			});
 		}
 
 		for (const entry of collection) {
-			const card = cardMap.get(entry.card_id);
-			if (!card) continue;
-			const totalValue = card.marketPrice * entry.quantity;
+			const meta = cardMap.get(entry.card_id);
+			// Even with no card_index row (shouldn't normally happen), still
+			// surface the holding so the count matches Total Cards.
+			const name = meta?.name ?? entry.card_id;
+			const imageUrl = meta?.imageUrl ?? null;
+			const marketPrice = meta?.marketPrice ?? null;
+			const totalValue = marketPrice != null ? marketPrice * entry.quantity : 0;
 			portfolioValue += totalValue;
 			const costBasis = (entry.purchase_price ?? 0) * entry.quantity;
 			topHoldings.push({
 				card_id: entry.card_id,
-				name: card.name,
+				name,
 				quantity: entry.quantity,
-				marketPrice: card.marketPrice,
+				marketPrice,
 				totalValue,
-				imageUrl: card.imageUrl,
-				gainLoss: totalValue - costBasis
+				imageUrl,
+				gainLoss: marketPrice != null ? totalValue - costBasis : null
 			});
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 
 	let { data } = $props();
 	let stats = $derived(data.stats);
-	let topHoldings = $derived(data.topHoldings as { card_id: string; name: string; quantity: number; marketPrice: number; totalValue: number; imageUrl: string; gainLoss: number }[]);
+	let topHoldings = $derived(data.topHoldings as { card_id: string; name: string; quantity: number; marketPrice: number | null; totalValue: number; imageUrl: string | null; gainLoss: number | null }[]);
 	let attention = $derived(((data as Record<string, unknown>).attention ?? { triggeredAlerts: [], triggeredAlertsTotal: 0, rising: [] }) as Attention);
 
 	function fmtMoney(n: number | null | undefined): string {
@@ -116,15 +116,15 @@
 	<div class="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
 		<div class="stat-card rounded-2xl border border-vault-border bg-vault-surface p-4 sm:p-6">
 			<div class="flex items-center justify-between">
-				<p class="text-sm text-vault-text-muted">Total Invested</p>
+				<p class="text-sm text-vault-text-muted">Portfolio Value</p>
 				<div class="flex h-10 w-10 items-center justify-center rounded-xl bg-vault-gold/10">
 					<svg class="h-5 w-5 text-vault-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
 					</svg>
 				</div>
 			</div>
-			<p class="mt-2 text-2xl font-bold sm:mt-3 sm:text-3xl text-vault-gold">${stats.totalInvested.toFixed(2)}</p>
-			<p class="mt-1 text-sm text-vault-text-muted">purchase cost basis</p>
+			<p class="mt-2 text-2xl font-bold sm:mt-3 sm:text-3xl text-vault-gold">${stats.portfolioValue.toFixed(2)}</p>
+			<p class="mt-1 text-sm text-vault-text-muted">cost basis ${stats.totalInvested.toFixed(2)}</p>
 		</div>
 		<div class="stat-card rounded-2xl border border-vault-border bg-vault-surface p-4 sm:p-6">
 			<div class="flex items-center justify-between">
@@ -175,16 +175,27 @@
 			<div class="divide-y divide-vault-border">
 				{#each topHoldings as holding}
 					<a href="/card/{holding.card_id}" class="flex items-center gap-3 px-3 py-3 transition-colors hover:bg-vault-surface-hover sm:gap-4 sm:px-6">
-						<img src={holding.imageUrl} alt={holding.name} class="h-14 w-10 rounded-lg object-cover" loading="lazy" />
+						{#if holding.imageUrl}
+							<img src={holding.imageUrl} alt={holding.name} class="h-14 w-10 rounded-lg object-cover" loading="lazy" />
+						{:else}
+							<div class="h-14 w-10 rounded-lg bg-vault-bg"></div>
+						{/if}
 						<div class="min-w-0 flex-1">
 							<p class="truncate text-sm font-medium text-white">{holding.name}</p>
-							<p class="text-xs text-vault-text-muted">Qty: {holding.quantity} &middot; ${holding.marketPrice.toFixed(2)} each</p>
+							<p class="text-xs text-vault-text-muted">
+								Qty: {holding.quantity} &middot;
+								{holding.marketPrice != null ? `$${holding.marketPrice.toFixed(2)} each` : 'price —'}
+							</p>
 						</div>
 						<div class="text-right">
-							<p class="text-sm font-bold text-vault-gold">${holding.totalValue.toFixed(2)}</p>
-							<p class="text-xs {holding.gainLoss >= 0 ? 'text-vault-green' : 'text-vault-red'}">
-								{holding.gainLoss >= 0 ? '+' : ''}${holding.gainLoss.toFixed(2)}
+							<p class="text-sm font-bold text-vault-gold">
+								{holding.marketPrice != null ? `$${holding.totalValue.toFixed(2)}` : '—'}
 							</p>
+							{#if holding.gainLoss != null}
+								<p class="text-xs {holding.gainLoss >= 0 ? 'text-vault-green' : 'text-vault-red'}">
+									{holding.gainLoss >= 0 ? '+' : ''}${holding.gainLoss.toFixed(2)}
+								</p>
+							{/if}
 						</div>
 					</a>
 				{/each}

--- a/src/routes/collection/+page.server.ts
+++ b/src/routes/collection/+page.server.ts
@@ -54,17 +54,84 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	// show an empty axis). score_momentum/score_liquidity are ~null in prod
 	// so they are deliberately NOT pulled.
 	const discoveryByCard: Record<string, DiscoverySignals> = {};
+	// Card metadata for the cardCache fallback (see below). pokemontcg.io
+	// 404s for Scrydex-only sets (e.g. `me3`), and when getCard() fails the
+	// whole row collapses to its card_id with a "..." thumbnail and falls
+	// out of the Insight strip. card_index is our source of truth for every
+	// owned card, so we read name/image/set/number/rarity off the same row
+	// and synthesize a minimal PokemonCard for any pokemontcg miss.
+	interface IndexMeta {
+		name: string;
+		set_id: string | null;
+		set_name: string | null;
+		card_number: string | null;
+		image_small_url: string | null;
+		image_large_url: string | null;
+		rarity: string | null;
+	}
+	const indexMeta: Record<string, IndexMeta> = {};
 	if (uniqueCardIds.length > 0) {
 		const { data: indexRows } = await supabase
 			.from('card_index')
-			.select(`card_id, raw_nm_price, ${DISCOVERY_SELECT_COLS}`)
+			.select(
+				`card_id, raw_nm_price, name, set_id, set_name, card_number, image_small_url, image_large_url, rarity, ${DISCOVERY_SELECT_COLS}`
+			)
 			.in('card_id', uniqueCardIds);
 		for (const r of (indexRows ?? []) as Array<
-			RawDiscoveryRow & { card_id: string; raw_nm_price: number | null }
+			RawDiscoveryRow & {
+				card_id: string;
+				raw_nm_price: number | null;
+				name: string;
+				set_id: string | null;
+				set_name: string | null;
+				card_number: string | null;
+				image_small_url: string | null;
+				image_large_url: string | null;
+				rarity: string | null;
+			}
 		>) {
 			indexPrices[r.card_id] = r.raw_nm_price;
 			discoveryByCard[r.card_id] = gateDiscoverySignals(r);
+			indexMeta[r.card_id] = {
+				name: r.name,
+				set_id: r.set_id,
+				set_name: r.set_name,
+				card_number: r.card_number,
+				image_small_url: r.image_small_url,
+				image_large_url: r.image_large_url,
+				rarity: r.rarity
+			};
 		}
+	}
+
+	// Backfill cardCache for any card the pokemontcg.io lookup missed. The
+	// UI reads card.name / card.images.small / card.set.name / card.number,
+	// so we synthesize just those fields from card_index. Cast to
+	// PokemonCard — fields the UI doesn't touch stay undefined.
+	for (const id of uniqueCardIds) {
+		if (cardCache[id]) continue;
+		const m = indexMeta[id];
+		if (!m) continue;
+		cardCache[id] = {
+			id,
+			name: m.name,
+			supertype: '',
+			number: m.card_number ?? '',
+			rarity: m.rarity ?? undefined,
+			images: {
+				small: m.image_small_url ?? '',
+				large: m.image_large_url ?? m.image_small_url ?? ''
+			},
+			set: {
+				id: m.set_id ?? '',
+				name: m.set_name ?? '',
+				series: '',
+				printedTotal: 0,
+				total: 0,
+				releaseDate: '',
+				images: { symbol: '', logo: '' }
+			}
+		} as PokemonCard;
 	}
 
 	// Add-modal state is driven by URL params so the whole flow works without

--- a/src/routes/watchlist/+page.server.ts
+++ b/src/routes/watchlist/+page.server.ts
@@ -12,23 +12,55 @@ export const load: PageServerLoad = async () => {
 
 	const cardIds = Array.from(new Set(entries.map((e) => e.card_id)));
 
-	// Batch-pull current prices from card_index (single round-trip) so the
-	// page can render triggered-alert state without hitting an external
-	// API per row. Fallback to TCG API market price for cards not indexed.
+	// Batch-pull current prices + metadata from card_index (single round-trip)
+	// so the page can render triggered-alert state without hitting an external
+	// API per row, AND so rows whose pokemontcg.io lookup misses (Scrydex
+	// sets, or a 429 storm) still have a name/image/set instead of "..." +
+	// bare card_id. card_index is our source of truth for every owned/
+	// watched card; we synthesize a minimal PokemonCard from it whenever
+	// getCard() returns null.
 	const indexPrices: Record<string, { raw_nm_price: number | null; psa10_price: number | null }> = {};
+	interface IndexMeta {
+		name: string;
+		set_id: string | null;
+		set_name: string | null;
+		card_number: string | null;
+		image_small_url: string | null;
+		image_large_url: string | null;
+		rarity: string | null;
+	}
+	const indexMeta: Record<string, IndexMeta> = {};
 	if (cardIds.length > 0) {
 		const { data: indexRows } = await supabase
 			.from('card_index')
-			.select('card_id, raw_nm_price, psa10_price')
+			.select(
+				'card_id, raw_nm_price, psa10_price, name, set_id, set_name, card_number, image_small_url, image_large_url, rarity'
+			)
 			.in('card_id', cardIds);
 		for (const r of (indexRows ?? []) as Array<{
 			card_id: string;
 			raw_nm_price: number | null;
 			psa10_price: number | null;
+			name: string;
+			set_id: string | null;
+			set_name: string | null;
+			card_number: string | null;
+			image_small_url: string | null;
+			image_large_url: string | null;
+			rarity: string | null;
 		}>) {
 			indexPrices[r.card_id] = {
 				raw_nm_price: r.raw_nm_price,
 				psa10_price: r.psa10_price
+			};
+			indexMeta[r.card_id] = {
+				name: r.name,
+				set_id: r.set_id,
+				set_name: r.set_name,
+				card_number: r.card_number,
+				image_small_url: r.image_small_url,
+				image_large_url: r.image_large_url,
+				rarity: r.rarity
 			};
 		}
 	}
@@ -42,6 +74,34 @@ export const load: PageServerLoad = async () => {
 	for (let i = 0; i < cardIds.length; i++) {
 		const card = cardLookups[i];
 		if (card) cardCache[cardIds[i]] = card;
+	}
+
+	// Backfill cardCache for any pokemontcg.io miss. UI only reads card.name
+	// / card.images.small / card.set.name / card.number — synthesize those.
+	for (const id of cardIds) {
+		if (cardCache[id]) continue;
+		const m = indexMeta[id];
+		if (!m) continue;
+		cardCache[id] = {
+			id,
+			name: m.name,
+			supertype: '',
+			number: m.card_number ?? '',
+			rarity: m.rarity ?? undefined,
+			images: {
+				small: m.image_small_url ?? '',
+				large: m.image_large_url ?? m.image_small_url ?? ''
+			},
+			set: {
+				id: m.set_id ?? '',
+				name: m.set_name ?? '',
+				series: '',
+				printedTotal: 0,
+				total: 0,
+				releaseDate: '',
+				images: { symbol: '', logo: '' }
+			}
+		} as PokemonCard;
 	}
 
 	function tcgMarketFor(card: PokemonCard | undefined): number | null {


### PR DESCRIPTION
## Summary

- Third instance of the same data-hydration bug (after #54 home + #55 collection). /watchlist calls \`getCard()\` (pokemontcg.io) per watched card for name/image/set/number; under a 429 storm or for Scrydex-only sets, the row silently collapses to a "..." placeholder + bare \`card_id\` text and loses its \`/card/[id]\` link.
- Verified on the verify server: first curl rendered 2 of 3 watchlist entries (pokemontcg.io was 429'ing). After the fix, all 3 render consistently regardless of pokemontcg.io health.
- Same approach as #55: extend the existing card_index batch query to include \`name / set_id / set_name / card_number / image_small_url / image_large_url / rarity\`, synthesize a minimal \`PokemonCard\` for any miss. .svelte side unchanged.

## Test plan

- [x] /watchlist curl renders all 3 entries with names + images + links

🤖 Generated with [Claude Code](https://claude.com/claude-code)