### PR TITLE
fix(home): apply condition discount to Top Holdings + Portfolio Value

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -110,24 +110,39 @@ export const load: PageServerLoad = async ({ setHeaders }) => {
 			});
 		}
 
+		// Same condition-discount ladder /collection uses so the dashboard's
+		// per-card unit price + portfolio total agree with /collection (and
+		// with the per-card "value (est.)" tag shown in the list). Keeps
+		// `marketPrice` honestly = the unit value at the entry's actual
+		// condition, not a fabricated NM number.
+		const CONDITION_DISCOUNT: Record<string, number> = {
+			NM: 1.0,
+			LP: 0.85,
+			MP: 0.7,
+			HP: 0.5,
+			DMG: 0.3
+		};
+
 		for (const entry of collection) {
 			const meta = cardMap.get(entry.card_id);
 			// Even with no card_index row (shouldn't normally happen), still
 			// surface the holding so the count matches Total Cards.
 			const name = meta?.name ?? entry.card_id;
 			const imageUrl = meta?.imageUrl ?? null;
-			const marketPrice = meta?.marketPrice ?? null;
-			const totalValue = marketPrice != null ? marketPrice * entry.quantity : 0;
+			const nmPrice = meta?.marketPrice ?? null;
+			const discount = CONDITION_DISCOUNT[entry.condition] ?? 1.0;
+			const unitPrice = nmPrice != null ? Math.round(nmPrice * discount * 100) / 100 : null;
+			const totalValue = unitPrice != null ? unitPrice * entry.quantity : 0;
 			portfolioValue += totalValue;
 			const costBasis = (entry.purchase_price ?? 0) * entry.quantity;
 			topHoldings.push({
 				card_id: entry.card_id,
 				name,
 				quantity: entry.quantity,
-				marketPrice,
+				marketPrice: unitPrice,
 				totalValue,
 				imageUrl,
-				gainLoss: marketPrice != null ? totalValue - costBasis : null
+				gainLoss: unitPrice != null ? totalValue - costBasis : null
 			});
 		}
 


### PR DESCRIPTION
## Summary

After #54 switched the dashboard to \`card_index.raw_nm_price\` (the NM-canonical raw price), every holding rendered at its NM value regardless of condition. \`/collection\` already applies the standard NM/LP/MP/HP/DMG ladder (1.0 / 0.85 / 0.7 / 0.5 / 0.3) so the two surfaces disagreed.

Concrete example: just added a $120 raw Rayquaza C LV.X #146 in HP condition (NM ≈ $218.66). /collection valued it at $109.33; /dashboard headlined it at $218.66 — a 2× discrepancy on a single owned card.

## Before → after (local verify, with Rayquaza HP in collection)

| | Before | After (matches /collection) |
|---|---|---|
| Rayquaza row "each" | $218.66 | **$109.33** |
| Portfolio Market Value banner | $303.88 | **$194.55** |
| Portfolio Value gold tile | $303.88 | **$194.55** |

## Test plan

- [x] Rayquaza HP ($120 cost) renders as $109.33 ea, gain/loss -$10.67
- [x] Dashboard Portfolio Value = /collection Current Value = $194.55
- [x] NM-condition holdings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)