### PR TITLE
Mobile UX: dedicated add-card search page + scroll-to-top on nav

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/stores';
+	import { afterNavigate } from '$app/navigation';
 	import { ApiStatus, Icon, CommandPalette, ShowModeToggle } from '$components';
 	// `showMode` store no longer read here — the sidebar Show button is now
 	// a link to /show (project_show_mode_page). The header ShowModeToggle
@@ -41,6 +42,17 @@
 	];
 
 	let mobileMenuOpen = $state(false);
+
+	// The scrollable region is <main> (overflow-y-auto), not the window — so
+	// SvelteKit's built-in scroll reset (which targets the window) leaves the
+	// inner panel parked wherever the previous page left it, dumping you
+	// mid-page after a navigation. Reset it ourselves on every navigation,
+	// except when jumping to an in-page #hash anchor.
+	let mainEl = $state<HTMLElement | null>(null);
+	afterNavigate((nav) => {
+		if (nav.to?.url.hash) return;
+		mainEl?.scrollTo({ top: 0, left: 0 });
+	});
 
 	// Standalone (no sidebar chrome) pages: /login, /privacy, /terms, /show.
 	// /privacy + /terms need to be readable by unauthenticated visitors
@@ -230,7 +242,7 @@
 		</header>
 
 		<!-- Page content -->
-		<main class="flex-1 overflow-y-auto p-3 sm:p-4 lg:p-8">
+		<main bind:this={mainEl} class="flex-1 overflow-y-auto p-3 sm:p-4 lg:p-8">
 			{@render children()}
 		</main>
 	</div>

--- a/src/routes/collection/+page.server.ts
+++ b/src/routes/collection/+page.server.ts
@@ -1,6 +1,6 @@
 import { supabase } from '$services/supabase';
-import { getCard, searchCards } from '$services/tcg-api';
-import { fail, redirect } from '@sveltejs/kit';
+import { getCard } from '$services/tcg-api';
+import { fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import type { PokemonCard, CollectionEntry } from '$types';
 import {
@@ -11,8 +11,6 @@ import {
 } from '$services/discovery-signals';
 import { valueEntry, loadConditionComps, compKey, type Valuation } from '$services/valuation';
 import { loadWatchlistData, type WatchlistLoadResult } from '$services/watchlist-load';
-
-const ADD_SEARCH_PAGE_SIZE = 12;
 
 export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	// Do NOT cache the HTML document. See src/routes/browse/+page.server.ts
@@ -136,12 +134,9 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 		} as PokemonCard;
 	}
 
-	// Add-modal state is driven by URL params so the whole flow works without
-	// JS: `?add=1` opens the modal, `?addSearch=<q>` runs a server-side card
-	// search, `?selectedCard=<id>` pre-fetches that card so the detail preview
-	// renders on the same round-trip. Option (b) from the task spec — keeping
-	// the modal in-page and using query params for each step is less
-	// disruptive than a separate /collection/add route.
+	// Adding a card now lives on the dedicated /collection/add page (live
+	// autosuggest over card_index) — the old in-page modal driven by ?add=1 /
+	// ?addSearch / ?selectedCard query params has been removed.
 	// Tab strip — Sprint 1D-i fold. /watchlist redirects here with ?tab=watchlist.
 	// Default tab is the collection view; the watchlist UI only appears when
 	// the user (or a redirect) asks for it explicitly. The watchlist data is
@@ -150,25 +145,6 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 	// badge can show even when the user is on the Collection tab.
 	const tabParam = url.searchParams.get('tab');
 	const tab: 'collection' | 'watchlist' = tabParam === 'watchlist' ? 'watchlist' : 'collection';
-
-	const addMode = url.searchParams.get('add') === '1';
-	const addSearch = url.searchParams.get('addSearch') ?? '';
-	const selectedCardId = url.searchParams.get('selectedCard') ?? '';
-
-	let addSearchResults: PokemonCard[] = [];
-	if (addMode && addSearch.trim()) {
-		try {
-			const result = await searchCards(`name:"${addSearch}*"`, 1, ADD_SEARCH_PAGE_SIZE);
-			addSearchResults = result.data;
-		} catch {
-			// swallow — show empty results rather than crashing the page
-		}
-	}
-
-	let selectedCard: PokemonCard | null = null;
-	if (addMode && selectedCardId) {
-		selectedCard = await getCard(selectedCardId).catch(() => null);
-	}
 
 	// Real per-condition TCGPlayer medians, batched. Same shared loader the
 	// dashboard uses so both surfaces always agree on which entries qualify
@@ -239,10 +215,6 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
 		cardCache,
 		valuationByEntry,
 		discoveryByCard,
-		addMode,
-		addSearch,
-		addSearchResults,
-		selectedCard,
 		watchlist
 	};
 };
@@ -261,56 +233,6 @@ export const load: PageServerLoad = async ({ url, setHeaders }) => {
  * the /api/collection POST handler so both paths behave identically.
  */
 export const actions: Actions = {
-	addEntry: async ({ request }) => {
-		const form = await request.formData();
-		const cardId = (form.get('card_id') ?? '').toString().trim();
-		if (!cardId) return fail(400, { action: 'add', message: 'Card is required' });
-
-		const conditionRaw = (form.get('condition') ?? 'NM').toString();
-		const condition = ['NM', 'LP', 'MP', 'HP', 'DMG'].includes(conditionRaw)
-			? conditionRaw
-			: 'NM';
-
-		const quantityRaw = parseInt((form.get('quantity') ?? '1').toString(), 10);
-		const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? quantityRaw : 1;
-
-		const priceRaw = (form.get('purchase_price') ?? '').toString().trim();
-		const purchasePrice = priceRaw ? parseFloat(priceRaw) : null;
-
-		const dateRaw = (form.get('purchase_date') ?? '').toString().trim();
-		const purchaseDate = dateRaw || null;
-
-		const notesRaw = (form.get('notes') ?? '').toString().trim();
-		const notes = notesRaw || null;
-
-		const { data: existing } = await supabase
-			.from('collection')
-			.select('id, quantity')
-			.eq('card_id', cardId)
-			.eq('condition', condition)
-			.maybeSingle();
-
-		if (existing) {
-			const { error: err } = await supabase
-				.from('collection')
-				.update({ quantity: existing.quantity + quantity })
-				.eq('id', existing.id);
-			if (err) return fail(500, { action: 'add', message: err.message });
-		} else {
-			const { error: err } = await supabase.from('collection').insert({
-				card_id: cardId,
-				quantity,
-				condition,
-				purchase_price: purchasePrice,
-				purchase_date: purchaseDate,
-				notes
-			});
-			if (err) return fail(500, { action: 'add', message: err.message });
-		}
-
-		throw redirect(303, '/collection');
-	},
-
 	increment: async ({ request }) => {
 		const form = await request.formData();
 		const id = (form.get('id') ?? '').toString();

--- a/src/routes/collection/+page.svelte
+++ b/src/routes/collection/+page.svelte
@@ -23,7 +23,7 @@
 		psa10_multiple: number | null;
 	}
 
-	let { data, form } = $props();
+	let { data } = $props();
 
 	// Tab strip — Sprint 1D-i fold. /watchlist now redirects to
 	// /collection?tab=watchlist so the two views share this shell.
@@ -45,13 +45,6 @@
 	let discoveryByCard = $derived(
 		((data as Record<string, unknown>).discoveryByCard ?? {}) as Record<string, DiscoverySignals>
 	);
-	let addMode = $derived(data.addMode);
-	let selectedCard = $derived(data.selectedCard as PokemonCard | null);
-	let addSearchResults = $derived(data.addSearchResults as PokemonCard[]);
-	let addSearchQuery = $derived(data.addSearch ?? '');
-
-	let saveError = $derived(form && !form.success ? form.message : null);
-
 	// Stats
 	let totalCards = $derived(entries.reduce((sum, e) => sum + e.quantity, 0));
 	let totalInvested = $derived(
@@ -252,14 +245,14 @@
 		</div>
 		{#if tab === 'collection'}
 			<!--
-				"+ Add Card" is a plain link to ?add=1 so the modal opens server-side.
-				The modal's card-search form submits back to the same route with
-				?addSearch=<q>; the loader populates results. Option (b) from the task
-				spec — less disruptive than a separate /collection/add route and keeps
-				the existing in-page modal UX.
+				"+ Add Card" navigates to the dedicated /collection/add page — a
+				search-engine style flow with live autosuggest (card_index) that
+				redirects back here once a card is added. Replaced the old in-page
+				modal, which searched the flaky pokemontcg.io API and errored on
+				mobile.
 			-->
 			<a
-				href="/collection?add=1"
+				href="/collection/add"
 				data-testid="open-add-modal"
 				class="btn-press rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-4 py-2 text-sm font-medium text-vault-bg shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40"
 			>
@@ -564,169 +557,3 @@
 	</div>
 	{/if}
 </div>
-
-<!-- Add Card Modal — rendered when ?add=1 is in the URL. Closing is a link back
-     to /collection (which re-runs load without the add params). -->
-{#if addMode}
-	<div class="fixed inset-0 z-50 flex items-center justify-center p-4" data-testid="add-modal">
-		<a href="/collection" aria-label="Close modal" class="fixed inset-0 bg-black/60"></a>
-		<div class="relative w-full max-w-sm rounded-2xl border border-vault-border bg-vault-surface p-4 shadow-2xl sm:max-w-lg sm:p-6">
-			<div class="flex items-center justify-between">
-				<h2 class="text-lg font-semibold text-white">Add Card to Collection</h2>
-				<a href="/collection" class="text-vault-text-muted hover:text-white" aria-label="Close">
-					<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-					</svg>
-				</a>
-			</div>
-
-			<div class="mt-4 space-y-4">
-				<!-- Card search — plain GET form back to /collection?add=1&addSearch=<q>.
-				     Loader runs the TCG search and returns results in data.addSearchResults. -->
-				<form method="GET" action="/collection" class="space-y-2">
-					<input type="hidden" name="add" value="1" />
-					<label class="block text-sm font-medium text-vault-text-muted" for="card-search">Search Card</label>
-					<div class="flex gap-2">
-						<input
-							id="card-search"
-							name="addSearch"
-							type="text"
-							value={addSearchQuery}
-							placeholder="Type a card name..."
-							data-testid="card-search-input"
-							class="flex-1 rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text placeholder-vault-text-muted focus:border-vault-purple focus:outline-none"
-						/>
-						<button
-							type="submit"
-							data-testid="card-search-submit"
-							class="rounded-lg bg-vault-accent px-4 py-2 text-sm font-medium text-vault-bg hover:bg-vault-accent-hover"
-						>
-							Search
-						</button>
-					</div>
-				</form>
-
-				<!-- Search results — each result is a link to ?add=1&selectedCard=<id>,
-				     so picking one is a normal navigation. -->
-				{#if addSearchResults.length > 0 && !selectedCard}
-					<div class="max-h-48 overflow-y-auto rounded-lg border border-vault-border bg-vault-bg" data-testid="card-search-results">
-						{#each addSearchResults as result}
-							<a
-								href="/collection?add=1&selectedCard={encodeURIComponent(result.id)}&addSearch={encodeURIComponent(addSearchQuery)}"
-								data-testid="card-search-result"
-								data-card-id={result.id}
-								class="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-vault-surface-hover"
-							>
-								<img src={result.images.small} alt={result.name} class="h-10 w-7 rounded object-cover" />
-								<div>
-									<p class="text-sm text-white">{result.name}</p>
-									<p class="text-xs text-vault-text-muted">{result.set.name} · #{result.number}</p>
-								</div>
-							</a>
-						{/each}
-					</div>
-				{/if}
-
-				{#if addSearchQuery && addSearchResults.length === 0 && !selectedCard}
-					<p class="text-sm text-vault-text-muted">No cards found for "{addSearchQuery}"</p>
-				{/if}
-
-				<!-- Selected card preview + add form. The final submit is a POST to
-				     ?/addEntry with all fields in FormData. -->
-				{#if selectedCard}
-					<div class="flex items-center gap-3 rounded-lg border border-vault-purple/30 bg-vault-purple/5 p-3" data-testid="selected-card">
-						<img src={selectedCard.images.small} alt={selectedCard.name} class="h-16 w-11 rounded object-cover" />
-						<div class="flex-1">
-							<p class="font-medium text-white">{selectedCard.name}</p>
-							<p class="text-xs text-vault-text-muted">{selectedCard.set.name} · {selectedCard.rarity ?? 'Unknown'}</p>
-						</div>
-						<a href="/collection?add=1&addSearch={encodeURIComponent(addSearchQuery)}" class="text-xs text-vault-text-muted hover:text-white">
-							Change
-						</a>
-					</div>
-
-					<form method="POST" action="?/addEntry" use:enhance class="space-y-4">
-						<input type="hidden" name="card_id" value={selectedCard.id} />
-
-						<div class="grid grid-cols-2 gap-4">
-							<div>
-								<label class="block text-sm font-medium text-vault-text-muted" for="quantity">Quantity</label>
-								<input
-									id="quantity"
-									name="quantity"
-									type="number"
-									min="1"
-									value="1"
-									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-								/>
-							</div>
-							<div>
-								<label class="block text-sm font-medium text-vault-text-muted" for="condition">Condition</label>
-								<select
-									id="condition"
-									name="condition"
-									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-								>
-									<option value="NM">Near Mint</option>
-									<option value="LP">Lightly Played</option>
-									<option value="MP">Moderately Played</option>
-									<option value="HP">Heavily Played</option>
-									<option value="DMG">Damaged</option>
-								</select>
-							</div>
-						</div>
-
-						<div class="grid grid-cols-2 gap-4">
-							<div>
-								<label class="block text-sm font-medium text-vault-text-muted" for="purchase-price">Purchase Price ($)</label>
-								<input
-									id="purchase-price"
-									name="purchase_price"
-									type="number"
-									step="0.01"
-									min="0"
-									placeholder="0.00"
-									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-								/>
-							</div>
-							<div>
-								<label class="block text-sm font-medium text-vault-text-muted" for="purchase-date">Purchase Date</label>
-								<input
-									id="purchase-date"
-									name="purchase_date"
-									type="date"
-									class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-								/>
-							</div>
-						</div>
-
-						<div>
-							<label class="block text-sm font-medium text-vault-text-muted" for="notes">Notes</label>
-							<input
-								id="notes"
-								name="notes"
-								type="text"
-								placeholder="Optional notes..."
-								class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
-							/>
-						</div>
-
-						<button
-							type="submit"
-							data-testid="submit-add-entry"
-							class="w-full rounded-lg bg-vault-accent px-4 py-2.5 text-sm font-medium text-vault-bg transition-colors hover:bg-vault-accent-hover disabled:opacity-50"
-						>
-							Add to Collection
-						</button>
-					</form>
-				{/if}
-
-				{#if saveError}
-					<div class="rounded-lg border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent" data-testid="save-error">
-						<span class="font-semibold">Couldn't save:</span> {saveError}
-					</div>
-				{/if}
-			</div>
-		</div>
-	</div>
-{/if}

--- a/src/routes/collection/add/+page.server.ts
+++ b/src/routes/collection/add/+page.server.ts
@@ -1,0 +1,115 @@
+import { supabase } from '$services/supabase';
+import { fail, redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+
+// Same columns the ⌘K palette + /api/search return, so the JS autosuggest
+// path and this no-JS server fallback render identical card rows.
+const SELECT = 'card_id, name, set_name, card_number, rarity, image_small_url, raw_nm_price';
+
+export interface CardLite {
+	card_id: string;
+	name: string;
+	set_name: string | null;
+	card_number: string | null;
+	rarity: string | null;
+	image_small_url: string | null;
+	raw_nm_price: number | null;
+}
+
+/**
+ * Dedicated "add a card" search page — replaces the old in-page modal that
+ * searched the flaky pokemontcg.io API (it 404'd/timed out and surfaced an
+ * error). Search now reads straight from card_index (fast, always-on), the
+ * same source the ⌘K palette uses.
+ *
+ * The page is JS-enhanced with live typeahead (see +page.svelte) but also
+ * works without JS: `?q=<term>` runs the search server-side here and
+ * `?card=<id>` pre-selects a card so the add form renders on the same load.
+ */
+export const load: PageServerLoad = async ({ url, setHeaders }) => {
+	// Never cache the document — same rationale as /collection (cached HTML
+	// referencing deleted immutable JS hashes breaks hydration post-deploy).
+	setHeaders({ 'cache-control': 'private, no-cache, must-revalidate' });
+
+	const q = (url.searchParams.get('q') ?? '').trim();
+	const cardId = (url.searchParams.get('card') ?? '').trim();
+
+	let results: CardLite[] = [];
+	if (q.length >= 2) {
+		const safe = q.replace(/[%_]/g, (c) => `\\${c}`);
+		const { data } = await supabase
+			.from('card_index')
+			.select(SELECT)
+			.or(`name.ilike.%${safe}%,set_name.ilike.%${safe}%`)
+			.limit(10);
+		results = (data ?? []) as CardLite[];
+	}
+
+	let selected: CardLite | null = null;
+	if (cardId) {
+		const { data } = await supabase
+			.from('card_index')
+			.select(SELECT)
+			.eq('card_id', cardId)
+			.maybeSingle();
+		selected = (data ?? null) as CardLite | null;
+	}
+
+	return { q, results, selected };
+};
+
+/**
+ * addEntry mirrors /collection's old addEntry (same dedupe-on-(card_id,
+ * condition) rule as the /api/collection POST handler) but lives here so the
+ * add form submits in-place. On success it redirects back to /collection —
+ * "take me back to my collection once the card is added".
+ */
+export const actions: Actions = {
+	addEntry: async ({ request }) => {
+		const form = await request.formData();
+		const cardId = (form.get('card_id') ?? '').toString().trim();
+		if (!cardId) return fail(400, { message: 'Card is required' });
+
+		const conditionRaw = (form.get('condition') ?? 'NM').toString();
+		const condition = ['NM', 'LP', 'MP', 'HP', 'DMG'].includes(conditionRaw) ? conditionRaw : 'NM';
+
+		const quantityRaw = parseInt((form.get('quantity') ?? '1').toString(), 10);
+		const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? quantityRaw : 1;
+
+		const priceRaw = (form.get('purchase_price') ?? '').toString().trim();
+		const purchasePrice = priceRaw ? parseFloat(priceRaw) : null;
+
+		const dateRaw = (form.get('purchase_date') ?? '').toString().trim();
+		const purchaseDate = dateRaw || null;
+
+		const notesRaw = (form.get('notes') ?? '').toString().trim();
+		const notes = notesRaw || null;
+
+		const { data: existing } = await supabase
+			.from('collection')
+			.select('id, quantity')
+			.eq('card_id', cardId)
+			.eq('condition', condition)
+			.maybeSingle();
+
+		if (existing) {
+			const { error: err } = await supabase
+				.from('collection')
+				.update({ quantity: existing.quantity + quantity })
+				.eq('id', existing.id);
+			if (err) return fail(500, { message: err.message });
+		} else {
+			const { error: err } = await supabase.from('collection').insert({
+				card_id: cardId,
+				quantity,
+				condition,
+				purchase_price: purchasePrice,
+				purchase_date: purchaseDate,
+				notes
+			});
+			if (err) return fail(500, { message: err.message });
+		}
+
+		throw redirect(303, '/collection');
+	}
+};

--- a/src/routes/collection/add/+page.svelte
+++ b/src/routes/collection/add/+page.svelte
@@ -1,0 +1,324 @@
+<!--
+	Add-a-card page — a dedicated search-engine style flow that replaced the
+	old in-page modal (which searched the flaky pokemontcg.io API and surfaced
+	an error on mobile).
+
+	Two-step flow:
+	  1. Type → live autosuggest from /api/search (card_index, fast + reliable).
+	  2. Pick a card → fill quantity/condition/price → "Add to Collection"
+	     POSTs to ?/addEntry which redirects back to /collection.
+
+	Works without JS too: the search box is a native GET form (?q=… runs the
+	search server-side in +page.server.ts), each result is a real link
+	(?card=…), and the add form is a native POST.
+-->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { enhance } from '$app/forms';
+	import { goto } from '$app/navigation';
+	import { Icon } from '$components';
+	import type { CardLite } from './+page.server';
+
+	let { data, form } = $props();
+
+	let mounted = $state(false);
+	let query = $state(data.q ?? '');
+	// Live (client) autosuggest results. Before mount / no-JS we fall back to
+	// the server-rendered data.results so the page is never empty.
+	let liveResults = $state<CardLite[]>([]);
+	let loading = $state(false);
+	let selected = $state<CardLite | null>(data.selected ?? null);
+	let inputEl = $state<HTMLInputElement | null>(null);
+
+	let results = $derived(mounted ? liveResults : (data.results as CardLite[]));
+	// addEntry only returns a payload on failure (fail({ message })); success
+	// throws a redirect, so a non-null form here always means an error.
+	let saveError = $derived((form as { message?: string } | null)?.message ?? null);
+
+	// Track the latest in-flight request so a slow earlier response can't
+	// clobber a newer one when typing fast (mirrors CommandPalette).
+	let requestSeq = 0;
+
+	function fmtMoney(n: number | null): string {
+		if (n == null) return '';
+		return n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${n.toFixed(2)}`;
+	}
+
+	async function runSearch(q: string) {
+		if (q.trim().length < 2) {
+			liveResults = [];
+			loading = false;
+			return;
+		}
+		const seq = ++requestSeq;
+		loading = true;
+		try {
+			const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+			if (seq !== requestSeq) return; // a newer request superseded this one
+			const json = await res.json();
+			liveResults = (json.results ?? []) as CardLite[];
+		} catch {
+			if (seq === requestSeq) liveResults = [];
+		} finally {
+			if (seq === requestSeq) loading = false;
+		}
+	}
+
+	// Debounce keystrokes — 120ms feels instant but avoids a request per key.
+	let searchTimer: ReturnType<typeof setTimeout> | null = null;
+	$effect(() => {
+		if (!mounted) return;
+		const q = query;
+		// Picking a card hides the list; typing again clears the selection so
+		// the search results come back.
+		if (searchTimer) clearTimeout(searchTimer);
+		searchTimer = setTimeout(() => runSearch(q), 120);
+		return () => {
+			if (searchTimer) clearTimeout(searchTimer);
+		};
+	});
+
+	function pick(card: CardLite) {
+		selected = card;
+		liveResults = [];
+	}
+
+	function clearSelection() {
+		selected = null;
+		setTimeout(() => inputEl?.focus(), 0);
+	}
+
+	onMount(() => {
+		mounted = true;
+		// Seed live results from the server render so a no-JS → JS handoff
+		// (e.g. landing here via ?q=) keeps the list visible.
+		liveResults = (data.results as CardLite[]) ?? [];
+		if (!selected) inputEl?.focus();
+	});
+
+	const conditionLabels: Array<[string, string]> = [
+		['NM', 'Near Mint'],
+		['LP', 'Lightly Played'],
+		['MP', 'Moderately Played'],
+		['HP', 'Heavily Played'],
+		['DMG', 'Damaged']
+	];
+</script>
+
+<svelte:head>
+	<title>Add a Card — Trove</title>
+</svelte:head>
+
+<div class="mx-auto max-w-lg space-y-6">
+	<!-- Header + back link -->
+	<div class="flex items-center gap-3">
+		<a
+			href="/collection"
+			data-testid="add-back"
+			class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl border border-vault-border text-vault-text-muted transition-colors hover:bg-vault-surface-hover hover:text-white"
+			aria-label="Back to collection"
+		>
+			<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+			</svg>
+		</a>
+		<div>
+			<h1 class="text-2xl font-bold text-gradient">Add a Card</h1>
+			<p class="text-sm text-vault-text-muted">Search for a card to add to your collection</p>
+		</div>
+	</div>
+
+	{#if !selected}
+		<!-- Search box — native GET form for no-JS; typeahead enhances it. -->
+		<form method="GET" action="/collection/add" class="relative" onsubmit={(e) => mounted && e.preventDefault()}>
+			<input
+				bind:this={inputEl}
+				bind:value={query}
+				name="q"
+				type="text"
+				autocomplete="off"
+				placeholder="Type a card name…"
+				data-testid="add-search-input"
+				class="w-full rounded-xl border border-vault-border bg-vault-bg px-4 py-3 pl-11 text-base text-vault-text placeholder-vault-text-muted focus:border-vault-purple focus:outline-none focus:ring-1 focus:ring-vault-purple/50"
+			/>
+			<Icon name="search" class="pointer-events-none absolute left-3.5 top-3.5 h-5 w-5 text-vault-text-muted" />
+			{#if loading}
+				<span class="absolute right-4 top-3.5 text-xs text-vault-purple">searching…</span>
+			{/if}
+			<!-- Visible only to no-JS users; the typeahead replaces it otherwise. -->
+			<noscript>
+				<button type="submit" class="mt-2 w-full rounded-xl bg-vault-accent px-4 py-2 text-sm font-medium text-vault-bg">
+					Search
+				</button>
+			</noscript>
+		</form>
+
+		<!-- Results -->
+		{#if results.length > 0}
+			<div class="overflow-hidden rounded-2xl border border-vault-border bg-vault-surface" data-testid="add-results">
+				{#each results as card (card.card_id)}
+					<a
+						href="/collection/add?card={encodeURIComponent(card.card_id)}"
+						data-testid="add-result"
+						data-card-id={card.card_id}
+						onclick={(e) => {
+							if (!mounted) return;
+							e.preventDefault();
+							pick(card);
+						}}
+						class="flex w-full items-center gap-3 border-b border-vault-border px-3 py-3 text-left transition-colors last:border-b-0 hover:bg-vault-surface-hover"
+					>
+						{#if card.image_small_url}
+							<img src={card.image_small_url} alt={card.name} loading="lazy" class="h-14 w-10 flex-shrink-0 rounded object-cover" />
+						{:else}
+							<div class="h-14 w-10 flex-shrink-0 rounded bg-vault-bg"></div>
+						{/if}
+						<div class="min-w-0 flex-1">
+							<p class="truncate text-sm font-medium text-white">{card.name}</p>
+							<p class="truncate text-xs text-vault-text-muted">
+								{card.set_name}{#if card.card_number} · #{card.card_number}{/if}{#if card.rarity} · {card.rarity}{/if}
+							</p>
+						</div>
+						{#if card.raw_nm_price != null}
+							<span class="flex-shrink-0 text-sm font-semibold text-vault-gold">{fmtMoney(card.raw_nm_price)}</span>
+						{/if}
+					</a>
+				{/each}
+			</div>
+		{:else if query.trim().length >= 2 && !loading}
+			<p class="rounded-xl border border-vault-border bg-vault-surface px-4 py-6 text-center text-sm text-vault-text-muted">
+				No cards match “{query}”.
+			</p>
+		{:else if query.trim().length < 2}
+			<p class="px-1 text-sm text-vault-text-muted">Keep typing — at least 2 characters.</p>
+		{/if}
+	{:else}
+		<!-- Selected card + add form -->
+		<div class="flex items-center gap-3 rounded-2xl border border-vault-purple/30 bg-vault-purple/5 p-3" data-testid="add-selected">
+			{#if selected.image_small_url}
+				<img src={selected.image_small_url} alt={selected.name} class="h-20 w-14 flex-shrink-0 rounded object-cover" />
+			{:else}
+				<div class="h-20 w-14 flex-shrink-0 rounded bg-vault-bg"></div>
+			{/if}
+			<div class="min-w-0 flex-1">
+				<p class="truncate font-medium text-white">{selected.name}</p>
+				<p class="truncate text-xs text-vault-text-muted">
+					{selected.set_name}{#if selected.card_number} · #{selected.card_number}{/if}
+				</p>
+				{#if selected.rarity}
+					<p class="truncate text-xs text-vault-text-muted">{selected.rarity}</p>
+				{/if}
+			</div>
+			<!-- Change pick: client clears state; no-JS falls back to the bare page. -->
+			<a
+				href="/collection/add"
+				data-testid="add-change"
+				onclick={(e) => {
+					if (!mounted) return;
+					e.preventDefault();
+					clearSelection();
+				}}
+				class="flex-shrink-0 rounded-lg border border-vault-border px-3 py-1.5 text-xs text-vault-text-muted transition-colors hover:bg-vault-surface-hover hover:text-white"
+			>
+				Change
+			</a>
+		</div>
+
+		<form
+			method="POST"
+			action="?/addEntry"
+			data-testid="add-form"
+			class="space-y-4 rounded-2xl border border-vault-border bg-vault-surface p-4"
+			use:enhance={() => {
+				return async ({ result, update }) => {
+					// addEntry throws a 303 redirect on success → enhance follows
+					// it back to /collection. On failure we re-render with the error.
+					if (result.type === 'redirect') {
+						goto(result.location);
+					} else {
+						await update();
+					}
+				};
+			}}
+		>
+			<input type="hidden" name="card_id" value={selected.card_id} />
+
+			<div class="grid grid-cols-2 gap-4">
+				<div>
+					<label class="block text-sm font-medium text-vault-text-muted" for="quantity">Quantity</label>
+					<input
+						id="quantity"
+						name="quantity"
+						type="number"
+						inputmode="numeric"
+						min="1"
+						value="1"
+						class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+					/>
+				</div>
+				<div>
+					<label class="block text-sm font-medium text-vault-text-muted" for="condition">Condition</label>
+					<select
+						id="condition"
+						name="condition"
+						class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+					>
+						{#each conditionLabels as [val, lbl]}
+							<option value={val}>{lbl}</option>
+						{/each}
+					</select>
+				</div>
+			</div>
+
+			<div class="grid grid-cols-2 gap-4">
+				<div>
+					<label class="block text-sm font-medium text-vault-text-muted" for="purchase-price">Purchase Price ($)</label>
+					<input
+						id="purchase-price"
+						name="purchase_price"
+						type="number"
+						inputmode="decimal"
+						step="0.01"
+						min="0"
+						placeholder="0.00"
+						class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+					/>
+				</div>
+				<div>
+					<label class="block text-sm font-medium text-vault-text-muted" for="purchase-date">Purchase Date</label>
+					<input
+						id="purchase-date"
+						name="purchase_date"
+						type="date"
+						class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+					/>
+				</div>
+			</div>
+
+			<div>
+				<label class="block text-sm font-medium text-vault-text-muted" for="notes">Notes</label>
+				<input
+					id="notes"
+					name="notes"
+					type="text"
+					placeholder="Optional notes…"
+					class="mt-1 w-full rounded-lg border border-vault-border bg-vault-bg px-4 py-2 text-sm text-vault-text focus:border-vault-purple focus:outline-none"
+				/>
+			</div>
+
+			<button
+				type="submit"
+				data-testid="add-submit"
+				class="btn-press w-full rounded-xl bg-gradient-to-r from-vault-accent to-vault-accent-hover px-4 py-3 text-sm font-medium text-vault-bg shadow-lg shadow-vault-accent/20 transition-all hover:shadow-vault-accent/40"
+			>
+				Add to Collection
+			</button>
+		</form>
+	{/if}
+
+	{#if saveError}
+		<div class="rounded-xl border border-vault-accent/40 bg-vault-accent/10 px-4 py-3 text-sm text-vault-accent" data-testid="add-error">
+			<span class="font-semibold">Couldn't save:</span> {saveError}
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Mobile-focused UX fixes for the collection flow

Three issues reported from mobile, all addressed:

### 1. "+ Add Card" errored and didn't work
The old in-page modal searched the flaky **pokemontcg.io** API (404s/timeouts → the error on mobile). Replaced it with a dedicated **`/collection/add` page**:
- **Live typeahead autosuggest** reading from `card_index` via the existing `/api/search` endpoint — fast, always-on, the same source the ⌘K palette uses.
- Pick a card → fill quantity/condition/price/date/notes → submit **redirects back to `/collection`** with the card added.
- Progressive enhancement: still works without JS (`?q=` runs the search server-side, `?card=` preselects, native POST submits).

### 2. Search should autosuggest + be a page, not a popup
Covered by the new page above — search-engine-style suggestions (thumbnail, set, #, price) and a return to the collection once a card is added, instead of the popup.

### 3. Always land at the top of the page
The scroll container is the inner `<main>` panel (`overflow-y-auto`), so SvelteKit's window-targeted scroll reset left it parked mid-page. Added an `afterNavigate` hook that resets `<main>` to the top on every navigation (except in-page `#hash` jumps). Fixes this app-wide.

Also removed the now-dead add-modal markup, loader logic, and `addEntry` action from `/collection`.

## Verification
- `svelte-check`: clean on the changed files (pre-existing errors in untouched files unaffected).
- Tests: 82/82 pass.
- Local dev server: `/collection/add` renders (200, search input present), `/collection` renders with the modal removed and the button rewired to `/collection/add`, `/api/search` returns gracefully.
- Note: this container has no `.env.local`, so live `card_index` results weren't cross-checked against the DB — autosuggest will populate against real data in the preview/prod deploy.

https://claude.ai/code/session_015VvokWtm8NDKW4gHUFjoCP

---
_Generated by [Claude Code](https://claude.ai/code/session_015VvokWtm8NDKW4gHUFjoCP)_